### PR TITLE
Downgrade simctl unknown execution log to debug

### DIFF
--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -1061,7 +1061,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         if (message.type === 'simctlStream') {
           const execution = simctlExecutions.get(message.id);
           if (!execution) {
-            logger.warn(`Received simctl stream for unknown execution: ${message.id}`);
+            logger.debug(`Received simctl stream for unknown execution: ${message.id}`);
             return;
           }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes log severity for a benign simctl streaming edge case, with no behavioral or data-handling impact.
> 
> **Overview**
> Downgrades the `simctlStream` handler log when a stream chunk arrives for an unknown/already-cleaned-up execution from `warn` to `debug`, reducing noisy logs during normal race conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26dd927034d6d06482346a7f21c9b8f5fb9c21fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->