### PR TITLE
node: respect HTTP_PROXY

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
   },
   "dependencies": {
     "eventsource-client": "^1.2.0",
+    "https-proxy-agent": "7.0.6",
     "ignore": "^7.0.5",
+    "proxy-from-env": "^2.1.0",
+    "undici": "7.24.7",
     "ws": "^8.18.3"
   },
   "devDependencies": {
@@ -37,6 +40,7 @@
     "@swc/jest": "^0.2.29",
     "@types/jest": "^29.4.0",
     "@types/node": "^20.17.6",
+    "@types/proxy-from-env": "^1.0.4",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "8.31.1",
     "@typescript-eslint/parser": "8.31.1",

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -6,6 +6,7 @@
  */
 
 import { createEventSource, type EventSourceClient, type EventSourceMessage } from 'eventsource-client';
+import { nodeProxyTransport } from './internal/proxy-transport';
 
 // =============================================================================
 // Types
@@ -153,7 +154,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       return;
     }
     try {
-      await fetch(`${this.options.apiUrl}/exec/${this.execId}/cancel`, {
+      await nodeProxyTransport.fetch(`${this.options.apiUrl}/exec/${this.execId}/cancel`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${this.options.token}`,
@@ -172,7 +173,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
     // 1. Trigger the build via POST /exec
     let execRes: Response;
     try {
-      execRes = await fetch(`${apiUrl}/exec`, {
+      execRes = await nodeProxyTransport.fetch(`${apiUrl}/exec`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -273,6 +274,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       try {
         const eventSource = createEventSource({
           url: eventsUrl,
+          fetch: nodeProxyTransport.fetch,
           headers: { Authorization: `Bearer ${this.options.token}` },
           onMessage: (message: EventSourceMessage) => {
             const data = typeof message.data === 'string' ? message.data : String(message.data ?? '');

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -7,6 +7,7 @@ import { watchFolderTree } from './folder-sync-watcher';
 import { type IgnoreFn } from './folder-sync-ignore';
 import { Readable } from 'stream';
 import * as zlib from 'zlib';
+import { nodeProxyTransport } from './internal/proxy-transport';
 
 // =============================================================================
 // Folder Sync (HTTP batch)
@@ -218,18 +219,20 @@ async function httpFolderSyncBatch(
   };
   sourceStream.on('error', onStreamError);
   bodyStream.on('error', onStreamError);
-  const res = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: bodyStream as any,
-    duplex: 'half' as any,
-    signal: controller.signal,
-  } as any).catch((err) => {
-    if (streamError) {
-      throw streamError;
-    }
-    throw err;
-  });
+  const res = await nodeProxyTransport
+    .fetch(url, {
+      method: 'POST',
+      headers,
+      body: bodyStream as any,
+      duplex: 'half' as any,
+      signal: controller.signal,
+    } as any)
+    .catch((err) => {
+      if (streamError) {
+        throw streamError;
+      }
+      throw err;
+    });
   const text = await res.text();
   if (!res.ok) {
     throw new Error(`folder-sync http failed: ${res.status} ${text}`);

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -1,6 +1,7 @@
 import { WebSocket, Data } from 'ws';
 import { exec } from 'node:child_process';
 
+import { nodeProxyTransport } from './internal/proxy-transport';
 import { startTcpTunnel, isNonRetryableError } from './tunnel';
 import type { Tunnel } from './tunnel';
 
@@ -597,7 +598,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       cleanup();
       updateConnectionState('connecting');
 
-      ws = new WebSocket(serverAddress);
+      const proxyAgent = nodeProxyTransport.getWebSocketAgent(serverAddress);
+      ws = new WebSocket(serverAddress, proxyAgent ? { agent: proxyAgent } : {});
 
       ws.on('message', (data: Data) => {
         let message: ServerMessage;

--- a/src/internal/proxy-transport.ts
+++ b/src/internal/proxy-transport.ts
@@ -1,0 +1,69 @@
+import type { Agent as HttpAgent } from 'http';
+
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { getProxyForUrl } from 'proxy-from-env';
+import { EnvHttpProxyAgent } from 'undici';
+
+import type { Fetch } from './builtin-types';
+
+class NodeProxyTransport {
+  private envHttpProxyAgent: EnvHttpProxyAgent | undefined;
+  private websocketAgents = new Map<string, HttpAgent>();
+
+  fetch: Fetch = async (input, init) => {
+    if (!this.hasProxyEnv()) {
+      return fetch(input, init);
+    }
+
+    return (fetch as any)(input, {
+      ...(init ?? {}),
+      dispatcher: this.getEnvHttpProxyAgent(),
+    });
+  };
+
+  getWebSocketAgent(url: string): HttpAgent | undefined {
+    if (!this.hasProxyEnv()) {
+      return undefined;
+    }
+
+    const proxyUrl = getProxyForUrl(this.getWebSocketProxyLookupUrl(url));
+    if (!proxyUrl) {
+      return undefined;
+    }
+
+    let agent = this.websocketAgents.get(proxyUrl);
+    if (!agent) {
+      const createdAgent = new HttpsProxyAgent(proxyUrl);
+      this.websocketAgents.set(proxyUrl, createdAgent);
+      agent = createdAgent;
+    }
+
+    return agent;
+  }
+
+  private getEnvHttpProxyAgent(): EnvHttpProxyAgent {
+    this.envHttpProxyAgent ??= new EnvHttpProxyAgent();
+    return this.envHttpProxyAgent;
+  }
+
+  private hasProxyEnv(): boolean {
+    if (typeof process === 'undefined' || !process.versions?.node) {
+      return false;
+    }
+
+    const env = process.env;
+    return !!(env['http_proxy'] || env['HTTP_PROXY'] || env['https_proxy'] || env['HTTPS_PROXY']);
+  }
+
+  private getWebSocketProxyLookupUrl(url: string): string {
+    const lookupUrl = new URL(url);
+    if (lookupUrl.protocol === 'ws:') {
+      lookupUrl.protocol = 'http:';
+    } else if (lookupUrl.protocol === 'wss:') {
+      lookupUrl.protocol = 'https:';
+    }
+    return lookupUrl.toString();
+  }
+}
+
+export const nodeProxyTransport = new NodeProxyTransport();

--- a/src/internal/shims.ts
+++ b/src/internal/shims.ts
@@ -8,11 +8,12 @@
  */
 
 import type { Fetch } from './builtin-types';
+import { nodeProxyTransport } from './proxy-transport';
 import type { ReadableStream } from './shim-types';
 
 export function getDefaultFetch(): Fetch {
   if (typeof fetch !== 'undefined') {
-    return fetch as any;
+    return nodeProxyTransport.fetch;
   }
 
   throw new Error(

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -9,6 +9,7 @@ import { pipeline } from 'stream/promises';
 import { isNonRetryableError } from './tunnel';
 import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './folder-sync';
 import { createIgnoreFn } from './folder-sync-ignore';
+import { nodeProxyTransport } from './internal/proxy-transport';
 
 /**
  * Connection state of the instance client
@@ -33,7 +34,7 @@ async function downloadFileToLocalPath(url: string, token: string, localPath: st
   const maxRetries = 3;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await fetch(url, {
+    const response = await nodeProxyTransport.fetch(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -849,7 +850,8 @@ export class LogStream extends EventEmitter {
 
   /** @internal - Establish the dedicated WebSocket connection */
   private _connect(): void {
-    this.ws = new WebSocket(this.wsUrl);
+    const proxyAgent = nodeProxyTransport.getWebSocketAgent(this.wsUrl);
+    this.ws = new WebSocket(this.wsUrl, proxyAgent ? { agent: proxyAgent } : {});
 
     this.ws.on('open', () => {
       if (this.stopped) {
@@ -1121,7 +1123,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       cleanup();
       updateConnectionState('connecting');
 
-      ws = new WebSocket(endpointWebSocketUrl);
+      const proxyAgent = nodeProxyTransport.getWebSocketAgent(endpointWebSocketUrl);
+      ws = new WebSocket(endpointWebSocketUrl, proxyAgent ? { agent: proxyAgent } : {});
 
       ws.on('message', (data: Data) => {
         let message: ServerResponse;
@@ -1594,7 +1597,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       try {
         // Node's fetch (undici) supports streaming request bodies but TS DOM types may not include
         // `duplex` and may not accept Node ReadStreams as BodyInit in some configs.
-        const response = await fetch(uploadUrl, {
+        const response = await nodeProxyTransport.fetch(uploadUrl, {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/octet-stream',

--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
 
 import { RequestOptions } from '../internal/request-options';
+import { nodeProxyTransport } from '../internal/proxy-transport';
 import { Assets as GeneratedAssets } from './assets';
 
 export interface AssetGetOrUploadParams {
@@ -45,7 +46,7 @@ export class Assets extends GeneratedAssets {
         md5: creationResponse.md5,
       };
     }
-    const uploadResponse = await fetch(creationResponse.signedUploadUrl, {
+    const uploadResponse = await nodeProxyTransport.fetch(creationResponse.signedUploadUrl, {
       headers: {
         'Content-Length': data.length.toString(),
         'Content-Type': 'application/octet-stream',

--- a/src/sandbox-client.ts
+++ b/src/sandbox-client.ts
@@ -4,6 +4,7 @@ import { syncFolder as syncFolderImpl, type FolderSyncOptions } from './folder-s
 import { exec, ExecChildProcess } from './exec-client';
 import { createIgnoreFn } from './folder-sync-ignore';
 import crypto from 'crypto';
+import { nodeProxyTransport } from './internal/proxy-transport';
 
 export type LogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug';
 
@@ -189,7 +190,7 @@ export async function createXCodeSandboxClient(
       simulatorToken: options.simulator.token ?? options.token,
     };
 
-    const res = await fetch(`${options.apiUrl}/simulator`, {
+    const res = await nodeProxyTransport.fetch(`${options.apiUrl}/simulator`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import * as net from 'net';
 import { WebSocket } from 'ws';
+import { nodeProxyTransport } from './internal/proxy-transport';
 
 /**
  * Controls the verbosity of logging in the tunnel
@@ -246,8 +247,10 @@ async function startSingletonTcpTunnel(
         url.searchParams.set('sessionId', sessionId);
       }
 
+      const proxyAgent = nodeProxyTransport.getWebSocketAgent(url.toString());
       ws = new WebSocket(url.toString(), {
         headers: { Authorization: `Bearer ${token}` },
+        ...(proxyAgent ? { agent: proxyAgent } : {}),
         perMessageDeflate: false,
       });
 
@@ -541,8 +544,10 @@ async function startMultiplexedTcpTunnel(
 
         logger.debug(`Connecting WebSocket to: ${url.toString()}`);
 
+        const proxyAgent = nodeProxyTransport.getWebSocketAgent(url.toString());
         ws = new WebSocket(url.toString(), {
           headers: { Authorization: `Bearer ${token}` },
+          ...(proxyAgent ? { agent: proxyAgent } : {}),
           perMessageDeflate: false,
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,13 @@
   dependencies:
     undici-types "~6.21.0"
 
+"@types/proxy-from-env@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@types/proxy-from-env/-/proxy-from-env-1.0.4.tgz#0a0545768f2d6c16b81a84ffefb53b423807907c"
+  integrity sha512-TPR9/bCZAr3V1eHN4G3LD3OLicdJjqX1QRXWuNcCYgE66f/K8jO2ZRtHxI2D9MbnuUP6+qiKSS8eUHp6TFHGCw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
@@ -1068,6 +1075,11 @@ acorn@^8.4.1:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1425,6 +1437,13 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.4"
@@ -1894,6 +1913,14 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+https-proxy-agent@7.0.6:
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -2894,6 +2921,11 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
+
 publint@^0.2.12:
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/publint/-/publint-0.2.12.tgz#d25cd6bd243d5bdd640344ecdddb3eeafdcc4059"
@@ -3322,6 +3354,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@7.24.7:
+  version "7.24.7"
+  resolved "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz#af9535341bbe80625ca403a02418477a5c6a8760"
+  integrity sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Centralizes all HTTP and WebSocket networking through a new proxy-aware transport, which could affect connectivity and request dispatching in Node environments that rely on custom agents/proxy settings.
> 
> **Overview**
> Adds a new internal `nodeProxyTransport` that detects `HTTP_PROXY`/`HTTPS_PROXY` (and lowercase variants) and routes Node `fetch` via Undici’s `EnvHttpProxyAgent`, plus WebSocket connections via `HttpsProxyAgent` using `proxy-from-env`.
> 
> Updates all SDK entry points that perform HTTP/SSE uploads/downloads or open WebSockets (`exec-client`, `folder-sync`, `ios-client`, `instance-client`, `sandbox-client`, `tunnel`, and asset uploads) to use this transport (including making `getDefaultFetch()` return the proxy-aware fetch). Dependency updates add `undici`, `proxy-from-env`, and `https-proxy-agent` (and types) to support this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5184e8b7460fb33e11239fdab53c43620f646aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->