### PR TITLE
android: add video recording and move to requiring only apiUrl

### DIFF
--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -1,10 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-import { Readable } from 'stream';
-import { pipeline } from 'stream/promises';
 import { WebSocket, Data } from 'ws';
 import { exec } from 'node:child_process';
 
+import { downloadFileToLocalPath } from './internal/download-file';
 import { nodeProxyTransport } from './internal/proxy-transport';
 import { startTcpTunnel, isNonRetryableError } from './tunnel';
 import type { Tunnel } from './tunnel';
@@ -21,33 +18,6 @@ export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'rec
  * Callback function for connection state changes
  */
 export type ConnectionStateCallback = (state: ConnectionState) => void;
-
-async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {
-  const maxRetries = 3;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await nodeProxyTransport.fetch(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    if (!response.ok) {
-      const errorBody = await response.text();
-      const isRetriable = response.status >= 500 && response.status < 600;
-      if (isRetriable && attempt < maxRetries) {
-        continue;
-      }
-      throw new Error(`Download failed: ${response.status} ${errorBody}`);
-    }
-    if (!response.body) {
-      throw new Error('Download failed: response body is missing');
-    }
-    await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
-    await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
-    return;
-  }
-}
 
 function deriveEndpointWebSocketUrl(apiUrl: string): string {
   const parsed = new URL(apiUrl);

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -1,9 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { WebSocket, Data } from 'ws';
 import { exec } from 'node:child_process';
 
 import { nodeProxyTransport } from './internal/proxy-transport';
 import { startTcpTunnel, isNonRetryableError } from './tunnel';
 import type { Tunnel } from './tunnel';
+
+const ANDROID_RECORDING_PATH = '/data/local/tmp/recordings/video_recording.mp4';
+const ANDROID_SIGNALING_PATH = '/ws';
 
 /**
  * Connection state of the instance client
@@ -14,6 +21,46 @@ export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'rec
  * Callback function for connection state changes
  */
 export type ConnectionStateCallback = (state: ConnectionState) => void;
+
+async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {
+  const maxRetries = 3;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await nodeProxyTransport.fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      const isRetriable = response.status >= 500 && response.status < 600;
+      if (isRetriable && attempt < maxRetries) {
+        continue;
+      }
+      throw new Error(`Download failed: ${response.status} ${errorBody}`);
+    }
+    if (!response.body) {
+      throw new Error('Download failed: response body is missing');
+    }
+    await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
+    await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
+    return;
+  }
+}
+
+function deriveEndpointWebSocketUrl(apiUrl: string): string {
+  const parsed = new URL(apiUrl);
+  parsed.protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+  parsed.search = '';
+  parsed.hash = '';
+  parsed.pathname = `${parsed.pathname.replace(/\/$/, '')}${ANDROID_SIGNALING_PATH}`;
+  return parsed.toString().replace(/\/$/, '');
+}
+
+function buildDownloadUrl(apiUrl: string): string {
+  return `${apiUrl}/files?path=${encodeURIComponent(ANDROID_RECORDING_PATH)}`;
+}
 
 /**
  * A client for interacting with a Limbar instance
@@ -65,6 +112,17 @@ export type InstanceClient = {
    * Open a URL/deeplink on Android.
    */
   openUrl: (url: string) => Promise<OpenUrlResult>;
+  /**
+ * Start recording device video. Use stopRecording() to finish the recording.
+   */
+  startRecording: () => Promise<void>;
+  /**
+   * Stop the active server-side recording.
+   * If `saveTo.presignedUrl` is provided, the server uploads the completed file there before resolving.
+   * If `saveTo.localPath` is provided, the client downloads the completed file to that path.
+   * Returns a download URL for the completed recording.
+   */
+  stopRecording: (saveTo: { presignedUrl?: string; localPath?: string }) => Promise<string>;
   /**
    * Disconnect from the Limbar instance
    */
@@ -152,13 +210,14 @@ export type AndroidElementNode = {
  */
 export type InstanceClientOptions = {
   /**
+   * HTTP base URL for the Android daemon. WebSocket control is derived from it
+   * using the `/ws` path, and recording downloads use the same base URL.
+   */
+  apiUrl: string;
+  /**
    * The URL of the ADB WebSocket endpoint.
    */
-  adbUrl: string;
-  /**
-   * The URL of the main endpoint WebSocket.
-   */
-  endpointUrl: string;
+  adbUrl?: string;
   /**
    * The token to use for the WebSocket connections.
    */
@@ -234,6 +293,8 @@ export type ScrollResult = {
 export type OpenUrlResult = {
   url: string;
 };
+
+type EmptyCommandResult = Record<string, never>;
 
 type ScreenshotErrorResponse = {
   type: 'screenshotError';
@@ -322,6 +383,20 @@ type OpenUrlResultMessage = {
   error?: CommandError;
 };
 
+type StartVideoRecordingResultMessage = {
+  type: 'startRecordingResult';
+  id: string;
+  payload?: EmptyCommandResult;
+  error?: CommandError;
+};
+
+type StopVideoRecordingResultMessage = {
+  type: 'stopRecordingResult';
+  id: string;
+  payload?: EmptyCommandResult;
+  error?: CommandError;
+};
+
 type KnownCommandResultMessage =
   | ScreenshotResultMessage
   | GetElementTreeResultMessage
@@ -331,7 +406,9 @@ type KnownCommandResultMessage =
   | PressKeyResultMessage
   | ScrollScreenResultMessage
   | ScrollElementResultMessage
-  | OpenUrlResultMessage;
+  | OpenUrlResultMessage
+  | StartVideoRecordingResultMessage
+  | StopVideoRecordingResultMessage;
 
 type ServerMessage =
   | ScreenshotResponse
@@ -350,6 +427,8 @@ type CommandRequestMap = {
   scrollScreen: { direction: ScrollDirection; amount?: number };
   scrollElement: AndroidElementTarget & { direction: ScrollDirection; amount?: number };
   openUrl: { url: string };
+  startRecording: Record<string, never>;
+  stopRecording: { upload?: { presignedUrl: string } };
 };
 
 type CommandResultMap = {
@@ -362,6 +441,8 @@ type CommandResultMap = {
   scrollScreen: ScrollResult;
   scrollElement: ScrollResult;
   openUrl: OpenUrlResult;
+  startRecording: EmptyCommandResult;
+  stopRecording: EmptyCommandResult;
 };
 
 type PendingRequest<T> = {
@@ -376,7 +457,9 @@ type PendingRequest<T> = {
  * @returns An InstanceClient for controlling the instance
  */
 export async function createInstanceClient(options: InstanceClientOptions): Promise<InstanceClient> {
-  const serverAddress = `${options.endpointUrl}?token=${options.token}`;
+  const endpointWebSocketUrl = deriveEndpointWebSocketUrl(options.apiUrl);
+  const serverAddress = `${endpointWebSocketUrl}?token=${options.token}`;
+  const recordingApiUrl = options.apiUrl;
   const logLevel = options.logLevel ?? 'info';
   const maxReconnectAttempts = options.maxReconnectAttempts ?? 6;
   const reconnectDelay = options.reconnectDelay ?? 1000;
@@ -388,7 +471,6 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
   let reconnectTimeout: NodeJS.Timeout | undefined;
   let intentionalDisconnect = false;
   let lastError: string | undefined;
-
   const pendingRequests: Map<string, PendingRequest<unknown>> = new Map();
   const pendingAssetRequestsByUrl: Map<string, Array<PendingRequest<void>>> = new Map();
 
@@ -522,6 +604,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         case 'scrollScreenResult':
         case 'scrollElementResult':
         case 'openUrlResult':
+        case 'startRecordingResult':
+        case 'stopRecordingResult':
           return 'id' in message && typeof message.id === 'string';
         default:
           return false;
@@ -759,6 +843,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             scrollScreen,
             scrollElement,
             openUrl,
+            startRecording,
+            stopRecording,
             disconnect,
             startAdbTunnel,
             sendAsset,
@@ -848,6 +934,23 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       };
     };
 
+    const startRecording = async (): Promise<void> => {
+      await sendRequest('startRecording', {});
+    };
+
+    const stopRecording = async (saveTo: { presignedUrl?: string; localPath?: string }): Promise<string> => {
+      const request: CommandRequestMap['stopRecording'] = {};
+      if (saveTo.presignedUrl) {
+        request.upload = { presignedUrl: saveTo.presignedUrl };
+      }
+      await sendRequest('stopRecording', request);
+      const downloadUrl = buildDownloadUrl(recordingApiUrl);
+      if (saveTo.localPath) {
+        await downloadFileToLocalPath(downloadUrl, options.token, saveTo.localPath);
+      }
+      return downloadUrl;
+    };
+
     const disconnect = (): void => {
       intentionalDisconnect = true;
       cleanup();
@@ -872,6 +975,9 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
      * client to it.
      */
     const startAdbTunnel = async (): Promise<Tunnel> => {
+      if (!options.adbUrl) {
+        throw new Error('adbUrl is required to start an ADB tunnel.');
+      }
       const tunnel = await startTcpTunnel(options.adbUrl, options.token, '127.0.0.1', 0, {
         maxReconnectAttempts,
         reconnectDelay,

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -113,7 +113,7 @@ export type InstanceClient = {
    */
   openUrl: (url: string) => Promise<OpenUrlResult>;
   /**
- * Start recording device video. Use stopRecording() to finish the recording.
+   * Start recording device video. Use stopRecording() to finish the recording.
    */
   startRecording: () => Promise<void>;
   /**

--- a/src/internal/download-file.ts
+++ b/src/internal/download-file.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+
+import { nodeProxyTransport } from './proxy-transport';
+
+export async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {
+  const maxRetries = 3;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await nodeProxyTransport.fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      const isRetriable = response.status >= 500 && response.status < 600;
+      if (isRetriable && attempt < maxRetries) {
+        continue;
+      }
+      throw new Error(`Download failed: ${response.status} ${errorBody}`);
+    }
+    if (!response.body) {
+      throw new Error('Download failed: response body is missing');
+    }
+    await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
+    await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
+    return;
+  }
+}

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -1,14 +1,11 @@
 import { WebSocket, Data } from 'ws';
-import fs from 'fs';
 import os from 'os';
-import path from 'path';
 import crypto from 'crypto';
 import { EventEmitter } from 'events';
-import { Readable } from 'stream';
-import { pipeline } from 'stream/promises';
 import { isNonRetryableError } from './tunnel';
 import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './folder-sync';
 import { createIgnoreFn } from './folder-sync-ignore';
+import { downloadFileToLocalPath } from './internal/download-file';
 import { nodeProxyTransport } from './internal/proxy-transport';
 
 /**
@@ -28,33 +25,6 @@ function generateRecordingFilename(): string {
 
   // Example: 20240602_17_45_30 for June 2, 2024 17:45:30 UTC
   return `ios_video_${formattedDate}_${rand}.mp4`;
-}
-
-async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {
-  const maxRetries = 3;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await nodeProxyTransport.fetch(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    if (!response.ok) {
-      const errorBody = await response.text();
-      const isRetriable = response.status >= 500 && response.status < 600;
-      if (isRetriable && attempt < maxRetries) {
-        continue;
-      }
-      throw new Error(`Download failed: ${response.status} ${errorBody}`);
-    }
-    if (!response.body) {
-      throw new Error('Download failed: response body is missing');
-    }
-    await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
-    await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
-    return;
-  }
 }
 
 function buildDownloadUrl(apiUrl: string, filename: string): string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to a breaking configuration change (replacing `endpointUrl`/required `adbUrl` with required `apiUrl` and optional `adbUrl`) and new recording/download flows that depend on server endpoints and file handling.
> 
> **Overview**
> Adds Android video recording support to `InstanceClient` via new `startRecording()`/`stopRecording()` commands, including optional server-side upload to a presigned URL and optional client-side download of the finished MP4.
> 
> Refactors Android connection configuration to require a single `apiUrl`, deriving the WebSocket control URL (`/ws`) and recording download URL (`/files?path=...`) from it; `adbUrl` is now optional and `startAdbTunnel()` throws if it’s not provided.
> 
> Extracts reusable `downloadFileToLocalPath()` into `src/internal/download-file.ts` and updates the iOS client to import it instead of maintaining its own copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553b3b8815600b5d81d15361f187345c26cde290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->