### PR TITLE
ios: add video recording api

### DIFF
--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -40,6 +40,10 @@ async function downloadFileToLocalPath(url: string, token: string, localPath: st
   await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
 }
 
+function buildDownloadUrl(apiUrl: string, filename: string): string {
+  return `${apiUrl}/files?name=${encodeURIComponent(filename)}`;
+}
+
 /**
  * Events emitted by a simctl execution
  */
@@ -328,13 +332,13 @@ export type InstanceClient = {
 
   /**
    * Stop the active recording for this client instance.
-   * If `saveTo.s3Url` is provided, the server uploads the completed file there before resolving.
+   * If `saveTo.presignedUrl` is provided, the server uploads the completed file there before resolving.
    * If `saveTo.localPath` is provided, the client downloads the completed file to that path.
    * If both are provided, both are performed.
    * Returns a download URL for the completed recording that can be used to download using the token.
    * Note that the download URL is only valid while the instance is running.
    */
-  stopRecording: (saveTo: { s3Url?: string; localPath?: string }) => Promise<string>;
+  stopRecording: (saveTo: { presignedUrl?: string; localPath?: string }) => Promise<string>;
 
   /**
    * Sync an iOS app bundle folder to the server and (optionally) install/launch it.
@@ -1074,7 +1078,6 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       startVideoRecordingResult: () => undefined,
       stopVideoRecordingResult: (msg) => ({
         filename: msg.filename || '',
-        url: msg.url || '',
       }),
       setOrientationResult: () => undefined,
       scrollResult: () => undefined,
@@ -1400,20 +1403,22 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       activeRecordingFilename = finalFilename;
     };
 
-    const stopRecording = async (saveTo: { s3Url?: string; localPath?: string }): Promise<string> => {
+    const stopRecording = async (saveTo: { presignedUrl?: string; localPath?: string }): Promise<string> => {
       const filename = activeRecordingFilename;
       if (!filename) {
         throw new Error('No active recording for this client. Call startRecording() first.');
       }
-      const result = await sendRequest<{ filename: string; url: string }>('stopVideoRecording', {
+      const result = await sendRequest<{ filename: string }>('stopVideoRecording', {
         filename,
-        upload: saveTo.s3Url ? { s3Url: saveTo.s3Url } : undefined,
+        upload: saveTo.presignedUrl ? { presignedUrl: saveTo.presignedUrl } : undefined,
       });
+      const finalFilename = result.filename || filename;
+      const downloadUrl = buildDownloadUrl(options.apiUrl, finalFilename);
       activeRecordingFilename = undefined;
       if (saveTo.localPath) {
-        await downloadFileToLocalPath(result.url, options.token, saveTo.localPath);
+        await downloadFileToLocalPath(downloadUrl, options.token, saveTo.localPath);
       }
-      return result.url;
+      return downloadUrl;
     };
 
     const syncApp = async (

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -296,6 +296,18 @@ export type InstanceClient = {
   ) => Promise<void>;
 
   /**
+   * Start recording simulator video to the provided filename.
+   */
+  startVideo: (filename: string) => Promise<void>;
+
+  /**
+   * Stop recording simulator video for the provided filename.
+   * If `upload.s3Url` is provided, the server uploads the completed file there before resolving.
+   * Returns a download URL for the completed recording.
+   */
+  stopVideo: (filename: string, options?: { upload?: { s3Url?: string } }) => Promise<string>;
+
+  /**
    * Sync an iOS app bundle folder to the server and (optionally) install/launch it.
    */
   syncApp: (
@@ -513,6 +525,7 @@ type ServerResponse = {
   elementType?: string;
   apps?: string;
   url?: string;
+  filename?: string;
   bundleId?: string;
   files?: LsofEntry[];
   // Device info fields
@@ -1028,6 +1041,11 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         url: msg.url || '',
         bundleId: msg.bundleId || '',
       }),
+      startVideoRecordingResult: () => undefined,
+      stopVideoRecordingResult: (msg) => ({
+        filename: msg.filename || '',
+        url: msg.url || '',
+      }),
       setOrientationResult: () => undefined,
       scrollResult: () => undefined,
       xcrunResult: (msg): CommandResult => ({
@@ -1200,6 +1218,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             installApp,
             setOrientation,
             scroll,
+            startVideo,
+            stopVideo,
             syncApp,
             disconnect,
             getConnectionState,
@@ -1339,6 +1359,21 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         coordinate: options?.coordinate,
         momentum: options?.momentum,
       });
+    };
+
+    const startVideo = async (filename: string): Promise<void> => {
+      await sendRequest<void>('startVideoRecording', { filename });
+    };
+
+    const stopVideo = async (
+      filename: string,
+      options?: { upload?: { s3Url?: string } },
+    ): Promise<string> => {
+      const result = await sendRequest<{ filename: string; url: string }>('stopVideoRecording', {
+        filename,
+        upload: options?.upload,
+      });
+      return result.url;
     };
 
     const syncApp = async (

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -27,21 +27,30 @@ function generateRecordingFilename(): string {
 }
 
 async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throw new Error(`Download failed: ${response.status} ${errorBody}`);
+  const maxRetries = 3;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      const isRetriable = response.status >= 500 && response.status < 600;
+      if (isRetriable && attempt < maxRetries) {
+        continue;
+      }
+      throw new Error(`Download failed: ${response.status} ${errorBody}`);
+    }
+    if (!response.body) {
+      throw new Error('Download failed: response body is missing');
+    }
+    await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
+    await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
+    return;
   }
-  if (!response.body) {
-    throw new Error('Download failed: response body is missing');
-  }
-  await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
-  await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
 }
 
 function buildDownloadUrl(apiUrl: string, filename: string): string {
@@ -1403,8 +1412,15 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         throw new Error(`A recording is already active for this client: ${activeRecordingFilename}`);
       }
       const finalFilename = generateRecordingFilename();
-      await sendRequest<void>('startVideoRecording', { filename: finalFilename });
       activeRecordingFilename = finalFilename;
+      try {
+        await sendRequest<void>('startVideoRecording', { filename: finalFilename });
+      } catch (error) {
+        if (activeRecordingFilename === finalFilename) {
+          activeRecordingFilename = undefined;
+        }
+        throw error;
+      }
     };
 
     const stopRecording = async (saveTo: { presignedUrl?: string; localPath?: string }): Promise<string> => {
@@ -1418,9 +1434,14 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       });
       const finalFilename = result.filename || filename;
       const downloadUrl = buildDownloadUrl(options.apiUrl, finalFilename);
-      activeRecordingFilename = undefined;
       if (saveTo.localPath) {
-        await downloadFileToLocalPath(downloadUrl, options.token, saveTo.localPath);
+        try {
+          await downloadFileToLocalPath(downloadUrl, options.token, saveTo.localPath);
+        } finally {
+          activeRecordingFilename = undefined;
+        }
+      } else {
+        activeRecordingFilename = undefined;
       }
       return downloadUrl;
     };

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -1,6 +1,9 @@
 import { WebSocket, Data } from 'ws';
 import fs from 'fs';
 import { EventEmitter } from 'events';
+import path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { isNonRetryableError } from './tunnel';
 import { syncApp as syncAppImpl, type SyncFolderResult, type FolderSyncOptions } from './folder-sync';
 
@@ -13,6 +16,29 @@ export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'rec
  * Callback function for connection state changes
  */
 export type ConnectionStateCallback = (state: ConnectionState) => void;
+
+function generateRecordingFilename(): string {
+  const rand = Math.random().toString(36).slice(2, 5).padEnd(3, '0');
+  return `vid_${Date.now()}_${rand}.mp4`;
+}
+
+async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Download failed: ${response.status} ${errorBody}`);
+  }
+  if (!response.body) {
+    throw new Error('Download failed: response body is missing');
+  }
+  await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
+  await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
+}
 
 /**
  * Events emitted by a simctl execution
@@ -296,16 +322,19 @@ export type InstanceClient = {
   ) => Promise<void>;
 
   /**
-   * Start recording simulator video to the provided filename.
+   * Start recording simulator video. Use stopRecording() to stop the recording.
    */
-  startVideo: (filename: string) => Promise<void>;
+  startRecording: () => Promise<void>;
 
   /**
-   * Stop recording simulator video for the provided filename.
-   * If `upload.s3Url` is provided, the server uploads the completed file there before resolving.
-   * Returns a download URL for the completed recording.
+   * Stop the active recording for this client instance.
+   * If `saveTo.s3Url` is provided, the server uploads the completed file there before resolving.
+   * If `saveTo.localPath` is provided, the client downloads the completed file to that path.
+   * If both are provided, both are performed.
+   * Returns a download URL for the completed recording that can be used to download using the token.
+   * Note that the download URL is only valid while the instance is running.
    */
-  stopVideo: (filename: string, options?: { upload?: { s3Url?: string } }) => Promise<string>;
+  stopRecording: (saveTo: { s3Url?: string; localPath?: string }) => Promise<string>;
 
   /**
    * Sync an iOS app bundle folder to the server and (optionally) install/launch it.
@@ -863,6 +892,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
   let reconnectTimeout: NodeJS.Timeout | undefined;
   let intentionalDisconnect = false;
   let lastError: string | undefined;
+  let activeRecordingFilename: string | undefined;
 
   // Centralized pending requests map - handles all request/response patterns
   const pendingRequests: Map<string, PendingRequest<any>> = new Map();
@@ -1218,8 +1248,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             installApp,
             setOrientation,
             scroll,
-            startVideo,
-            stopVideo,
+            startRecording,
+            stopRecording,
             syncApp,
             disconnect,
             getConnectionState,
@@ -1361,18 +1391,28 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       });
     };
 
-    const startVideo = async (filename: string): Promise<void> => {
-      await sendRequest<void>('startVideoRecording', { filename });
+    const startRecording = async (): Promise<void> => {
+      if (activeRecordingFilename) {
+        throw new Error(`A recording is already active for this client: ${activeRecordingFilename}`);
+      }
+      const finalFilename = generateRecordingFilename();
+      await sendRequest<void>('startVideoRecording', { filename: finalFilename });
+      activeRecordingFilename = finalFilename;
     };
 
-    const stopVideo = async (
-      filename: string,
-      options?: { upload?: { s3Url?: string } },
-    ): Promise<string> => {
+    const stopRecording = async (saveTo: { s3Url?: string; localPath?: string }): Promise<string> => {
+      const filename = activeRecordingFilename;
+      if (!filename) {
+        throw new Error('No active recording for this client. Call startRecording() first.');
+      }
       const result = await sendRequest<{ filename: string; url: string }>('stopVideoRecording', {
         filename,
-        upload: options?.upload,
+        upload: saveTo.s3Url ? { s3Url: saveTo.s3Url } : undefined,
       });
+      activeRecordingFilename = undefined;
+      if (saveTo.localPath) {
+        await downloadFileToLocalPath(result.url, options.token, saveTo.localPath);
+      }
       return result.url;
     };
 

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -19,7 +19,11 @@ export type ConnectionStateCallback = (state: ConnectionState) => void;
 
 function generateRecordingFilename(): string {
   const rand = Math.random().toString(36).slice(2, 5).padEnd(3, '0');
-  return `vid_${Date.now()}_${rand}.mp4`;
+  const now = new Date();
+  const formattedDate = now.toISOString().replace(/[-:]/g, '_').replace('T', '_').replace(/\..+/, '');
+
+  // Example: 20240602_17_45_30 for June 2, 2024 17:45:30 UTC
+  return `ios_video_${formattedDate}_${rand}.mp4`;
 }
 
 async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new client API that triggers server-side recording and optionally downloads the resulting file, introducing new file/network I/O paths and state handling that could fail or leak resources if misused.
> 
> **Overview**
> Adds simulator video recording to the TypeScript `InstanceClient` via new `startRecording()`/`stopRecording()` methods that wrap `startVideoRecording`/`stopVideoRecording` WebSocket requests.
> 
> `stopRecording()` can optionally request server upload to a presigned URL and/or download the finished recording locally (with retry + streaming to disk), returning a temporary `/files?name=...` download URL while the instance is running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b884a9a470199c6e2660942841caa952d36f0e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->