### PR TITLE
folder-sync: centralize ignored file matchers and use it in both triggers and upload

### DIFF
--- a/examples/ios-hot-reload/.gitignore
+++ b/examples/ios-hot-reload/.gitignore
@@ -1,1 +1,0 @@
-.limsync-cache

--- a/examples/xcode-sandbox/.gitignore
+++ b/examples/xcode-sandbox/.gitignore
@@ -1,1 +1,0 @@
-.limsync-cache

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -166,7 +166,6 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
     const { apiUrl, token } = this.options;
 
     // 1. Trigger the build via POST /exec
-    log('debug', `POST ${apiUrl}/exec`);
     let execRes: Response;
     try {
       execRes = await fetch(`${apiUrl}/exec`, {
@@ -201,7 +200,6 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
 
     // 2. Stream logs via SSE and wait for exit code
     const eventsUrl = `${apiUrl}/exec/${this.execId}/events`;
-    log('debug', `GET ${eventsUrl} (SSE)`);
 
     const timeoutMs = 3600 * 1000; // 1 hour max
     let exitCode: number;

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -197,7 +197,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
 
     const execData = (await execRes.json()) as { execId: string };
     this.execId = execData.execId;
-    log('info', `Build started: ${this.execId}`);
+    log('debug', `Build started: ${this.execId}`);
 
     // 2. Stream logs via SSE and wait for exit code
     const eventsUrl = `${apiUrl}/exec/${this.execId}/events`;
@@ -215,7 +215,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       ]);
     } catch {
       if (this.killed) {
-        log('info', 'Build killed');
+        log('debug', 'Build killed');
         exitCode = -1;
       } else {
         log('warn', 'SSE completion timeout');
@@ -250,7 +250,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       status,
     };
 
-    this.log('info', `Build finished: ${result.status} (exit ${result.exitCode})`);
+    this.log('debug', `Build finished: ${result.status} (exit ${result.exitCode})`);
     return result;
   }
 

--- a/src/folder-sync-ignore.ts
+++ b/src/folder-sync-ignore.ts
@@ -6,7 +6,7 @@ export type IgnoreFn = (relativePath: string) => boolean;
 
 export type IgnoreFnOptions = {
   additional?: IgnoreFn;
-  basisCacheDir?: string;
+  basisCacheDir: string;
 };
 
 function normalizeRelativePath(relativePath: string): string {
@@ -17,7 +17,7 @@ function normalizeRelativePath(relativePath: string): string {
     .replace(/\/+/g, '/');
 }
 
-export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions = {}): Promise<IgnoreFn> {
+export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions): Promise<IgnoreFn> {
   const rootResolved = path.resolve(rootDir);
   const ig = ignorePkg();
   const gitignorePath = path.join(rootResolved, '.gitignore');
@@ -27,14 +27,9 @@ export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions =
   } catch {
     // No .gitignore file, return empty ignore instance
   }
-  const basisCacheRoot =
-    options.basisCacheDir ?
-      path.resolve(process.cwd(), options.basisCacheDir)
-    : path.join(process.cwd(), '.limsync-cache');
-  const basisCacheRelative = normalizeRelativePath(path.relative(rootResolved, basisCacheRoot)).replace(
-    /\/+$/,
-    '',
-  );
+  const basisCacheRelative = normalizeRelativePath(
+    path.relative(rootResolved, options.basisCacheDir),
+  ).replace(/\/+$/, '');
   const shouldIgnoreBasisCache =
     basisCacheRelative &&
     basisCacheRelative !== '.' &&
@@ -48,6 +43,8 @@ export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions =
 
     if (
       withoutTrailingSlash === '.git' ||
+      withoutTrailingSlash.endsWith('/.git') ||
+      withoutTrailingSlash.includes('/.git/') ||
       withoutTrailingSlash === '.DS_Store' ||
       withoutTrailingSlash.endsWith('/.DS_Store')
     ) {

--- a/src/folder-sync-ignore.ts
+++ b/src/folder-sync-ignore.ts
@@ -43,6 +43,7 @@ export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions):
 
     if (
       withoutTrailingSlash === '.git' ||
+      withoutTrailingSlash.startsWith('.git/') ||
       withoutTrailingSlash.endsWith('/.git') ||
       withoutTrailingSlash.includes('/.git/') ||
       withoutTrailingSlash === '.DS_Store' ||

--- a/src/folder-sync-ignore.ts
+++ b/src/folder-sync-ignore.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import path from 'path';
+import ignorePkg from 'ignore';
+
+export type IgnoreFn = (relativePath: string) => boolean;
+
+export type IgnoreFnOptions = {
+  additional?: IgnoreFn;
+  basisCacheDir?: string;
+};
+
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath
+    .split(path.sep)
+    .join('/')
+    .replace(/^\.\/+/, '')
+    .replace(/\/+/g, '/');
+}
+
+export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions = {}): Promise<IgnoreFn> {
+  const rootResolved = path.resolve(rootDir);
+  const ig = ignorePkg();
+  const gitignorePath = path.join(rootResolved, '.gitignore');
+  try {
+    const content = await fs.promises.readFile(gitignorePath, 'utf-8');
+    ig.add(content);
+  } catch {
+    // No .gitignore file, return empty ignore instance
+  }
+  const basisCacheRoot =
+    options.basisCacheDir ?
+      path.resolve(process.cwd(), options.basisCacheDir)
+    : path.join(process.cwd(), '.limsync-cache');
+  const basisCacheRelative = normalizeRelativePath(path.relative(rootResolved, basisCacheRoot)).replace(
+    /\/+$/,
+    '',
+  );
+  const shouldIgnoreBasisCache =
+    basisCacheRelative &&
+    basisCacheRelative !== '.' &&
+    basisCacheRelative !== '..' &&
+    !basisCacheRelative.startsWith('../');
+
+  return (relativePath: string) => {
+    const normalized = normalizeRelativePath(relativePath);
+    if (!normalized) return false;
+    const withoutTrailingSlash = normalized.replace(/\/+$/, '');
+
+    if (
+      withoutTrailingSlash === '.git' ||
+      withoutTrailingSlash === '.DS_Store' ||
+      withoutTrailingSlash.endsWith('/.DS_Store')
+    ) {
+      return true;
+    }
+    if (
+      shouldIgnoreBasisCache &&
+      (withoutTrailingSlash === basisCacheRelative ||
+        withoutTrailingSlash.startsWith(`${basisCacheRelative}/`))
+    ) {
+      return true;
+    }
+    if (ig.ignores(normalized)) return true;
+    if (options.additional?.(normalized)) return true;
+    return false;
+  };
+}

--- a/src/folder-sync-watcher.ts
+++ b/src/folder-sync-watcher.ts
@@ -1,9 +1,11 @@
 import fs from 'fs';
 import path from 'path';
+import { IgnoreFn } from './folder-sync-ignore';
 
 export type FolderSyncWatcherOptions = {
   rootPath: string;
   log?: (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
+  ignoreFn: IgnoreFn;
   onChange: (reason: string) => void;
 };
 
@@ -11,7 +13,16 @@ type WatcherHandle = { close: () => void };
 
 const noopLogger = (_level: 'debug' | 'info' | 'warn' | 'error', _msg: string) => {};
 
-async function listDirsRecursive(root: string): Promise<string[]> {
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath.split(path.sep).join('/');
+}
+
+function shouldWatchRelativePath(relativePath: string, ignoreFn: IgnoreFn, isDirectory = false): boolean {
+  const normalized = normalizeRelativePath(relativePath);
+  return !ignoreFn(isDirectory ? `${normalized}/` : normalized);
+}
+
+async function listDirsRecursive(root: string, ignoreFn: IgnoreFn): Promise<string[]> {
   const dirs: string[] = [root];
   const queue: string[] = [root];
   while (queue.length) {
@@ -25,6 +36,8 @@ async function listDirsRecursive(root: string): Promise<string[]> {
     for (const ent of entries) {
       if (!ent.isDirectory()) continue;
       const full = path.join(dir, ent.name);
+      const rel = path.relative(root, full);
+      if (!shouldWatchRelativePath(rel, ignoreFn, true)) continue;
       dirs.push(full);
       queue.push(full);
     }
@@ -52,11 +65,18 @@ export async function watchFolderTree(opts: FolderSyncWatcherOptions): Promise<W
     if (timer) clearTimeout(timer);
     timer = setTimeout(() => opts.onChange(reason), debounceMs);
   };
+  const scheduleIfIncluded = (filename?: string | Buffer | null) => {
+    const relativePath = filename ? normalizeRelativePath(filename.toString()) : '';
+    if (relativePath && !shouldWatchRelativePath(relativePath, opts.ignoreFn)) {
+      return;
+    }
+    schedule(relativePath ? `change:${relativePath}` : 'change');
+  };
 
   // Preferred: recursive watch
   try {
     const watcher = fs.watch(rootPath, { recursive: true }, (_eventType, filename) => {
-      schedule(filename ? `change:${filename.toString()}` : 'change');
+      scheduleIfIncluded(filename);
     });
     log('info', `watchFolderTree(recursive): ${rootPath}`);
     return { close: () => watcher.close() };
@@ -71,12 +91,12 @@ export async function watchFolderTree(opts: FolderSyncWatcherOptions): Promise<W
   const watchers = new Map<string, fs.FSWatcher>();
 
   const ensureWatched = async () => {
-    const dirs = await listDirsRecursive(rootPath);
+    const dirs = await listDirsRecursive(rootPath, opts.ignoreFn);
     for (const d of dirs) {
       if (watchers.has(d)) continue;
       try {
         const w = fs.watch(d, (_eventType, filename) => {
-          schedule(filename ? `change:${filename.toString()}` : 'change');
+          scheduleIfIncluded(filename);
           void ensureWatched();
         });
         watchers.set(d, w);

--- a/src/folder-sync-watcher.ts
+++ b/src/folder-sync-watcher.ts
@@ -13,38 +13,6 @@ type WatcherHandle = { close: () => void };
 
 const noopLogger = (_level: 'debug' | 'info' | 'warn' | 'error', _msg: string) => {};
 
-function normalizeRelativePath(relativePath: string): string {
-  return relativePath.split(path.sep).join('/');
-}
-
-function shouldWatchRelativePath(relativePath: string, ignoreFn: IgnoreFn, isDirectory = false): boolean {
-  const normalized = normalizeRelativePath(relativePath);
-  return !ignoreFn(isDirectory ? `${normalized}/` : normalized);
-}
-
-async function listDirsRecursive(root: string, ignoreFn: IgnoreFn): Promise<string[]> {
-  const dirs: string[] = [root];
-  const queue: string[] = [root];
-  while (queue.length) {
-    const dir = queue.pop()!;
-    let entries: fs.Dirent[];
-    try {
-      entries = await fs.promises.readdir(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const ent of entries) {
-      if (!ent.isDirectory()) continue;
-      const full = path.join(dir, ent.name);
-      const rel = path.relative(root, full);
-      if (!shouldWatchRelativePath(rel, ignoreFn, true)) continue;
-      dirs.push(full);
-      queue.push(full);
-    }
-  }
-  return dirs;
-}
-
 /**
  * Watch a folder tree for changes. Uses recursive watch when supported (macOS),
  * otherwise falls back to watching each directory. Debounced.
@@ -65,8 +33,8 @@ export async function watchFolderTree(opts: FolderSyncWatcherOptions): Promise<W
   };
   const watcher = fs.watch(rootPath, { recursive: true }, (_eventType, filename) => {
     if (!filename) return;
-    const relativePath = normalizeRelativePath(filename);
-    if (relativePath && !shouldWatchRelativePath(relativePath, opts.ignoreFn)) {
+    const relativePath = filename.split(path.sep).join('/');
+    if (opts.ignoreFn(relativePath)) {
       return;
     }
     schedule(relativePath ? `change:${relativePath}` : 'change');

--- a/src/folder-sync-watcher.ts
+++ b/src/folder-sync-watcher.ts
@@ -55,65 +55,22 @@ export async function watchFolderTree(opts: FolderSyncWatcherOptions): Promise<W
   const log = opts.log ?? noopLogger;
   const debounceMs = 500;
   const rootPath = opts.rootPath;
-
   if (!fs.existsSync(rootPath)) {
     throw new Error(`watchFolderTree root does not exist: ${rootPath}`);
   }
-
   let timer: NodeJS.Timeout | undefined;
   const schedule = (reason: string) => {
     if (timer) clearTimeout(timer);
     timer = setTimeout(() => opts.onChange(reason), debounceMs);
   };
-  const scheduleIfIncluded = (filename?: string | Buffer | null) => {
-    const relativePath = filename ? normalizeRelativePath(filename.toString()) : '';
+  const watcher = fs.watch(rootPath, { recursive: true }, (_eventType, filename) => {
+    if (!filename) return;
+    const relativePath = normalizeRelativePath(filename);
     if (relativePath && !shouldWatchRelativePath(relativePath, opts.ignoreFn)) {
       return;
     }
     schedule(relativePath ? `change:${relativePath}` : 'change');
-  };
-
-  // Preferred: recursive watch
-  try {
-    const watcher = fs.watch(rootPath, { recursive: true }, (_eventType, filename) => {
-      scheduleIfIncluded(filename);
-    });
-    log('info', `watchFolderTree(recursive): ${rootPath}`);
-    return { close: () => watcher.close() };
-  } catch (err) {
-    log(
-      'warn',
-      `watchFolderTree: recursive unsupported, using per-directory watches: ${(err as Error).message}`,
-    );
-  }
-
-  // Fallback: watch every directory. Also re-scan on any event to pick up newly-created dirs.
-  const watchers = new Map<string, fs.FSWatcher>();
-
-  const ensureWatched = async () => {
-    const dirs = await listDirsRecursive(rootPath, opts.ignoreFn);
-    for (const d of dirs) {
-      if (watchers.has(d)) continue;
-      try {
-        const w = fs.watch(d, (_eventType, filename) => {
-          scheduleIfIncluded(filename);
-          void ensureWatched();
-        });
-        watchers.set(d, w);
-      } catch {
-        // ignore dirs we can't watch
-      }
-    }
-  };
-
-  await ensureWatched();
-  log('info', `watchFolderTree(per-dir): ${rootPath} dirs=${watchers.size}`);
-
-  return {
-    close: () => {
-      if (timer) clearTimeout(timer);
-      for (const w of watchers.values()) w.close();
-      watchers.clear();
-    },
-  };
+  });
+  log('debug', `watchFolderTree(recursive): ${rootPath}`);
+  return { close: () => watcher.close() };
 }

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -562,7 +562,7 @@ async function syncFolderOnce(
   const tookMs = nowMs() - totalStart;
   const totalBytes = bytesSentFull + bytesSentDelta;
   slog(
-    'info',
+    'debug',
     `sync finished files=${files.length} sent=${fmtBytes(totalBytes)} syncWork=${fmtMs(
       syncWorkMs,
     )} total=${fmtMs(tookMs)}`,

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -312,15 +312,6 @@ async function runXdelta3Encode(basis: string, target: string, outPatch: string)
   });
 }
 
-function localBasisCacheRoot(opts: FolderSyncOptions, localFolderPath: string): string {
-  const hostKey = opts.apiUrl.replace(/[:/]+/g, '_');
-  const resolved = path.resolve(localFolderPath);
-  const base = path.basename(resolved);
-  const hash = crypto.createHash('sha1').update(resolved).digest('hex').slice(0, 8);
-  // Include folder identity to avoid collisions between different roots.
-  return path.join(opts.basisCacheDir, 'folder-sync', hostKey, opts.udid, `${base}-${hash}`);
-}
-
 async function cachePut(cacheRoot: string, relPath: string, srcFile: string): Promise<void> {
   const dst = path.join(cacheRoot, relPath.split('/').join(path.sep));
   await fs.promises.mkdir(path.dirname(dst), { recursive: true });
@@ -408,8 +399,7 @@ async function syncFolderOnce(
   const rootName = path.basename(path.resolve(localFolderPath));
   const preferredCompression = (zlib as any).createZstdCompress ? 'zstd' : 'gzip';
 
-  const cacheRoot = localBasisCacheRoot(opts, localFolderPath);
-  await fs.promises.mkdir(cacheRoot, { recursive: true });
+  await fs.promises.mkdir(opts.basisCacheDir, { recursive: true });
 
   // Track how many bytes we actually transmit to the server (single HTTP request).
   let bytesSentFull = 0;
@@ -422,7 +412,7 @@ async function syncFolderOnce(
   const encodeLimit = concurrencyLimit();
   const changed: FileEntry[] = [];
   for (const f of files) {
-    const basisPath = cacheGet(cacheRoot, f.path);
+    const basisPath = cacheGet(opts.basisCacheDir, f.path);
     if (!fs.existsSync(basisPath)) {
       changed.push(f);
       continue;
@@ -434,7 +424,7 @@ async function syncFolderOnce(
   }
 
   const encodedPayloads = await mapLimit(changed, encodeLimit, async (f): Promise<EncodedPayload> => {
-    const basisPath = cacheGet(cacheRoot, f.path);
+    const basisPath = cacheGet(opts.basisCacheDir, f.path);
     if (fs.existsSync(basisPath)) {
       const basisSha = await sha256FileHex(basisPath);
       const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'limulator-xdelta3-'));
@@ -586,7 +576,7 @@ async function syncFolderOnce(
   }
   // Update local cache optimistically: after a successful sync, cache reflects current local tree.
   for (const f of files) {
-    await cachePut(cacheRoot, f.path, f.absPath);
+    await cachePut(opts.basisCacheDir, f.path, f.absPath);
   }
   return out;
 }

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -4,9 +4,9 @@ import os from 'os';
 import crypto from 'crypto';
 import { spawn } from 'child_process';
 import { watchFolderTree } from './folder-sync-watcher';
+import { type IgnoreFn } from './folder-sync-ignore';
 import { Readable } from 'stream';
 import * as zlib from 'zlib';
-import ignore, { type Ignore } from 'ignore';
 
 // =============================================================================
 // Folder Sync (HTTP batch)
@@ -21,9 +21,9 @@ export type FolderSyncOptions = {
    * Used to store the last-synced “basis” copies of files (and related sync metadata) so we can compute xdelta patches
    * on subsequent syncs without re-downloading server state.
    *
-   * Can be absolute or relative to process.cwd(). Defaults to `.limsync-cache/`.
+   * Defaults to a temporary directory under the OS temp directory.
    */
-  basisCacheDir?: string;
+  basisCacheDir: string;
   install?: boolean;
   launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
   /** If true, watch the folder and re-sync on any changes (debounced, single-flight). */
@@ -33,20 +33,20 @@ export type FolderSyncOptions = {
   /** Controls logging verbosity */
   log?: (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
   /**
-   * Optional filter function to include/exclude files and directories.
+   * Predicate for ignoring files and directories during sync.
    * Called with the relative path from localFolderPath (using forward slashes).
    * For directories, the path ends with '/'.
-   * Return true to include, false to exclude.
+   * Return true to ignore, false to keep.
    *
    * @example
-   * // Exclude build folder
-   * filter: (path) => !path.startsWith('build/')
+   * // Ignore build folder
+   * ignoreFn: (path) => path.startsWith('build/')
    *
    * @example
-   * // Only include source files
-   * filter: (path) => path.startsWith('src/') || path.endsWith('.json')
+   * // Ignore anything outside src/ and JSON files
+   * ignoreFn: (path) => !(path.startsWith('src/') || path.endsWith('.json'))
    */
-  filter?: (relativePath: string) => boolean;
+  ignoreFn: IgnoreFn;
 };
 
 export type SyncFolderResult = {
@@ -246,11 +246,8 @@ async function sha256FileHex(filePath: string): Promise<string> {
   });
 }
 
-async function walkFiles(root: string, filter?: (relativePath: string) => boolean): Promise<FileEntry[]> {
+async function walkFiles(root: string, ignoreFn: IgnoreFn): Promise<FileEntry[]> {
   const rootResolved = path.resolve(root);
-
-  // Load .gitignore if it exists
-  const ig = await loadGitignore(rootResolved);
 
   const out: FileEntry[] = [];
   const stack: string[] = [rootResolved];
@@ -258,28 +255,21 @@ async function walkFiles(root: string, filter?: (relativePath: string) => boolea
     const dir = stack.pop()!;
     const entries = await fs.promises.readdir(dir, { withFileTypes: true });
     for (const ent of entries) {
-      // Always skip .git folder and .DS_Store
-      if (ent.name === '.DS_Store' || ent.name === '.git') continue;
-
       const abs = path.join(dir, ent.name);
       const rel = path.relative(rootResolved, abs).split(path.sep).join('/');
-
-      // Check if ignored by .gitignore
-      if (ig.ignores(rel)) continue;
 
       if (ent.isDirectory()) {
         // For directories, check with trailing slash
         const relDir = rel + '/';
-        if (ig.ignores(relDir)) continue;
-        // Check custom filter (directories have trailing slash)
-        if (filter && !filter(relDir)) continue;
+        // Check custom ignores (directories have trailing slash)
+        if (ignoreFn(relDir)) continue;
         stack.push(abs);
         continue;
       }
       if (!ent.isFile()) continue;
 
-      // Check custom filter for files
-      if (filter && !filter(rel)) continue;
+      // Check custom ignores for files
+      if (ignoreFn(rel)) continue;
 
       const st = await fs.promises.stat(abs);
       const sha256 = await sha256FileHex(abs);
@@ -290,22 +280,6 @@ async function walkFiles(root: string, filter?: (relativePath: string) => boolea
   }
   out.sort((a, b) => a.path.localeCompare(b.path));
   return out;
-}
-
-/**
- * Load and parse .gitignore file if it exists.
- * Returns an Ignore instance that can be used to test paths.
- */
-async function loadGitignore(rootDir: string): Promise<Ignore> {
-  const ig = ignore();
-  const gitignorePath = path.join(rootDir, '.gitignore');
-  try {
-    const content = await fs.promises.readFile(gitignorePath, 'utf-8');
-    ig.add(content);
-  } catch {
-    // No .gitignore file, return empty ignore instance
-  }
-  return ig;
 }
 
 let xdelta3Ready: Promise<void> | null = null;
@@ -343,12 +317,8 @@ function localBasisCacheRoot(opts: FolderSyncOptions, localFolderPath: string): 
   const resolved = path.resolve(localFolderPath);
   const base = path.basename(resolved);
   const hash = crypto.createHash('sha1').update(resolved).digest('hex').slice(0, 8);
-  const rootOverride =
-    opts.basisCacheDir ?
-      path.resolve(process.cwd(), opts.basisCacheDir)
-    : path.join(process.cwd(), '.limsync-cache');
   // Include folder identity to avoid collisions between different roots.
-  return path.join(rootOverride, 'folder-sync', hostKey, opts.udid, `${base}-${hash}`);
+  return path.join(opts.basisCacheDir, 'folder-sync', hostKey, opts.udid, `${base}-${hash}`);
 }
 
 async function cachePut(cacheRoot: string, relPath: string, srcFile: string): Promise<void> {
@@ -361,9 +331,10 @@ function cacheGet(cacheRoot: string, relPath: string): string {
   return path.join(cacheRoot, relPath.split('/').join(path.sep));
 }
 
-export type SyncAppResult = SyncFolderResult;
-
-export async function syncApp(localFolderPath: string, opts: FolderSyncOptions): Promise<SyncFolderResult> {
+export async function syncFolder(
+  localFolderPath: string,
+  opts: FolderSyncOptions,
+): Promise<SyncFolderResult> {
   if (!opts.watch) {
     const result = await syncFolderOnce(localFolderPath, opts);
     return result;
@@ -391,11 +362,12 @@ export async function syncApp(localFolderPath: string, opts: FolderSyncOptions):
   };
 
   const watcherLog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => {
-    (opts.log ?? noopLogger)(level, `syncApp: ${msg}`);
+    (opts.log ?? noopLogger)(level, `syncFolder: ${msg}`);
   };
   const watcher = await watchFolderTree({
     rootPath: localFolderPath,
     log: watcherLog,
+    ignoreFn: opts.ignoreFn,
     onChange: (reason) => {
       void run(reason);
     },
@@ -417,7 +389,7 @@ async function syncFolderOnce(
 ): Promise<SyncFolderResult> {
   const totalStart = nowMs();
   const log = opts.log ?? noopLogger;
-  const slog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => log(level, `syncApp: ${msg}`);
+  const slog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => log(level, `syncFolder: ${msg}`);
   const maxPatchBytes = opts.maxPatchBytes ?? 4 * 1024 * 1024;
 
   const tEnsureStart = nowMs();
@@ -425,7 +397,7 @@ async function syncFolderOnce(
   const tEnsureMs = nowMs() - tEnsureStart;
 
   const tWalkStart = nowMs();
-  const files = await walkFiles(localFolderPath, opts.filter);
+  const files = await walkFiles(localFolderPath, opts.ignoreFn);
   const tWalkMs = nowMs() - tWalkStart;
   const fileMap = new Map(files.map((f) => [f.path, f]));
 
@@ -513,7 +485,7 @@ async function syncFolderOnce(
   const hasDelta = encodedPayloads.some((p) => p.payload.kind === 'delta');
   const compression: 'zstd' | 'gzip' | 'identity' = hasDelta ? 'identity' : preferredCompression;
   slog(
-    'info',
+    'debug',
     `sync started files=${files.length}${reason ? ` reason=${reason}` : ''} compression=${compression}`,
   );
 

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -24,14 +24,14 @@ export type FolderSyncOptions = {
    * Defaults to a temporary directory under the OS temp directory.
    */
   basisCacheDir: string;
-  install?: boolean;
-  launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
+  install: boolean;
+  launchMode: 'ForegroundIfRunning' | 'RelaunchIfRunning';
   /** If true, watch the folder and re-sync on any changes (debounced, single-flight). */
-  watch?: boolean;
+  watch: boolean;
   /** Max patch size (bytes) to send as delta before falling back to full upload. */
-  maxPatchBytes?: number;
+  maxPatchBytes: number;
   /** Controls logging verbosity */
-  log?: (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
+  log: (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
   /**
    * Predicate for ignoring files and directories during sync.
    * Called with the relative path from localFolderPath (using forward slashes).
@@ -329,10 +329,7 @@ export async function syncFolder(
   const log = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => {
     (opts.log ?? noopLogger)(level, `syncFolder: ${msg}`);
   };
-  log(
-    'debug',
-    `syncFolder: setup ${localFolderPath} watch=${opts.watch} basisCacheDir=${opts.basisCacheDir}`,
-  );
+  log('debug', `setup ${localFolderPath} watch=${opts.watch} basisCacheDir=${opts.basisCacheDir}`);
   if (!opts.watch) {
     const result = await syncFolderOnce(localFolderPath, opts);
     return result;
@@ -385,14 +382,9 @@ async function syncFolderOnce(
   const log = opts.log ?? noopLogger;
   const slog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => log(level, `syncFolder: ${msg}`);
   const maxPatchBytes = opts.maxPatchBytes ?? 4 * 1024 * 1024;
-
-  const tEnsureStart = nowMs();
   await ensureXdelta3();
-  const tEnsureMs = nowMs() - tEnsureStart;
 
-  const tWalkStart = nowMs();
   const files = await walkFiles(localFolderPath, opts.ignoreFn);
-  const tWalkMs = nowMs() - tWalkStart;
   const fileMap = new Map(files.map((f) => [f.path, f]));
 
   const syncId = genId('sync');
@@ -470,7 +462,7 @@ async function syncFolderOnce(
   const meta: FolderSyncHttpMeta = {
     id: syncId,
     rootName,
-    install: opts.install ?? true,
+    install: opts.install,
     ...(opts.launchMode ? { launchMode: opts.launchMode } : {}),
     files: files.map((f) => ({ path: f.path, size: f.size, sha256: f.sha256.toLowerCase(), mode: f.mode })),
     payloads: encodedPayloads.map((p) => p.payload),
@@ -559,13 +551,6 @@ async function syncFolderOnce(
     `sync finished files=${files.length} sent=${fmtBytes(totalBytes)} syncWork=${fmtMs(
       syncWorkMs,
     )} total=${fmtMs(tookMs)}`,
-  );
-  slog('debug', `sync bytes full=${fmtBytes(bytesSentFull)} delta=${fmtBytes(bytesSentDelta)}`);
-  slog(
-    'debug',
-    `timing ensureXdelta3=${fmtMs(tEnsureMs)} walk=${fmtMs(tWalkMs)} httpSend=${fmtMs(
-      httpSendMsTotal,
-    )} deltaEncode=${fmtMs(deltaEncodeMsTotal)}`,
   );
   const out: SyncFolderResult = {};
   if (resp.installedAppPath) {

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -335,6 +335,13 @@ export async function syncFolder(
   localFolderPath: string,
   opts: FolderSyncOptions,
 ): Promise<SyncFolderResult> {
+  const log = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => {
+    (opts.log ?? noopLogger)(level, `syncFolder: ${msg}`);
+  };
+  log(
+    'debug',
+    `syncFolder: setup ${localFolderPath} watch=${opts.watch} basisCacheDir=${opts.basisCacheDir}`,
+  );
   if (!opts.watch) {
     const result = await syncFolderOnce(localFolderPath, opts);
     return result;
@@ -360,13 +367,9 @@ export async function syncFolder(
       }
     }
   };
-
-  const watcherLog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => {
-    (opts.log ?? noopLogger)(level, `syncFolder: ${msg}`);
-  };
   const watcher = await watchFolderTree({
     rootPath: localFolderPath,
-    log: watcherLog,
+    log,
     ignoreFn: opts.ignoreFn,
     onChange: (reason) => {
       void run(reason);

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -2,6 +2,7 @@ import { WebSocket, Data } from 'ws';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import crypto from 'crypto';
 import { EventEmitter } from 'events';
 import { isNonRetryableError } from './tunnel';
 import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './folder-sync';
@@ -1364,7 +1365,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       }
       const resolvedPath = path.resolve(localAppBundlePath);
       const folderName = path.basename(resolvedPath);
-      const hash = Buffer.from(resolvedPath).toString('base64').replace(/[+/=]/g, '').slice(0, 8);
+      const hash = crypto.createHash('sha1').update(resolvedPath).digest('hex').slice(0, 8);
       const cacheKey = `limsync-cache-${folderName}-${hash}`;
       const basisCacheDir = opts?.basisCacheDir ?? path.join(os.tmpdir(), cacheKey);
       const folderSyncOpts: FolderSyncOptions = {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -301,11 +301,19 @@ export type InstanceClient = {
 
   /**
    * Sync an iOS app bundle folder to the server and (optionally) install/launch it.
+   * @param localAppBundlePath The path to the local app bundle folder
+   * @param opts Optional sync options
+   * @param opts.install If true, install the app after syncing. Defaults to true.
+   * @param opts.basisCacheDir Directory for the client-side folder-sync cache.
+   * @param opts.maxPatchBytes Max patch size (bytes) to send as delta before falling back to full upload. Defaults to 4MB.
+   * @param opts.launchMode Launch mode after installation: "ForegroundIfRunning" (default): bring to foreground if already running, otherwise launch, "RelaunchIfRunning": kill and relaunch if already running
+   * @param opts.watch If true, watch the folder and re-sync on any changes (debounced, single-flight).
    */
   syncApp: (
     localAppBundlePath: string,
     opts?: {
       install?: boolean;
+      basisCacheDir?: string;
       maxPatchBytes?: number;
       launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
       watch?: boolean;
@@ -1393,10 +1401,10 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
               break;
           }
         },
-        ...(opts?.install !== undefined ? { install: opts.install } : {}),
-        ...(opts?.maxPatchBytes !== undefined ? { maxPatchBytes: opts.maxPatchBytes } : {}),
-        ...(opts?.launchMode !== undefined ? { launchMode: opts.launchMode } : {}),
-        ...(opts?.watch !== undefined ? { watch: opts.watch } : {}),
+        install: opts?.install ?? true,
+        maxPatchBytes: opts?.maxPatchBytes ?? 4 * 1024 * 1024,
+        launchMode: opts?.launchMode ?? 'ForegroundIfRunning',
+        watch: opts?.watch ?? true,
       };
       return await syncFolder(localAppBundlePath, folderSyncOpts);
     };

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -1,8 +1,11 @@
 import { WebSocket, Data } from 'ws';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { EventEmitter } from 'events';
 import { isNonRetryableError } from './tunnel';
-import { syncApp as syncAppImpl, type SyncFolderResult, type FolderSyncOptions } from './folder-sync';
+import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './folder-sync';
+import { createIgnoreFn } from './folder-sync-ignore';
 
 /**
  * Connection state of the instance client
@@ -1345,18 +1348,31 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       localAppBundlePath: string,
       opts?: {
         install?: boolean;
+        basisCacheDir?: string;
         maxPatchBytes?: number;
         launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
         watch?: boolean;
       },
     ): Promise<SyncFolderResult> => {
+      const infoPlistPath = path.join(localAppBundlePath, 'Info.plist');
+      const infoPlistStat = await fs.promises.stat(infoPlistPath).catch(() => null);
+      if (!infoPlistStat?.isFile()) {
+        throw new Error(`The folder is not a valid app bundle: missing Info.plist at ${infoPlistPath}`);
+      }
       if (!cachedDeviceInfo) {
         throw new Error('Device info not available yet; wait for client connection to be established.');
       }
-      const appSyncOpts: FolderSyncOptions = {
+      const resolvedPath = path.resolve(localAppBundlePath);
+      const folderName = path.basename(resolvedPath);
+      const hash = Buffer.from(resolvedPath).toString('base64').replace(/[+/=]/g, '').slice(0, 8);
+      const cacheKey = `limsync-cache-${folderName}-${hash}`;
+      const basisCacheDir = opts?.basisCacheDir ?? path.join(os.tmpdir(), cacheKey);
+      const folderSyncOpts: FolderSyncOptions = {
         apiUrl: options.apiUrl,
         token: options.token,
-        udid: cachedDeviceInfo.udid,
+        udid: cacheKey,
+        ignoreFn: await createIgnoreFn(localAppBundlePath, { basisCacheDir }),
+        basisCacheDir,
         log: (level, msg) => {
           switch (level) {
             case 'debug':
@@ -1381,7 +1397,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         ...(opts?.launchMode !== undefined ? { launchMode: opts.launchMode } : {}),
         ...(opts?.watch !== undefined ? { watch: opts.watch } : {}),
       };
-      return await syncAppImpl(localAppBundlePath, appSyncOpts);
+      return await syncFolder(localAppBundlePath, folderSyncOpts);
     };
 
     const lsof = (): Promise<LsofEntry[]> => {

--- a/src/sandbox-client.ts
+++ b/src/sandbox-client.ts
@@ -1,5 +1,8 @@
-import { syncApp as syncFolderImpl, type FolderSyncOptions } from './folder-sync';
+import os from 'os';
+import path from 'path';
+import { syncFolder as syncFolderImpl, type FolderSyncOptions } from './folder-sync';
 import { exec, ExecChildProcess } from './exec-client';
+import { createIgnoreFn } from './folder-sync-ignore';
 
 export type LogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug';
 
@@ -27,32 +30,36 @@ export type SimulatorConfig = {
  */
 export type SyncOptions = {
   /**
-   * Cache scoping key for delta basis caching. Defaults to 'xcode-sandbox'.
-   * This is not sent to the server.
-   */
-  cacheKey?: string;
-  basisCacheDir?: string;
-  maxPatchBytes?: number;
-  /**
    * If true, watch the folder and re-sync on any changes.
    */
   watch?: boolean;
+  /**
+   * Directory for the client-side folder-sync cache.
+   * Used to store the last-synced “basis” copies of files (and related sync metadata) so we can compute xdelta patches
+   * on subsequent syncs without re-downloading server state.
+   *
+   * Defaults to a temporary directory under the OS temp directory.
+   */
+  basisCacheDir?: string;
+  /** Max patch size (bytes) to send as delta before falling back to full upload. */
+  maxPatchBytes?: number;
   log?: (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
   /**
-   * Optional filter function to include/exclude files and directories.
+   * Optional predicate for ignoring files and directories during sync.
+   * Applied in addition to built-in sync and Xcode-specific ignore rules.
    * Called with the relative path from the sync root (using forward slashes).
    * For directories, the path ends with '/'.
-   * Return true to include, false to exclude.
+   * Return true to ignore, false to keep.
    *
    * @example
-   * // Exclude build folder
-   * filter: (path) => !path.startsWith('build/')
+   * // Ignore build folder
+   * ignore: (path) => path.startsWith('build/')
    *
    * @example
-   * // Only include source files
-   * filter: (path) => path.startsWith('src/') || path.endsWith('.json')
+   * // Ignore anything outside src/ and JSON files
+   * ignore: (path) => !(path.startsWith('src/') || path.endsWith('.json'))
    */
-  filter?: (relativePath: string) => boolean;
+  ignore?: (relativePath: string) => boolean;
 };
 
 /**
@@ -196,51 +203,51 @@ export async function createXCodeSandboxClient(
 
   return {
     async sync(localCodePath: string, opts?: SyncOptions): Promise<SyncResult> {
+      // Use folder name and hash of absolute path to scope basisCacheDir uniquely for each sync root
+      const resolvedPath = path.resolve(localCodePath);
+      const folderName = path.basename(resolvedPath);
+      const hash = Buffer.from(resolvedPath).toString('base64').replace(/[+/=]/g, '').slice(0, 8);
+      const cacheKey = `limsync-cache-${folderName}-${hash}`;
+      const basisCacheDir = opts?.basisCacheDir ?? path.join(os.tmpdir(), cacheKey);
       const codeSyncOpts: FolderSyncOptions = {
         apiUrl: options.apiUrl,
         token: options.token,
-        udid: opts?.cacheKey ?? 'xcode-sandbox',
+        udid: cacheKey,
         install: false,
-        filter: (relativePath: string) => {
-          if (
-            relativePath.startsWith('build/') ||
-            relativePath.startsWith('.build/') ||
-            relativePath.startsWith('DerivedData/') ||
-            relativePath.startsWith('Index.noindex/') ||
-            relativePath.startsWith('ModuleCache.noindex/') ||
-            relativePath.startsWith('.index-build/')
-          ) {
+        ignoreFn: await createIgnoreFn(localCodePath, {
+          basisCacheDir,
+          additional: (relativePath: string) => {
+            if (
+              relativePath.startsWith('build/') ||
+              relativePath.startsWith('.build/') ||
+              relativePath.startsWith('DerivedData/') ||
+              relativePath.startsWith('Index.noindex/') ||
+              relativePath.startsWith('ModuleCache.noindex/') ||
+              relativePath.startsWith('.index-build/')
+            ) {
+              return true;
+            }
+            if (
+              relativePath.startsWith('.swiftpm/') ||
+              relativePath.startsWith('Pods/') ||
+              relativePath.startsWith('Carthage/Build/')
+            ) {
+              return true;
+            }
+            if (relativePath.includes('/xcuserdata/')) {
+              return true;
+            }
+            if (relativePath.includes('.dSYM/')) {
+              return true;
+            }
+            // User-provided ignores
+            if (opts?.ignore?.(relativePath)) {
+              return true;
+            }
             return false;
-          }
-          if (
-            relativePath.startsWith('.swiftpm/') ||
-            relativePath.startsWith('Pods/') ||
-            relativePath.startsWith('Carthage/Build/')
-          ) {
-            return false;
-          }
-          if (
-            relativePath.startsWith('.git/') ||
-            relativePath.startsWith('.limsync-cache/') ||
-            relativePath === '.DS_Store' ||
-            relativePath.endsWith('/.DS_Store')
-          ) {
-            return false;
-          }
-          if (relativePath.includes('/xcuserdata/')) {
-            return false;
-          }
-          if (relativePath.includes('.dSYM/')) {
-            return false;
-          }
-
-          // User-provided filter
-          if (opts?.filter && !opts.filter(relativePath)) {
-            return false;
-          }
-          return true;
-        },
-        ...(opts?.basisCacheDir ? { basisCacheDir: opts.basisCacheDir } : {}),
+          },
+        }),
+        basisCacheDir,
         ...(opts?.maxPatchBytes !== undefined ? { maxPatchBytes: opts.maxPatchBytes } : {}),
         ...(opts?.watch !== undefined ? { watch: opts.watch } : {}),
         log: opts?.log ?? logFn,

--- a/src/sandbox-client.ts
+++ b/src/sandbox-client.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { syncFolder as syncFolderImpl, type FolderSyncOptions } from './folder-sync';
 import { exec, ExecChildProcess } from './exec-client';
 import { createIgnoreFn } from './folder-sync-ignore';
+import crypto from 'crypto';
 
 export type LogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug';
 
@@ -206,7 +207,7 @@ export async function createXCodeSandboxClient(
       // Use folder name and hash of absolute path to scope basisCacheDir uniquely for each sync root
       const resolvedPath = path.resolve(localCodePath);
       const folderName = path.basename(resolvedPath);
-      const hash = Buffer.from(resolvedPath).toString('base64').replace(/[+/=]/g, '').slice(0, 8);
+      const hash = crypto.createHash('sha1').update(resolvedPath).digest('hex').slice(0, 8);
       const cacheKey = `limsync-cache-${folderName}-${hash}`;
       const basisCacheDir = opts?.basisCacheDir ?? path.join(os.tmpdir(), cacheKey);
       const codeSyncOpts: FolderSyncOptions = {

--- a/src/sandbox-client.ts
+++ b/src/sandbox-client.ts
@@ -31,7 +31,7 @@ export type SimulatorConfig = {
  */
 export type SyncOptions = {
   /**
-   * If true, watch the folder and re-sync on any changes.
+   * If true, watch the folder and re-sync on any changes. Defaults to true.
    */
   watch?: boolean;
   /**
@@ -44,7 +44,8 @@ export type SyncOptions = {
   basisCacheDir?: string;
   /** Max patch size (bytes) to send as delta before falling back to full upload. */
   maxPatchBytes?: number;
-  log?: (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
+  /** If true, install the app after syncing. Defaults to true. */
+  install?: boolean;
   /**
    * Optional predicate for ignoring files and directories during sync.
    * Applied in addition to built-in sync and Xcode-specific ignore rules.
@@ -158,7 +159,7 @@ export async function createXCodeSandboxClient(
     },
   };
 
-  const logFn = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => {
+  const log = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => {
     switch (level) {
       case 'debug':
         logger.debug(msg);
@@ -214,7 +215,7 @@ export async function createXCodeSandboxClient(
         apiUrl: options.apiUrl,
         token: options.token,
         udid: cacheKey,
-        install: false,
+        install: opts?.install ?? true,
         ignoreFn: await createIgnoreFn(localCodePath, {
           basisCacheDir,
           additional: (relativePath: string) => {
@@ -249,9 +250,10 @@ export async function createXCodeSandboxClient(
           },
         }),
         basisCacheDir,
-        ...(opts?.maxPatchBytes !== undefined ? { maxPatchBytes: opts.maxPatchBytes } : {}),
-        ...(opts?.watch !== undefined ? { watch: opts.watch } : {}),
-        log: opts?.log ?? logFn,
+        watch: opts?.watch ?? true,
+        maxPatchBytes: opts?.maxPatchBytes ?? 4 * 1024 * 1024,
+        launchMode: 'ForegroundIfRunning',
+        log,
       };
 
       const result = await syncFolderImpl(localCodePath, codeSyncOpts);
@@ -267,7 +269,7 @@ export async function createXCodeSandboxClient(
         {
           apiUrl: options.apiUrl,
           token: options.token,
-          log: logFn,
+          log,
         },
       );
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes file selection and watch-trigger behavior for folder sync (including removing the non-recursive watcher fallback) and alters default cache/option handling, which could cause missed or extra syncs or different delta-cache behavior across platforms.
> 
> **Overview**
> Centralizes folder-sync ignore logic into a new `createIgnoreFn` (combining `.gitignore`, built-in exclusions like `.git`/`.DS_Store`, and automatic exclusion of the configured basis cache directory) and applies it consistently to both the filesystem watcher triggers and the file-walk/upload planning.
> 
> Refactors folder sync option handling: `basisCacheDir`, `watch`, `install`, `launchMode`, `maxPatchBytes`, and `log` are now required by `syncFolder`, and the iOS and Xcode sandbox clients now generate a per-root temp `basisCacheDir` and wire in the shared ignore function (including Xcode-specific ignores plus user-provided `ignore`).
> 
> Reduces noisy logging by downgrading several build/sync lifecycle logs from `info` to `debug`, adds validation that `syncApp` targets a real app bundle (`Info.plist`), and removes `.limsync-cache` ignores from the example `.gitignore` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f12f6c0ca8df51c251585202d193989ede455ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->