### PR TITLE
sync: use xdelta3-wasm library instead of requiring xdelta binary

### DIFF
--- a/examples/ios-hot-reload/README.md
+++ b/examples/ios-hot-reload/README.md
@@ -10,13 +10,9 @@ For example, a native Swift app with a 25mb binary has a string change, the
 only chunk sent is that changed 1kb and our server applies that patch which
 happens in milliseconds.
 
-Under the hood, it uses `xdelta3` algorithm for diff-ing and OS-specific
-functionality for watching changes.
-
-Pre-requisite:
-```bash
-brew install xdelta
-```
+Under the hood, it uses the `xdelta3` algorithm for diff-ing (shipped in-process
+as a WebAssembly module, no host install required) and OS-specific functionality
+for watching changes.
 
 Clone this repo and enter this example folder:
 ```bash

--- a/examples/ios-with-xcode/README.md
+++ b/examples/ios-with-xcode/README.md
@@ -12,21 +12,6 @@ git clone https://github.com/limrun-inc/typescript-sdk.git
 cd typescript-sdk/examples/ios-with-xcode
 ```
 
-### Pre-requisites
-
-We utilize `xdelta3` algorithm for differential patching, so it needs to be
-installed in the environment.
-
-```bash
-# macOS
-brew install xdelta
-```
-
-```bash
-# Ubuntu/Debian
-sudo apt-get install xdelta3
-```
-
 ### Run
 
 Clone our sample Swift-based native app.

--- a/examples/xcode-sandbox/README.md
+++ b/examples/xcode-sandbox/README.md
@@ -12,21 +12,6 @@ git clone https://github.com/limrun-inc/typescript-sdk.git
 cd typescript-sdk/examples/xcode-sandbox
 ```
 
-### Pre-requisites
-
-We utilize `xdelta3` algorithm for differential patching, so it needs to be
-installed in the environment.
-
-```bash
-# macOS
-brew install xdelta
-```
-
-```bash
-# Ubuntu/Debian
-sudo apt-get install xdelta3
-```
-
 ### Run
 
 Clone our sample Swift-based native app.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "ignore": "^7.0.5",
     "proxy-from-env": "^2.1.0",
     "undici": "7.24.7",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "xdelta3-wasm": "^1.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.0",

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
-import { spawn } from 'child_process';
 import { watchFolderTree } from './folder-sync-watcher';
 import { type IgnoreFn } from './folder-sync-ignore';
 import { Readable } from 'stream';
@@ -285,34 +284,69 @@ async function walkFiles(root: string, ignoreFn: IgnoreFn): Promise<FileEntry[]>
   return out;
 }
 
-let xdelta3Ready: Promise<void> | null = null;
-async function ensureXdelta3(): Promise<void> {
-  if (!xdelta3Ready) {
-    xdelta3Ready = new Promise<void>((resolve, reject) => {
-      const p = spawn('xdelta3', ['-V']);
-      p.on('error', reject);
-      p.on('exit', (code) => {
-        if (code === 0) resolve();
-        else reject(new Error(`xdelta3 not available (exit=${code})`));
-      });
+// xdelta3 encoder backed by a WASM build of the upstream xdelta3 library.
+// Produces VCDIFF-compatible patches identical to `xdelta3 -e -s basis target`,
+// so the server-side decoder continues to apply them without changes.
+type Xdelta3Wasm = {
+  init: () => Promise<void>;
+  xd3_encode_memory: (
+    input: Uint8Array,
+    source: Uint8Array,
+    output_size_max: number,
+    smatch_cfg: number,
+  ) => { ret: number; str: string; output: Uint8Array };
+  xd3_smatch_cfg: { DEFAULT: number };
+  WASI_ERRNO: { ENOSPC: number };
+};
+
+let xdelta3WasmReady: Promise<Xdelta3Wasm> | null = null;
+async function loadXdelta3Wasm(): Promise<Xdelta3Wasm> {
+  if (!xdelta3WasmReady) {
+    xdelta3WasmReady = (async () => {
+      // Dynamic import so the WASM module is only loaded when sync is actually used.
+      // Works in both CJS and ESM outputs emitted by tsc-multi.
+      const mod = (await import('xdelta3-wasm')) as unknown as Xdelta3Wasm;
+      await mod.init();
+      return mod;
+    })().catch((err) => {
+      // Allow retry on a subsequent call if the first init failed.
+      xdelta3WasmReady = null;
+      throw err;
     });
   }
-  return await xdelta3Ready;
+  return await xdelta3WasmReady;
 }
 
-async function runXdelta3Encode(basis: string, target: string, outPatch: string): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const p = spawn('xdelta3', ['-e', '-s', basis, target, outPatch], {
-      stdio: ['ignore', 'ignore', 'pipe'],
-    });
-    let stderr = '';
-    p.stderr.on('data', (d) => (stderr += d.toString()));
-    p.on('error', reject);
-    p.on('exit', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`xdelta3 encode failed (exit=${code}): ${stderr.trim()}`));
-    });
-  });
+/**
+ * Encode an xdelta3/VCDIFF patch for `target` relative to `basis` and write it
+ * to `outPatch`. Returns the size of the resulting patch in bytes.
+ *
+ * If the encoder would produce a patch larger than `maxPatchBytes`, it short-
+ * circuits with ENOSPC and this function returns -1 without writing a file, so
+ * callers can fall back to a full upload cheaply.
+ */
+export async function encodeXdelta3Patch(
+  basis: string,
+  target: string,
+  outPatch: string,
+  maxPatchBytes: number,
+): Promise<number> {
+  const wasm = await loadXdelta3Wasm();
+  const [basisBuf, targetBuf] = await Promise.all([
+    fs.promises.readFile(basis),
+    fs.promises.readFile(target),
+  ]);
+  const basisBytes = new Uint8Array(basisBuf.buffer, basisBuf.byteOffset, basisBuf.byteLength);
+  const targetBytes = new Uint8Array(targetBuf.buffer, targetBuf.byteOffset, targetBuf.byteLength);
+  const res = wasm.xd3_encode_memory(targetBytes, basisBytes, maxPatchBytes, wasm.xd3_smatch_cfg.DEFAULT);
+  if (res.ret === wasm.WASI_ERRNO.ENOSPC) {
+    return -1;
+  }
+  if (res.ret !== 0) {
+    throw new Error(`xdelta3 encode failed: ${res.str} (code=${res.ret})`);
+  }
+  await fs.promises.writeFile(outPatch, res.output);
+  return res.output.byteLength;
 }
 
 async function cachePut(cacheRoot: string, relPath: string, srcFile: string): Promise<void> {
@@ -385,7 +419,6 @@ async function syncFolderOnce(
   const log = opts.log ?? noopLogger;
   const slog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => log(level, `syncFolder: ${msg}`);
   const maxPatchBytes = opts.maxPatchBytes ?? 4 * 1024 * 1024;
-  await ensureXdelta3();
 
   const files = await walkFiles(localFolderPath, opts.ignoreFn);
   const fileMap = new Map(files.map((f) => [f.path, f]));
@@ -425,23 +458,22 @@ async function syncFolderOnce(
       const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'limulator-xdelta3-'));
       const patchPath = path.join(tmpDir, 'patch.xdelta3');
       const encodeStart = nowMs();
-      await runXdelta3Encode(basisPath, f.absPath, patchPath);
+      const patchSize = await encodeXdelta3Patch(basisPath, f.absPath, patchPath, maxPatchBytes);
       const encodeMs = nowMs() - encodeStart;
       deltaEncodeMsTotal += encodeMs;
-      const st = await fs.promises.stat(patchPath);
-      if (st.size <= maxPatchBytes) {
+      if (patchSize >= 0) {
         slog(
           'debug',
-          `delta(file): ${path.posix.basename(f.path)} patchSize=${st.size} encode=${fmtMs(encodeMs)}`,
+          `delta(file): ${path.posix.basename(f.path)} patchSize=${patchSize} encode=${fmtMs(encodeMs)}`,
         );
-        bytesSentDelta += st.size;
+        bytesSentDelta += patchSize;
         return {
           payload: {
             kind: 'delta',
             path: f.path,
             basisSha256: basisSha.toLowerCase(),
             targetSha256: f.sha256.toLowerCase(),
-            length: st.size,
+            length: patchSize,
           },
           filePath: patchPath,
           cleanupDir: tmpDir,

--- a/tests/folder-sync-xdelta3.test.ts
+++ b/tests/folder-sync-xdelta3.test.ts
@@ -1,0 +1,79 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { encodeXdelta3Patch } from '@limrun/api/folder-sync';
+
+function mkTmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeFileBytes(p: string, bytes: Uint8Array): void {
+  fs.writeFileSync(p, bytes);
+}
+
+describe('encodeXdelta3Patch', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkTmpDir('xdelta3-wasm-test-');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('produces a VCDIFF-magic patch that a decoder can round-trip', async () => {
+    // VCDIFF magic bytes per RFC 3284: 0xD6 0xC3 0xC4 0x00 (ASCII 'V' 'C' 'D' with high bit set, then version 0).
+    const basis = Buffer.from('Hello, world! ' + 'The quick brown fox jumps over the lazy dog. '.repeat(8));
+    const target = Buffer.from(
+      'Hello, world! ' + 'The quick brown fox jumps over the lazy cat. '.repeat(8) + 'Extra tail bits.',
+    );
+    const basisPath = path.join(tmpDir, 'basis.bin');
+    const targetPath = path.join(tmpDir, 'target.bin');
+    const patchPath = path.join(tmpDir, 'patch.xdelta3');
+    writeFileBytes(basisPath, basis);
+    writeFileBytes(targetPath, target);
+
+    const size = await encodeXdelta3Patch(basisPath, targetPath, patchPath, 1 << 20);
+
+    expect(size).toBeGreaterThan(0);
+    const patch = fs.readFileSync(patchPath);
+    expect(patch.length).toBe(size);
+    expect(patch[0]).toBe(0xd6);
+    expect(patch[1]).toBe(0xc3);
+    expect(patch[2]).toBe(0xc4);
+
+    // Round-trip using the same WASM module to prove the patch is valid xdelta3 output.
+    const wasm = (await import('xdelta3-wasm')) as unknown as {
+      init: () => Promise<void>;
+      xd3_decode_memory: (
+        input: Uint8Array,
+        source: Uint8Array,
+        output_size_max: number,
+      ) => { ret: number; output: Uint8Array };
+    };
+    await wasm.init();
+    const decoded = wasm.xd3_decode_memory(new Uint8Array(patch), new Uint8Array(basis), 1 << 20);
+    expect(decoded.ret).toBe(0);
+    expect(Buffer.from(decoded.output).equals(target)).toBe(true);
+  });
+
+  test('returns -1 and writes no file when the patch would exceed maxPatchBytes', async () => {
+    // Use incompressible random bytes with no relationship between basis and target so the
+    // encoder cannot produce a small delta.
+    const basis = Buffer.alloc(128 * 1024);
+    const target = Buffer.alloc(128 * 1024);
+    for (let i = 0; i < basis.length; i++) basis[i] = (i * 2654435761) & 0xff;
+    for (let i = 0; i < target.length; i++) target[i] = (i * 40503) & 0xff;
+
+    const basisPath = path.join(tmpDir, 'basis.bin');
+    const targetPath = path.join(tmpDir, 'target.bin');
+    const patchPath = path.join(tmpDir, 'patch.xdelta3');
+    writeFileBytes(basisPath, basis);
+    writeFileBytes(targetPath, target);
+
+    const size = await encodeXdelta3Patch(basisPath, targetPath, patchPath, 16);
+    expect(size).toBe(-1);
+    expect(fs.existsSync(patchPath)).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3445,6 +3445,11 @@ ws@^8.18.3:
   resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
+xdelta3-wasm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/xdelta3-wasm/-/xdelta3-wasm-1.0.0.tgz#43b6ef9e9649830e25713914e40324217f8565fd"
+  integrity sha512-vhS28BhVaE3S/PGG1KQIwjBVqJecuS5Sdh82UAZysbnYaU93KS6l8ZPtsqonNZMeuyFgrGW9D44hh2lwQCsidA==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"


### PR DESCRIPTION
It's friction to require xdelta3 binary in environments. This library wraps it as WASM and behaves the same way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core delta-patching path in `syncFolder` from a spawned `xdelta3` process to an in-process WASM encoder, which could impact patch compatibility, performance, and memory usage across environments.
> 
> **Overview**
> Removes the runtime dependency on a host-installed `xdelta3` binary by switching folder sync delta generation to `xdelta3-wasm`, loaded lazily via dynamic import.
> 
> Adds a new `encodeXdelta3Patch` helper that returns patch size (or `-1` when exceeding `maxPatchBytes`) and updates sync logic to use this size directly instead of `stat`-ing the patch file.
> 
> Updates example READMEs to drop `xdelta3` installation steps and adds a focused test to validate VCDIFF output/round-trip decoding and the oversize short-circuit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05abfdeca724b92cc5303a70145d874eb46e502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->