### PR TITLE
add new performActions API and add examples to websocket-ios

### DIFF
--- a/examples/websocket-ios/index.ts
+++ b/examples/websocket-ios/index.ts
@@ -239,6 +239,88 @@ try {
   console.log(`Simctl exited with code: ${result.code}`);
 
   // ========================================================================
+  // performActions (batch) - open Safari, focus URL bar, make sure the
+  // on-screen keyboard is up, and type `ycombinator.com` + Enter.
+  //
+  // Everything is sent as a single batch so there is no client round-trip
+  // between steps — the pod runs them sequentially and stops on the first
+  // failure. The returned `results` array mirrors each action (including
+  // partial results if the batch fails early).
+  // ========================================================================
+  console.log('\n--- Testing performActions: Safari navigation ---');
+  const navResult = await client.performActions([
+    // `openUrl` also launches Safari if it wasn't running.
+    { type: 'openUrl', url: 'https://www.apple.com' },
+    { type: 'wait', durationMs: 2000 },
+    // Focus the URL bar so typed text lands there.
+    { type: 'tapElement', selector: { elementType: 'TextField' } },
+    { type: 'wait', durationMs: 500 },
+    // If a hardware keyboard is attached the software keyboard may be
+    // hidden; `toggleKeyboard` (Cmd+K in the simulator) flips visibility
+    // so the on-screen keyboard is showing while we type.
+    { type: 'toggleKeyboard' },
+    { type: 'wait', durationMs: 300 },
+    { type: 'typeText', text: 'ycombinator.com', pressEnter: true },
+    { type: 'wait', durationMs: 2500 },
+  ]);
+  console.log(`performActions: ${navResult.results.length} action(s) executed`);
+  navResult.results.forEach((r, i) => {
+    const status = r.error ? `ERROR: ${r.error}` : 'ok';
+    const label = r.elementLabel ? ` [${r.elementLabel}]` : '';
+    console.log(`  ${i + 1}. ${r.type}${label} — ${status}`);
+  });
+  if (navResult.error) {
+    console.log(`  batch stopped early: ${navResult.error}`);
+  }
+
+  // ========================================================================
+  // performActions (batch) - custom scroll gesture built from raw HID
+  // primitives (touchDown / touchMove / touchUp).
+  //
+  // This bypasses the `scroll` helper so you can pick your own pacing,
+  // distance and interpolation. We scroll the page down 200px and then
+  // back up 200px at the center of the screen.
+  // ========================================================================
+  console.log('\n--- Testing performActions: HID scroll gestures ---');
+  const { width, height } = await client.screenshot();
+  const cx = width / 2;
+  const startY = height / 2 + 100;
+  const endY = startY - 200;
+
+  const hidResult = await client.performActions([
+    // Scroll content up by 200px (finger moves up, page scrolls up).
+    { type: 'touchDown', x: cx, y: startY },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: startY - 50 },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: startY - 100 },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: startY - 150 },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: endY },
+    { type: 'touchUp', x: cx, y: endY },
+    { type: 'wait', durationMs: 800 },
+
+    // Now scroll back in the opposite direction (finger moves down).
+    { type: 'touchDown', x: cx, y: endY },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: endY + 50 },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: endY + 100 },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: endY + 150 },
+    { type: 'wait', durationMs: 30 },
+    { type: 'touchMove', x: cx, y: startY },
+    { type: 'touchUp', x: cx, y: startY },
+  ]);
+  console.log(`performActions: ${hidResult.results.length} HID event(s) executed`);
+  if (hidResult.error) {
+    console.log(`  batch stopped early: ${hidResult.error}`);
+  } else {
+    console.log('  HID scroll round-trip complete');
+  }
+
+  // ========================================================================
   // Take final screenshot
   // ========================================================================
   console.log('\n--- Taking final screenshot ---');

--- a/examples/websocket-ios/index.ts
+++ b/examples/websocket-ios/index.ts
@@ -261,25 +261,31 @@ try {
   }));
 
   try {
-    const navResult = await client.performActions([
-      // `openUrl` also launches Safari if it wasn't running.
-      { type: 'openUrl', url: 'https://www.apple.com' },
-      { type: 'wait', durationMs: 2000 },
-      // Focus the URL bar so the keyboard appears and typed keys land there.
-      { type: 'tapElement', selector: { elementType: 'TextField' } },
-      { type: 'wait', durationMs: 500 },
-      // If a hardware keyboard is attached the software keyboard is hidden;
-      // `toggleKeyboard` (Cmd+K in the simulator) flips visibility so the
-      // on-screen keys are actually tappable.
-      { type: 'toggleKeyboard' },
-      { type: 'wait', durationMs: 500 },
-      // Tap each key of "ycombinator.com" on the software keyboard.
-      ...keyTaps,
-      // Submit by tapping the on-screen "Go" button (Safari's return key in
-      // URL mode). On other locales this is "go" — `labelContains` stays loose.
-      { type: 'tapElement', selector: { labelContains: 'go', elementType: 'Button' } },
-      { type: 'wait', durationMs: 2500 },
-    ]);
+    const navResult = await client.performActions(
+      [
+        // `openUrl` also launches Safari if it wasn't running.
+        { type: 'openUrl', url: 'https://www.apple.com' },
+        { type: 'wait', durationMs: 2000 },
+        // Focus the URL bar so the keyboard appears and typed keys land there.
+        { type: 'tapElement', selector: { elementType: 'TextField' } },
+        { type: 'wait', durationMs: 500 },
+        // If a hardware keyboard is attached the software keyboard is hidden;
+        // `toggleKeyboard` (Cmd+K in the simulator) flips visibility so the
+        // on-screen keys are actually tappable.
+        { type: 'toggleKeyboard' },
+        { type: 'wait', durationMs: 500 },
+        // Tap each key of "ycombinator.com" on the software keyboard.
+        ...keyTaps,
+        // Submit by tapping the on-screen "Go" button (Safari's return key in
+        // URL mode). On other locales this is "go" — `labelContains` stays loose.
+        { type: 'tapElement', selector: { labelContains: 'go', elementType: 'Button' } },
+        { type: 'wait', durationMs: 2500 },
+      ],
+      // Explicit timeout — the default is already scaled by batch size and
+      // wait durations, but for a long user-driven flow like this one you
+      // may want a generous ceiling.
+      { timeoutMs: 60_000 },
+    );
     console.log(`performActions: ${navResult.results.length} action(s) executed`);
     navResult.results.forEach((r, i) => {
       const label = r.elementLabel ? ` [${r.elementLabel}]` : '';
@@ -304,32 +310,36 @@ try {
   const endY = startY - 200;
 
   try {
-    const hidResult = await client.performActions([
-      // Scroll content up by 200px (finger moves up, page scrolls up).
-      { type: 'touchDown', x: cx, y: startY },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: startY - 50 },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: startY - 100 },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: startY - 150 },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: endY },
-      { type: 'touchUp', x: cx, y: endY },
-      { type: 'wait', durationMs: 800 },
+    const hidResult = await client.performActions(
+      [
+        // Scroll content up by 200px (finger moves up, page scrolls up).
+        { type: 'touchDown', x: cx, y: startY },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: startY - 50 },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: startY - 100 },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: startY - 150 },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: endY },
+        { type: 'touchUp', x: cx, y: endY },
+        { type: 'wait', durationMs: 800 },
 
-      // Now scroll back in the opposite direction (finger moves down).
-      { type: 'touchDown', x: cx, y: endY },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: endY + 50 },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: endY + 100 },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: endY + 150 },
-      { type: 'wait', durationMs: 30 },
-      { type: 'touchMove', x: cx, y: startY },
-      { type: 'touchUp', x: cx, y: startY },
-    ]);
+        // Now scroll back in the opposite direction (finger moves down).
+        { type: 'touchDown', x: cx, y: endY },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: endY + 50 },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: endY + 100 },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: endY + 150 },
+        { type: 'wait', durationMs: 30 },
+        { type: 'touchMove', x: cx, y: startY },
+        { type: 'touchUp', x: cx, y: startY },
+      ],
+      // HID gesture is short (~1s of waits) — tight timeout to fail fast.
+      { timeoutMs: 10_000 },
+    );
     console.log(`performActions: ${hidResult.results.length} HID event(s) executed`);
     console.log('  HID scroll round-trip complete');
   } catch (e) {

--- a/examples/websocket-ios/index.ts
+++ b/examples/websocket-ios/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { Ios, Limrun } from '@limrun/api';
+import type { PerformAction } from '@limrun/api';
 
 const apiKey = process.env['LIM_API_KEY'];
 
@@ -244,33 +245,48 @@ try {
   //
   // Everything is sent as a single batch so there is no client round-trip
   // between steps — the pod runs them sequentially and stops on the first
-  // failure. The returned `results` array mirrors each action (including
-  // partial results if the batch fails early).
+  // failure. On a partial failure, `performActions` throws with the failing
+  // action's error message.
   // ========================================================================
   console.log('\n--- Testing performActions: Safari navigation ---');
-  const navResult = await client.performActions([
-    // `openUrl` also launches Safari if it wasn't running.
-    { type: 'openUrl', url: 'https://www.apple.com' },
-    { type: 'wait', durationMs: 2000 },
-    // Focus the URL bar so typed text lands there.
-    { type: 'tapElement', selector: { elementType: 'TextField' } },
-    { type: 'wait', durationMs: 500 },
-    // If a hardware keyboard is attached the software keyboard may be
-    // hidden; `toggleKeyboard` (Cmd+K in the simulator) flips visibility
-    // so the on-screen keyboard is showing while we type.
-    { type: 'toggleKeyboard' },
-    { type: 'wait', durationMs: 300 },
-    { type: 'typeText', text: 'ycombinator.com', pressEnter: true },
-    { type: 'wait', durationMs: 2500 },
-  ]);
-  console.log(`performActions: ${navResult.results.length} action(s) executed`);
-  navResult.results.forEach((r, i) => {
-    const status = r.error ? `ERROR: ${r.error}` : 'ok';
-    const label = r.elementLabel ? ` [${r.elementLabel}]` : '';
-    console.log(`  ${i + 1}. ${r.type}${label} — ${status}`);
-  });
-  if (navResult.error) {
-    console.log(`  batch stopped early: ${navResult.error}`);
+
+  // Tap each character on the on-screen keyboard by its accessibility label.
+  // iOS keyboard keys have `elementType: "Key"` and `AXLabel` equal to the
+  // character they insert. This actually drives the software keyboard UI
+  // (unlike `typeText`, which injects hardware USB HID keystrokes and
+  // bypasses the on-screen keyboard entirely).
+  const keyTaps: PerformAction[] = Array.from('ycombinator.com').map((ch) => ({
+    type: 'tapElement',
+    selector: { label: ch, elementType: 'Key' },
+  }));
+
+  try {
+    const navResult = await client.performActions([
+      // `openUrl` also launches Safari if it wasn't running.
+      { type: 'openUrl', url: 'https://www.apple.com' },
+      { type: 'wait', durationMs: 2000 },
+      // Focus the URL bar so the keyboard appears and typed keys land there.
+      { type: 'tapElement', selector: { elementType: 'TextField' } },
+      { type: 'wait', durationMs: 500 },
+      // If a hardware keyboard is attached the software keyboard is hidden;
+      // `toggleKeyboard` (Cmd+K in the simulator) flips visibility so the
+      // on-screen keys are actually tappable.
+      { type: 'toggleKeyboard' },
+      { type: 'wait', durationMs: 500 },
+      // Tap each key of "ycombinator.com" on the software keyboard.
+      ...keyTaps,
+      // Submit by tapping the on-screen "Go" button (Safari's return key in
+      // URL mode). On other locales this is "go" — `labelContains` stays loose.
+      { type: 'tapElement', selector: { labelContains: 'go', elementType: 'Button' } },
+      { type: 'wait', durationMs: 2500 },
+    ]);
+    console.log(`performActions: ${navResult.results.length} action(s) executed`);
+    navResult.results.forEach((r, i) => {
+      const label = r.elementLabel ? ` [${r.elementLabel}]` : '';
+      console.log(`  ${i + 1}. ${r.type}${label}`);
+    });
+  } catch (e) {
+    console.log(`performActions batch stopped early: ${(e as Error).message}`);
   }
 
   // ========================================================================
@@ -287,37 +303,37 @@ try {
   const startY = height / 2 + 100;
   const endY = startY - 200;
 
-  const hidResult = await client.performActions([
-    // Scroll content up by 200px (finger moves up, page scrolls up).
-    { type: 'touchDown', x: cx, y: startY },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: startY - 50 },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: startY - 100 },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: startY - 150 },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: endY },
-    { type: 'touchUp', x: cx, y: endY },
-    { type: 'wait', durationMs: 800 },
+  try {
+    const hidResult = await client.performActions([
+      // Scroll content up by 200px (finger moves up, page scrolls up).
+      { type: 'touchDown', x: cx, y: startY },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: startY - 50 },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: startY - 100 },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: startY - 150 },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: endY },
+      { type: 'touchUp', x: cx, y: endY },
+      { type: 'wait', durationMs: 800 },
 
-    // Now scroll back in the opposite direction (finger moves down).
-    { type: 'touchDown', x: cx, y: endY },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: endY + 50 },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: endY + 100 },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: endY + 150 },
-    { type: 'wait', durationMs: 30 },
-    { type: 'touchMove', x: cx, y: startY },
-    { type: 'touchUp', x: cx, y: startY },
-  ]);
-  console.log(`performActions: ${hidResult.results.length} HID event(s) executed`);
-  if (hidResult.error) {
-    console.log(`  batch stopped early: ${hidResult.error}`);
-  } else {
+      // Now scroll back in the opposite direction (finger moves down).
+      { type: 'touchDown', x: cx, y: endY },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: endY + 50 },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: endY + 100 },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: endY + 150 },
+      { type: 'wait', durationMs: 30 },
+      { type: 'touchMove', x: cx, y: startY },
+      { type: 'touchUp', x: cx, y: startY },
+    ]);
+    console.log(`performActions: ${hidResult.results.length} HID event(s) executed`);
     console.log('  HID scroll round-trip complete');
+  } catch (e) {
+    console.log(`HID batch stopped early: ${(e as Error).message}`);
   }
 
   // ========================================================================

--- a/examples/websocket-ios/package.json
+++ b/examples/websocket-ios/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@limrun/api": "0.20.3"
+    "@limrun/api": "0.24.5"
   },
   "devDependencies": {
     "tsx": "^4.20.5",

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -200,15 +200,14 @@ export type PerformActionResult = {
 };
 
 /**
- * Aggregate result of `performActions`. On the first failing action the batch
- * stops early: `results` contains one entry per action that was executed
- * (including the failing one) and `error` is set to that action's error
- * message. On full success, `error` is undefined and `results.length`
+ * Aggregate result of a successful `performActions` call. `results.length`
  * matches the number of actions submitted.
+ *
+ * When the batch stops early because an action failed, `performActions`
+ * rejects with the failing action's error message — it does not resolve.
  */
 export type PerformActionsResult = {
   results: PerformActionResult[];
-  error?: string;
 };
 
 /**
@@ -375,9 +374,9 @@ export type InstanceClient = {
   /**
    * Run a sequence of actions sequentially inside the pod, without a
    * client round-trip between steps. On the first failing action the
-   * batch stops early; the returned `results` array contains one entry
-   * per action that was executed (including the failing one) and the
-   * top-level `error` is set to that action's error message.
+   * batch stops early and this method rejects with that action's error
+   * message; on full success it resolves with a `results` array that
+   * has one entry per submitted action.
    *
    * In addition to the same actions as the single-action methods
    * (`tap`, `typeText`, `scroll`, `toggleKeyboard`, …) this accepts:
@@ -387,6 +386,7 @@ export type InstanceClient = {
    *   gestures such as long-presses or bespoke scrolls.
    *
    * @param actions The actions to run in order.
+   * @throws If any action fails — subsequent actions are not executed.
    */
   performActions: (actions: PerformAction[]) => Promise<PerformActionsResult>;
 
@@ -1170,7 +1170,6 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       scrollResult: () => undefined,
       performActionsResult: (msg): PerformActionsResult => ({
         results: msg.results ?? [],
-        error: msg.error,
       }),
       xcrunResult: (msg): CommandResult => ({
         stdout: msg.stdout ? Buffer.from(msg.stdout, 'base64').toString('utf-8') : '',
@@ -1242,7 +1241,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         clearTimeout(request.timeout);
         pendingRequests.delete(message.id);
 
-        if (message.error && message.type !== 'performActionsResult') {
+        if (message.error) {
           logger.debug(`Server error for ${message.type}: ${message.error}`);
           request.reject(new Error(message.error));
           return;

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -385,10 +385,19 @@ export type InstanceClient = {
    *   `keyDown`/`keyUp`, `buttonDown`/`buttonUp`) for building custom
    *   gestures such as long-presses or bespoke scrolls.
    *
+   * The default request timeout grows with the batch (sum of `wait`
+   * durations + 2s per action + a 30s base) so a batch whose waits
+   * alone exceed 30s won't time out client-side. Pass
+   * `options.timeoutMs` to override.
+   *
    * @param actions The actions to run in order.
+   * @param options.timeoutMs Custom client-side timeout in milliseconds.
    * @throws If any action fails — subsequent actions are not executed.
    */
-  performActions: (actions: PerformAction[]) => Promise<PerformActionsResult>;
+  performActions: (
+    actions: PerformAction[],
+    options?: { timeoutMs?: number },
+  ) => Promise<PerformActionsResult>;
 
   /**
    * Start recording simulator video. Use stopRecording() to stop the recording.
@@ -1487,8 +1496,16 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       });
     };
 
-    const performActions = (actions: PerformAction[]): Promise<PerformActionsResult> => {
-      return sendRequest<PerformActionsResult>('performActions', { actions });
+    const performActions = (
+      actions: PerformAction[],
+      options?: { timeoutMs?: number },
+    ): Promise<PerformActionsResult> => {
+      // Batch duration is unbounded (user-supplied `wait` durations, plus
+      // per-action server work), so we grow the timeout with the batch
+      // rather than sticking to sendRequest's 30s default.
+      const waitMs = actions.reduce((acc, a) => acc + (a.type === 'wait' ? Math.max(0, a.durationMs) : 0), 0);
+      const timeoutMs = options?.timeoutMs ?? 30_000 + waitMs + actions.length * 2_000;
+      return sendRequest<PerformActionsResult>('performActions', { actions }, timeoutMs);
     };
 
     const startRecording = async (opts?: { quality?: RecordingQuality }): Promise<void> => {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -146,6 +146,71 @@ export type AppInstallationOptions = {
   launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
 };
 
+// ============================================================================
+// performActions - batch action execution (ran sequentially inside the pod,
+// stopping on the first failure).
+// ============================================================================
+
+/**
+ * A single action in a `performActions` batch. The `type` tag matches the
+ * request-side message `type` used by the equivalent single-action methods.
+ *
+ * HID primitives (`touchDown`/`touchMove`/`touchUp`, `keyDown`/`keyUp`,
+ * `buttonDown`/`buttonUp`) are deliberately unpaired so callers can build
+ * their own gestures (e.g. long-press = `touchDown` + `wait` + `touchUp`).
+ */
+export type PerformAction =
+  | { type: 'tap'; x: number; y: number; screenWidth?: number; screenHeight?: number }
+  | { type: 'tapElement'; selector: AccessibilitySelector }
+  | { type: 'incrementElement'; selector: AccessibilitySelector }
+  | { type: 'decrementElement'; selector: AccessibilitySelector }
+  | { type: 'setElementValue'; text: string; selector: AccessibilitySelector }
+  | { type: 'typeText'; text: string; pressEnter?: boolean }
+  | { type: 'pressKey'; key: string; modifiers?: string[] }
+  | {
+      type: 'scroll';
+      direction: 'up' | 'down' | 'left' | 'right';
+      pixels: number;
+      coordinate?: [number, number];
+      momentum?: number;
+    }
+  | { type: 'toggleKeyboard' }
+  | { type: 'openUrl'; url: string }
+  | { type: 'setOrientation'; orientation: 'Portrait' | 'Landscape' }
+  | { type: 'wait'; durationMs: number }
+  | { type: 'touchDown'; x: number; y: number; screenWidth?: number; screenHeight?: number }
+  | { type: 'touchMove'; x: number; y: number; screenWidth?: number; screenHeight?: number }
+  | { type: 'touchUp'; x: number; y: number; screenWidth?: number; screenHeight?: number }
+  | { type: 'keyDown'; keyCode: number }
+  | { type: 'keyUp'; keyCode: number }
+  | { type: 'buttonDown'; button: 'home' | 'lock' | 'side' | 'applePay' | 'softwareKeyboard' | string }
+  | { type: 'buttonUp'; button: 'home' | 'lock' | 'side' | 'applePay' | 'softwareKeyboard' | string };
+
+/**
+ * Per-action result in a `performActions` batch. `type` identifies which
+ * action the result corresponds to; `error` is non-null when that action
+ * failed. Element-based actions additionally populate `elementLabel` and
+ * `elementType` on success.
+ */
+export type PerformActionResult = {
+  type: string;
+  elementLabel?: string;
+  elementType?: string;
+  error?: string;
+};
+
+/**
+ * Aggregate result of `performActions`. On the first failing action the batch
+ * stops early: `results` contains one entry per action that was executed
+ * (including the failing one) and `error` is set to that action's error
+ * message. On full success, `error` is undefined and `results.length`
+ * matches the number of actions submitted.
+ */
+export type PerformActionsResult = {
+  results: PerformActionResult[];
+  error?: string;
+};
+
 /**
  * A client for interacting with a Limrun iOS instance
  */
@@ -306,6 +371,24 @@ export type InstanceClient = {
     pixels: number,
     options?: { coordinate?: [number, number]; momentum?: number },
   ) => Promise<void>;
+
+  /**
+   * Run a sequence of actions sequentially inside the pod, without a
+   * client round-trip between steps. On the first failing action the
+   * batch stops early; the returned `results` array contains one entry
+   * per action that was executed (including the failing one) and the
+   * top-level `error` is set to that action's error message.
+   *
+   * In addition to the same actions as the single-action methods
+   * (`tap`, `typeText`, `scroll`, `toggleKeyboard`, …) this accepts:
+   * - `wait` for inline delays between actions,
+   * - raw HID primitives (`touchDown`/`touchMove`/`touchUp`,
+   *   `keyDown`/`keyUp`, `buttonDown`/`buttonUp`) for building custom
+   *   gestures such as long-presses or bespoke scrolls.
+   *
+   * @param actions The actions to run in order.
+   */
+  performActions: (actions: PerformAction[]) => Promise<PerformActionsResult>;
 
   /**
    * Start recording simulator video. Use stopRecording() to stop the recording.
@@ -577,6 +660,8 @@ type ServerResponse = {
   logs?: string;
   // App log streaming fields
   lines?: string[];
+  // performActions batch result fields
+  results?: PerformActionResult[];
 };
 
 /**
@@ -1083,6 +1168,10 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       stopVideoRecordingResult: () => undefined,
       setOrientationResult: () => undefined,
       scrollResult: () => undefined,
+      performActionsResult: (msg): PerformActionsResult => ({
+        results: msg.results ?? [],
+        error: msg.error,
+      }),
       xcrunResult: (msg): CommandResult => ({
         stdout: msg.stdout ? Buffer.from(msg.stdout, 'base64').toString('utf-8') : '',
         stderr: msg.stderr ? Buffer.from(msg.stderr, 'base64').toString('utf-8') : '',
@@ -1153,7 +1242,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         clearTimeout(request.timeout);
         pendingRequests.delete(message.id);
 
-        if (message.error) {
+        if (message.error && message.type !== 'performActionsResult') {
           logger.debug(`Server error for ${message.type}: ${message.error}`);
           request.reject(new Error(message.error));
           return;
@@ -1254,6 +1343,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             installApp,
             setOrientation,
             scroll,
+            performActions,
             startRecording,
             stopRecording,
             keepAlive,
@@ -1396,6 +1486,10 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         coordinate: options?.coordinate,
         momentum: options?.momentum,
       });
+    };
+
+    const performActions = (actions: PerformAction[]): Promise<PerformActionsResult> => {
+      return sendRequest<PerformActionsResult>('performActions', { actions });
     };
 
     const startRecording = async (opts?: { quality?: RecordingQuality }): Promise<void> => {


### PR DESCRIPTION
add new performActions API usage and sample to Typescript SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new websocket request type and client API for batched device actions; correctness depends on server support and timeout sizing, and failures could impact consumers using the new method.
> 
> **Overview**
> Introduces a new `performActions` batch API on the TypeScript iOS `InstanceClient`, including typed `PerformAction`/result structures, protocol decoding of per-action `results`, and a client-side timeout that scales with batch size and embedded `wait` durations.
> 
> Updates the `websocket-ios` example to demonstrate real-world batched flows (Safari navigation via element taps and custom HID scroll gestures) and bumps `@limrun/api` to `0.24.5` to pick up the new API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c84a0bc5eeabac1ad837b9351e80b5d51c6a33d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->