### PR TITLE
Fix: receive screenshotResult instead of screenshot

### DIFF
--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -1247,6 +1247,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               updateStatus('Added ICE candidate');
               break;
             case 'screenshot':
+            case 'screenshotResult':
               if (typeof message.id !== 'string' || typeof message.dataUri !== 'string') {
                 debugWarn('Received invalid screenshot success message:', message);
                 break;


### PR DESCRIPTION
I had trouble making a screenshot, so I enabled debug logs and saw this:

`Received unhandled message type: screenshotResult `

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small UI-side protocol compatibility change limited to the WebSocket message switch for screenshot responses.
> 
> **Overview**
> Updates `RemoteControl`’s WebSocket message handler to treat `screenshotResult` as a successful screenshot response (in addition to `screenshot`), resolving pending screenshot promises when that type is received.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac9e22d5c3bee97247542c32771c01a5fef6801e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->