### PR TITLE
examples: fix implicit any type error in xcode-sandbox

### DIFF
--- a/examples/xcode-sandbox/index.ts
+++ b/examples/xcode-sandbox/index.ts
@@ -44,7 +44,7 @@ const xcodeInstance = await lim.xcodeInstances.create({
 const xcode = await lim.xcodeInstances.createClient({ instance: xcodeInstance });
 
 // Optionally attach a simulator
-let iosInstance;
+let iosInstance: Limrun.IosInstance | undefined;
 if (withSimulator) {
   console.log('Creating iOS simulator and attaching...');
   iosInstance = await lim.iosInstances.create({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only change in an example script; no runtime behavior or API flow changes.
> 
> **Overview**
> Fixes a TypeScript `implicit any` issue in `examples/xcode-sandbox` by explicitly typing `iosInstance` as `Limrun.IosInstance | undefined` when optionally creating/attaching an iOS simulator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a828e99a65adee5c78dd2fb7c3d0e500116097b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->