### PR TITLE
cli: add perform actions and device info and improve descriptions and examples for agents

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -93,6 +93,7 @@ lim ios create          # Create a new iOS instance
 lim ios list            # List all ready iOS instances
 lim ios get <ID>        # Get details of a specific instance
 lim ios delete <ID>     # Delete an instance
+lim ios info            # Get device info from a running instance
 ```
 
 #### Create Options
@@ -147,6 +148,10 @@ lim ios get <ID>                               # Single instance details
 All interaction commands accept an optional `--id`. When omitted, the last created iOS instance is used.
 
 ```bash
+# Device info
+lim ios info
+lim ios info --json
+
 # Screenshots
 lim ios screenshot -o screenshot.png
 lim ios screenshot                      # Output base64 to stdout
@@ -164,6 +169,18 @@ lim ios press-key a --modifier shift
 
 # Scrolling
 lim ios scroll down --amount 500
+
+# Batch multiple actions in one call
+lim ios perform --action type=tap,x=100,y=200 --action 'type=typeText,text=Hello World'
+lim ios perform --action type=wait,durationMs=500 --action type=pressKey,key=enter
+lim ios perform --file ./actions.yaml
+
+# actions.yaml
+- type: tap
+  x: 100
+  y: 200
+- type: typeText
+  text: "Hello World"
 
 # UI inspection
 lim ios element-tree

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,11 +35,11 @@ The CLI stores configuration in `~/.lim/config.yaml`. This file is compatible wi
 
 Every command supports these flags:
 
-| Flag | Description |
-|------|-------------|
-| `--api-key <value>` | API key (also reads `LIM_API_KEY` env var) |
-| `--json` | Output as JSON instead of human-readable tables |
-| `--help` | Show help for any command |
+| Flag                | Description                                     |
+| ------------------- | ----------------------------------------------- |
+| `--api-key <value>` | API key (also reads `LIM_API_KEY` env var)      |
+| `--json`            | Output as JSON instead of human-readable tables |
+| `--help`            | Show help for any command                       |
 
 ## Command Structure
 
@@ -117,19 +117,19 @@ lim ios create --region us-west --display-name "CI Test" --label env=ci --rm
 
 **Flags for `ios create`:**
 
-| Flag | Description |
-|------|-------------|
-| `--rm` | Auto-delete the instance on exit (Ctrl+C) |
-| `--model <iphone\|ipad\|watch>` | Simulator device model |
-| `--xcode` | Attach a Xcode build sandbox to the iOS instance |
-| `--region <value>` | Region for the instance (e.g. `us-west`) |
-| `--display-name <value>` | Human-readable name |
-| `--label <key=value>` | Labels (repeatable). Used for filtering and reuse |
-| `--hard-timeout <duration>` | Max lifetime (e.g. `1m`, `10m`, `3h`). Default: none |
-| `--inactivity-timeout <duration>` | Idle timeout. Default: `3m` |
-| `--reuse-if-exists` | Reuse an existing instance with matching labels/region |
-| `--install <file>` | Local file to install (auto-uploads, repeatable) |
-| `--install-asset <name>` | Asset name to install (repeatable) |
+| Flag                              | Description                                            |
+| --------------------------------- | ------------------------------------------------------ |
+| `--rm`                            | Auto-delete the instance on exit (Ctrl+C)              |
+| `--model <iphone\|ipad\|watch>`   | Simulator device model                                 |
+| `--xcode`                         | Attach a Xcode build sandbox to the iOS instance       |
+| `--region <value>`                | Region for the instance (e.g. `us-west`)               |
+| `--display-name <value>`          | Human-readable name                                    |
+| `--label <key=value>`             | Labels (repeatable). Used for filtering and reuse      |
+| `--hard-timeout <duration>`       | Max lifetime (e.g. `1m`, `10m`, `3h`). Default: none   |
+| `--inactivity-timeout <duration>` | Idle timeout. Default: `3m`                            |
+| `--reuse-if-exists`               | Reuse an existing instance with matching labels/region |
+| `--install <file>`                | Local file to install (auto-uploads, repeatable)       |
+| `--install-asset <name>`          | Asset name to install (repeatable)                     |
 
 #### List and Filter
 
@@ -163,7 +163,7 @@ lim ios tap-element --accessibility-id btn_ok
 
 # Text input
 lim ios type "Hello World"
-lim ios type "search query" --press-enter
+lim ios type "search query" --enter
 lim ios press-key enter
 lim ios press-key a --modifier shift
 
@@ -264,11 +264,11 @@ lim android create --region us-west --display-name "CI Test" --label env=ci --rm
 
 **Android-specific flags:**
 
-| Flag | Description |
-|------|-------------|
-| `--[no-]connect` | Start ADB tunnel (default: true) |
-| `--[no-]stream` | Launch scrcpy for visual control (default: true) |
-| `--adb-path <path>` | Path to `adb` binary (default: `adb`) |
+| Flag                | Description                                      |
+| ------------------- | ------------------------------------------------ |
+| `--[no-]connect`    | Start ADB tunnel (default: true)                 |
+| `--[no-]stream`     | Launch scrcpy for visual control (default: true) |
+| `--adb-path <path>` | Path to `adb` binary (default: `adb`)            |
 
 #### Device Interaction
 
@@ -429,6 +429,7 @@ If only one session is active, `lim session stop` (no ID) stops it automatically
 #### How It Works
 
 Each `lim session start` spawns an independent background daemon that:
+
 - Holds a persistent WebSocket connection to that specific instance
 - Listens on its own Unix socket at `/tmp/lim-sessions/<instance-id>/`
 - All interaction commands automatically detect the matching session and route through it
@@ -594,10 +595,10 @@ The CLI reads configuration from multiple sources (in order of precedence):
 
 **Config file keys:**
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `api-key` | — | Your Limrun API key |
-| `api-endpoint` | `https://api.limrun.com` | API base URL |
+| Key                | Default                      | Description             |
+| ------------------ | ---------------------------- | ----------------------- |
+| `api-key`          | —                            | Your Limrun API key     |
+| `api-endpoint`     | `https://api.limrun.com`     | API base URL            |
 | `console-endpoint` | `https://console.limrun.com` | Console URL (for login) |
 
 ---

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -9,11 +9,13 @@ const VERSION = require('../package.json').version;
 export abstract class BaseCommand extends Command {
   static baseFlags = {
     'api-key': Flags.string({
-      description: 'API key for authentication',
+      description:
+        'API key to use for this command. Overrides the saved login and can also be provided via LIM_API_KEY.',
       env: 'LIM_API_KEY',
     }),
     json: Flags.boolean({
-      description: 'Output as JSON',
+      description:
+        'Output structured JSON instead of human-readable tables or plain text when the command supports it.',
       default: false,
     }),
   };

--- a/packages/cli/src/commands/android/connect.ts
+++ b/packages/cli/src/commands/android/connect.ts
@@ -3,15 +3,26 @@ import { BaseCommand } from '../../base-command';
 
 export default class AndroidConnect extends BaseCommand {
   static summary = 'Connect to an existing Android instance via ADB tunnel';
+  static description =
+    'Open a long-lived ADB tunnel to a running Android instance so local tools can talk to it as if it were attached over USB. The command stays running until you stop it.';
   static aliases = ['connect android'];
-  static examples = ['<%= config.bin %> android connect', '<%= config.bin %> android connect --id <ID>'];
+  static examples = [
+    '<%= config.bin %> android connect',
+    '<%= config.bin %> android connect --id <ID>',
+    '<%= config.bin %> android connect --id android_abc123 --adb-path /opt/homebrew/bin/adb',
+  ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Android instance ID (defaults to last created)' }),
-    'adb-path': Flags.string({ description: 'Path to adb binary', default: 'adb' }),
+    id: Flags.string({
+      description: 'Android instance ID to connect to. Defaults to the last created Android instance.',
+    }),
+    'adb-path': Flags.string({
+      description: 'Path to the adb binary available on your machine',
+      default: 'adb',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -9,37 +9,57 @@ import { type AndroidInstanceCreateParams } from '@limrun/api/resources/android-
 export default class AndroidCreate extends BaseCommand {
   static summary = 'Create a new Android instance';
   static description =
-    'Creates and optionally connects to a new Android instance with ADB tunnel and scrcpy streaming.';
+    'Create a new cloud Android instance and optionally connect to it immediately with an ADB tunnel and scrcpy streaming.';
   static aliases = ['run android'];
 
   static examples = [
     '<%= config.bin %> android create',
     '<%= config.bin %> android create --rm --install ./app.apk',
     '<%= config.bin %> android create --region us-west --label env=dev',
+    '<%= config.bin %> android create --no-connect',
   ];
 
   static flags = {
     ...BaseCommand.baseFlags,
     connect: Flags.boolean({
-      description: 'Connect to the instance (start ADB tunnel)',
+      description: 'Connect to the new instance immediately by starting an ADB tunnel',
       default: true,
       allowNo: true,
     }),
-    stream: Flags.boolean({ description: 'Stream the instance with scrcpy', default: true, allowNo: true }),
-    rm: Flags.boolean({ description: 'Delete instance on exit', default: false }),
-    'adb-path': Flags.string({ description: 'Path to adb binary', default: 'adb' }),
-    'display-name': Flags.string({ description: 'Display name for the instance' }),
-    region: Flags.string({ description: 'Region where the instance will be created' }),
-    'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
-    'inactivity-timeout': Flags.string({ description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default: 3m' }),
-    label: Flags.string({ description: 'Labels in key=value format', multiple: true }),
-    'reuse-if-exists': Flags.boolean({
-      description: 'Reuse existing instance with same labels/region',
+    stream: Flags.boolean({
+      description: 'Launch scrcpy after connecting so you can watch and control the device visually',
+      default: true,
+      allowNo: true,
+    }),
+    rm: Flags.boolean({
+      description: 'Delete the instance automatically when this CLI process exits',
       default: false,
     }),
-    'install-asset': Flags.string({ description: 'Asset name to install (can be repeated)', multiple: true }),
+    'adb-path': Flags.string({
+      description: 'Path to the adb binary used for tunnel-driven workflows',
+      default: 'adb',
+    }),
+    'display-name': Flags.string({
+      description: 'Human-friendly display name shown in listings and the console',
+    }),
+    region: Flags.string({ description: 'Region where the instance should be created, such as us-west' }),
+    'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
+    'inactivity-timeout': Flags.string({ description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default: 3m' }),
+    label: Flags.string({
+      description: 'Metadata label in key=value format. Repeat to attach multiple labels.',
+      multiple: true,
+    }),
+    'reuse-if-exists': Flags.boolean({
+      description: 'Reuse an existing matching instance instead of creating a new one',
+      default: false,
+    }),
+    'install-asset': Flags.string({
+      description: 'Existing asset name to install after creation. Repeat for multiple assets.',
+      multiple: true,
+    }),
     install: Flags.string({
-      description: 'Local file to install (auto-uploads if needed, can be repeated)',
+      description:
+        'Local app file to upload and install automatically after creation. Repeat for multiple files.',
       multiple: true,
     }),
   };

--- a/packages/cli/src/commands/android/delete.ts
+++ b/packages/cli/src/commands/android/delete.ts
@@ -3,11 +3,15 @@ import { BaseCommand } from '../../base-command';
 
 export default class AndroidDelete extends BaseCommand {
   static summary = 'Delete an Android instance';
+  static description = 'Delete an existing Android instance by ID.';
   static aliases = ['delete android'];
-  static examples = ['<%= config.bin %> android delete <ID>'];
+  static examples = [
+    '<%= config.bin %> android delete <ID>',
+    '<%= config.bin %> android delete android_abc123',
+  ];
 
   static args = {
-    id: Args.string({ description: 'Instance ID to delete', required: true }),
+    id: Args.string({ description: 'Android instance ID to delete', required: true }),
   };
 
   static flags = { ...BaseCommand.baseFlags };

--- a/packages/cli/src/commands/android/get.ts
+++ b/packages/cli/src/commands/android/get.ts
@@ -3,11 +3,13 @@ import { BaseCommand } from '../../base-command';
 
 export default class AndroidGet extends BaseCommand {
   static summary = 'Get details for a specific Android instance';
+  static description =
+    'Fetch detailed metadata for a single Android instance, including region, state, and display name. Use `--json` to inspect the full API response.';
   static aliases = ['get android', 'get a'];
-  static examples = ['<%= config.bin %> android get <ID>'];
+  static examples = ['<%= config.bin %> android get <ID>', '<%= config.bin %> android get <ID> --json'];
 
   static args = {
-    id: Args.string({ description: 'Instance ID to get', required: true }),
+    id: Args.string({ description: 'Android instance ID to fetch', required: true }),
   };
 
   static flags = { ...BaseCommand.baseFlags };

--- a/packages/cli/src/commands/android/list.ts
+++ b/packages/cli/src/commands/android/list.ts
@@ -3,16 +3,29 @@ import { BaseCommand } from '../../base-command';
 
 export default class AndroidList extends BaseCommand {
   static summary = 'List Android instances';
-  static examples = ['<%= config.bin %> android list'];
+  static description =
+    'List Android instances in your account. By default only ready instances are shown; use `--all` or `--state` to inspect other lifecycle states.';
+  static examples = [
+    '<%= config.bin %> android list',
+    '<%= config.bin %> android list --all',
+    '<%= config.bin %> android list --region us-west --label-selector env=prod',
+  ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    state: Flags.string({ description: 'Filter by state (unknown, creating, ready, terminated)' }),
-    region: Flags.string({ description: 'Filter by region' }),
-    'label-selector': Flags.string({ description: 'Filter by labels (e.g. env=prod,region=us-west)' }),
-    all: Flags.boolean({ description: 'Show all states, not just ready', default: false }),
+    state: Flags.string({
+      description: 'Lifecycle state to filter by: unknown, creating, ready, or terminated',
+    }),
+    region: Flags.string({ description: 'Region to filter by, such as us-west' }),
+    'label-selector': Flags.string({
+      description: 'Comma-separated label filters, for example env=prod,team=mobile',
+    }),
+    all: Flags.boolean({
+      description: 'Show all states instead of defaulting to ready instances only',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/asset/delete.ts
+++ b/packages/cli/src/commands/asset/delete.ts
@@ -3,8 +3,9 @@ import { BaseCommand } from '../../base-command';
 
 export default class AssetDelete extends BaseCommand {
   static summary = 'Delete an asset';
+  static description = 'Delete an uploaded asset by ID.';
   static aliases = ['delete asset'];
-  static examples = ['<%= config.bin %> asset delete <ID>'];
+  static examples = ['<%= config.bin %> asset delete <ID>', '<%= config.bin %> asset delete asset_abc123'];
 
   static args = {
     id: Args.string({ description: 'Asset ID to delete', required: true }),

--- a/packages/cli/src/commands/asset/list.ts
+++ b/packages/cli/src/commands/asset/list.ts
@@ -3,18 +3,30 @@ import { BaseCommand } from '../../base-command';
 
 export default class AssetList extends BaseCommand {
   static summary = 'List assets or get a specific one';
+  static description =
+    'List uploaded assets in your account or fetch a single asset by ID. You can optionally include signed download or upload URLs when preparing follow-up automation steps.';
   static aliases = ['get asset', 'get assets'];
-  static examples = ['<%= config.bin %> asset list', '<%= config.bin %> asset list <ID>'];
+  static examples = [
+    '<%= config.bin %> asset list',
+    '<%= config.bin %> asset list <ID>',
+    '<%= config.bin %> asset list --name MyApp --download-url',
+  ];
 
   static args = {
-    id: Args.string({ description: 'Asset ID to get', required: false }),
+    id: Args.string({ description: 'Asset ID to fetch. Omit to list assets instead.', required: false }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    name: Flags.string({ description: 'Filter by asset name' }),
-    'download-url': Flags.boolean({ description: 'Include download URL in output', default: false }),
-    'upload-url': Flags.boolean({ description: 'Include upload URL in output', default: false }),
+    name: Flags.string({ description: 'Filter listed assets by exact name' }),
+    'download-url': Flags.boolean({
+      description: 'Include a signed download URL in the output where available',
+      default: false,
+    }),
+    'upload-url': Flags.boolean({
+      description: 'Include a signed upload URL in the output where available',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/asset/pull.ts
+++ b/packages/cli/src/commands/asset/pull.ts
@@ -5,23 +5,29 @@ import { BaseCommand } from '../../base-command';
 
 export default class AssetPull extends BaseCommand {
   static summary = 'Download an asset file';
+  static description =
+    'Download an asset by ID or by name into a local directory. When you pass a name, the command picks the first matching asset returned by the API.';
   static aliases = ['pull'];
   static examples = [
     '<%= config.bin %> asset pull <ID>',
     '<%= config.bin %> asset pull my-app.apk',
     '<%= config.bin %> asset pull <ID> -o ./downloads',
+    '<%= config.bin %> asset pull my-app.apk --name my-app.apk',
   ];
 
   static args = {
-    id_or_name: Args.string({ description: 'Asset ID or name', required: true }),
+    id_or_name: Args.string({ description: 'Asset ID or asset name to download', required: true }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    name: Flags.string({ char: 'n', description: 'Asset name to search for' }),
+    name: Flags.string({
+      char: 'n',
+      description: 'Explicit asset name to search for when the positional argument is not an asset ID',
+    }),
     output: Flags.string({
       char: 'o',
-      description: 'Output directory (defaults to current directory)',
+      description: 'Output directory where the downloaded file should be written',
       default: '.',
     }),
   };

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -5,6 +5,8 @@ import { BaseCommand } from '../../base-command';
 
 export default class AssetPush extends BaseCommand {
   static summary = 'Upload an asset file';
+  static description =
+    'Upload a local file to Limrun asset storage so it can be installed on instances or reused by later commands. The asset name defaults to the filename unless you provide `-n`.';
   static aliases = ['push'];
   static examples = [
     '<%= config.bin %> asset push ./app.apk',
@@ -12,12 +14,12 @@ export default class AssetPush extends BaseCommand {
   ];
 
   static args = {
-    file: Args.string({ description: 'Path to the file to upload', required: true }),
+    file: Args.string({ description: 'Path to the local file to upload as an asset', required: true }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    name: Flags.string({ char: 'n', description: 'Name for the asset (defaults to filename)' }),
+    name: Flags.string({ char: 'n', description: 'Asset name to store. Defaults to the source filename.' }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -4,7 +4,7 @@ import { detectInstanceType } from '../lib/instance-client-factory';
 import { loadInstanceCache } from '../lib/config';
 
 export default class Build extends BaseCommand {
-  static summary = 'Run xcodebuild on a Xcode sandbox';
+  static summary = 'Run xcodebuild on an Xcode sandbox';
   static aliases = ['ios build', 'xcode build'];
   static description =
     'Syncs a local project path once (or the current working directory if omitted), then triggers a remote xcodebuild with streaming output. ' +
@@ -17,19 +17,28 @@ export default class Build extends BaseCommand {
     '<%= config.bin %> build ./MyProject --id <xcode-instance-ID>',
     '<%= config.bin %> build --id <ios-instance-ID> --scheme MyApp',
     '<%= config.bin %> build --id <xcode-instance-ID> --scheme MyApp --workspace MyApp.xcworkspace',
+    '<%= config.bin %> build ./MyProject --project MyApp.xcodeproj --upload ios-build.zip',
   ];
 
   static args = {
-    path: Args.string({ description: 'Local project path (defaults to current directory)', required: false }),
+    path: Args.string({
+      description: 'Local project path to sync before building. Defaults to the current working directory.',
+      required: false,
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Xcode or iOS instance ID (defaults to last created)' }),
-    scheme: Flags.string({ description: 'Xcode scheme' }),
-    workspace: Flags.string({ description: 'Xcode workspace file' }),
-    project: Flags.string({ description: 'Xcode project file' }),
-    upload: Flags.string({ description: 'Upload build artifact as asset with this name' }),
+    id: Flags.string({
+      description:
+        'Xcode instance ID or iOS instance ID with `--xcode` enabled. Defaults to the last created matching instance.',
+    }),
+    scheme: Flags.string({ description: 'Xcode scheme to build, such as MyApp' }),
+    workspace: Flags.string({
+      description: 'Workspace file to pass to xcodebuild, such as MyApp.xcworkspace',
+    }),
+    project: Flags.string({ description: 'Project file to pass to xcodebuild, such as MyApp.xcodeproj' }),
+    upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/delete/index.ts
+++ b/packages/cli/src/commands/delete/index.ts
@@ -4,14 +4,20 @@ import { clearInstanceCache } from '../../lib/config';
 
 export default class Delete extends BaseCommand {
   static summary = 'Delete a resource by ID (auto-detects type from ID prefix)';
+  static description =
+    'Delete an Android, iOS, Xcode, sandbox, or asset resource by passing its full ID. The command chooses the correct API based on the ID prefix.';
   static examples = [
     '<%= config.bin %> delete android_abc123',
     '<%= config.bin %> delete ios_abc123',
     '<%= config.bin %> delete xcode_abc123',
+    '<%= config.bin %> delete asset_abc123',
   ];
 
   static args = {
-    id: Args.string({ description: 'Resource ID to delete', required: true }),
+    id: Args.string({
+      description: 'Resource ID to delete, such as android_..., ios_..., xcode_..., xcode_..., or asset_...',
+      required: true,
+    }),
   };
 
   static flags = { ...BaseCommand.baseFlags };

--- a/packages/cli/src/commands/exec/element-tree.ts
+++ b/packages/cli/src/commands/exec/element-tree.ts
@@ -4,17 +4,23 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecElementTree extends BaseCommand {
   static summary = 'Get the UI element tree from a running instance';
+  static description =
+    'Inspect the current accessibility hierarchy of a running iOS or Android instance. Use `--json` for structured output that agents can search, filter, or feed into later automation steps.';
   static aliases = ['ios element-tree', 'android element-tree'];
   static examples = [
     '<%= config.bin %> ios element-tree',
+    '<%= config.bin %> android element-tree --id <instance-ID>',
     '<%= config.bin %> ios element-tree --id <instance-ID>',
+    '<%= config.bin %> ios element-tree --json',
   ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description: 'Instance ID to inspect. Defaults to the last created instance of the command alias type.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/install-app.ts
+++ b/packages/cli/src/commands/exec/install-app.ts
@@ -7,21 +7,28 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 export default class ExecInstallApp extends BaseCommand {
   static summary = 'Install an app on a running instance';
   static description =
-    'Installs an app from a local file or URL. Local files are auto-uploaded to asset storage first.';
+    'Install an app from a local file path or remote URL onto a running iOS or Android instance. Local files are uploaded to Limrun asset storage automatically before installation.';
   static aliases = ['ios install-app', 'android install-app'];
 
   static examples = [
     '<%= config.bin %> ios install-app ./MyApp.ipa',
     '<%= config.bin %> android install-app ./app.apk --id <instance-ID>',
+    '<%= config.bin %> ios install-app https://example.com/MyApp.ipa --json',
   ];
 
   static args = {
-    path_or_url: Args.string({ description: 'Local file path or URL', required: true }),
+    path_or_url: Args.string({
+      description: 'Local app file path or remote URL to an installable package such as .ipa or .apk',
+      required: true,
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description:
+        'Instance ID to install the app on. Defaults to the last created instance of the command alias type.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/open-url.ts
+++ b/packages/cli/src/commands/exec/open-url.ts
@@ -4,19 +4,27 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecOpenUrl extends BaseCommand {
   static summary = 'Open a URL on a running instance';
+  static description =
+    'Open a web URL or application deep link on a running iOS or Android instance. This is useful for browser navigation, deep-link testing, and app routing flows.';
   static aliases = ['ios open-url', 'android open-url'];
   static examples = [
     '<%= config.bin %> ios open-url https://example.com',
     '<%= config.bin %> ios open-url https://example.com --id <instance-ID>',
+    '<%= config.bin %> android open-url myapp://settings --id <instance-ID>',
   ];
 
   static args = {
-    url: Args.string({ description: 'URL to open', required: true }),
+    url: Args.string({
+      description: 'URL or deep link to open, such as https://example.com or myapp://settings',
+      required: true,
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description: 'Instance ID to target. Defaults to the last created instance of the command alias type.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/perform.ts
+++ b/packages/cli/src/commands/exec/perform.ts
@@ -1,0 +1,279 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import {
+  detectInstanceType,
+  getInstanceClient,
+  hasActiveSession,
+  sendSessionCommand,
+} from '../../lib/instance-client-factory';
+
+type PerformActionInput = {
+  type: string;
+  durationMs?: number;
+  [key: string]: unknown;
+};
+
+type PerformActionsResult = {
+  results: Array<Record<string, unknown>>;
+};
+
+function splitActionFields(raw: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let escaped = false;
+
+  for (const char of raw) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === ',') {
+      fields.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaped) {
+    current += '\\';
+  }
+
+  fields.push(current);
+  return fields;
+}
+
+function parseScalarValue(value: string): unknown {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // Fall through to plain string parsing if this is not valid JSON.
+    }
+  }
+
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (/^-?\d+(\.\d+)?$/.test(value)) return Number(value);
+  return value;
+}
+
+function parseAction(raw: string, index: number): PerformActionInput {
+  const action: Record<string, unknown> = {};
+
+  for (const field of splitActionFields(raw)) {
+    const trimmed = field.trim();
+    if (!trimmed) continue;
+
+    const equalsIndex = trimmed.indexOf('=');
+    if (equalsIndex === -1) {
+      throw new Error(`Action ${index + 1} field "${trimmed}" must use key=value syntax`);
+    }
+
+    const key = trimmed.slice(0, equalsIndex).trim();
+    const value = trimmed.slice(equalsIndex + 1);
+    if (!key) {
+      throw new Error(`Action ${index + 1} contains an empty key`);
+    }
+
+    action[key] = parseScalarValue(value);
+  }
+
+  if (typeof action.type !== 'string' || action.type.length === 0) {
+    throw new Error(`Action ${index + 1} must include type=<action-name>`);
+  }
+
+  return action as PerformActionInput;
+}
+
+function parseActionsDocument(raw: string, source: string): PerformActionInput[] {
+  let parsed: unknown;
+
+  try {
+    parsed = yaml.load(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse actions from ${source}: ${(error as Error).message}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Actions in ${source} must be an array`);
+  }
+
+  for (const [index, action] of parsed.entries()) {
+    if (!action || typeof action !== 'object' || typeof (action as { type?: unknown }).type !== 'string') {
+      throw new Error(`Action at index ${index} in ${source} must be an object with a string "type" field`);
+    }
+  }
+
+  return parsed as PerformActionInput[];
+}
+
+function parseActions(rawActions: string[]): PerformActionInput[] {
+  if (rawActions.length === 0) {
+    throw new Error('Provide at least one --action flag');
+  }
+
+  return rawActions.map((rawAction, index) => parseAction(rawAction, index));
+}
+
+async function readActions(flags: { action?: string[]; file?: string }): Promise<PerformActionInput[]> {
+  const hasInlineActions = (flags.action?.length ?? 0) > 0;
+  const hasFile = typeof flags.file === 'string';
+
+  if (!hasInlineActions && !hasFile) {
+    throw new Error('Provide either at least one --action flag or --file');
+  }
+
+  if (hasInlineActions && hasFile) {
+    throw new Error('Use either --action or --file, not both');
+  }
+
+  if (hasInlineActions) {
+    return parseActions(flags.action!);
+  }
+
+  const raw = await fs.promises.readFile(flags.file!, 'utf-8');
+  return parseActionsDocument(raw, flags.file!);
+}
+
+function estimateTimeoutMs(actions: PerformActionInput[], overrideTimeoutMs?: number): number {
+  if (overrideTimeoutMs !== undefined) {
+    return overrideTimeoutMs;
+  }
+
+  const waitMs = actions.reduce((total, action) => {
+    if (action.type !== 'wait' || typeof action.durationMs !== 'number') {
+      return total;
+    }
+
+    return total + Math.max(0, action.durationMs);
+  }, 0);
+
+  return 30_000 + waitMs + actions.length * 2_000;
+}
+
+export default class ExecPerform extends BaseCommand {
+  static summary = 'Perform multiple iOS actions in a single batch';
+  static description =
+    'Run a batch of iOS actions in a single CLI invocation using repeated `--action` flags or a JSON/YAML action file. This is the best choice for agent-driven multi-step interactions that should execute without reconnecting between steps.';
+  static aliases = ['ios perform', 'ios perform-actions'];
+  static examples = [
+    '<%= config.bin %> ios perform --action type=tap,x=100,y=200 --action "type=typeText,text=Hello World"',
+    '<%= config.bin %> ios perform --action type=wait,durationMs=1000 --action type=pressKey,key=enter',
+    '<%= config.bin %> ios perform --file ./actions.yaml',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    action: Flags.string({
+      description: `Action definition as comma-separated key=value pairs; repeat for multiple actions.
+
+Available action types:
+- Tap on coordinate: type=tap,x=100,y=200
+- Tap on element by using a selector: type=tapElement,selector={"AXLabel":"Submit"}
+- Increment an element by using a selector: type=incrementElement,selector={"AXLabel":"Volume"}
+- Decrement an element by using a selector: type=decrementElement,selector={"AXLabel":"Volume"}
+- Set an element value by using a selector: type=setElementValue,text=42,selector={"AXLabel":"Counter"}
+- Type text into the focused field: type=typeText,text=Hello World,pressEnter=true
+- Press a key with optional modifiers: type=pressKey,key=a,modifiers=["shift"]
+- Scroll the screen: type=scroll,direction=down,pixels=300,coordinate=[200,400],momentum=0.2
+- Toggle the software keyboard: type=toggleKeyboard
+- Open a URL or deep link: type=openUrl,url=https://example.com
+- Set device orientation: type=setOrientation,orientation=Landscape
+- Wait before the next action: type=wait,durationMs=1000
+- Start a touch gesture: type=touchDown,x=100,y=200
+- Move a touch gesture: type=touchMove,x=120,y=220
+- End a touch gesture: type=touchUp,x=120,y=220
+- Press a raw key code down: type=keyDown,keyCode=4
+- Release a raw key code: type=keyUp,keyCode=4
+- Press a hardware button down: type=buttonDown,button=home
+- Release a hardware button: type=buttonUp,button=home
+
+Use JSON values for complex fields like selector, modifiers, and coordinate.`,
+      multiple: true,
+    }),
+    file: Flags.string({
+      char: 'f',
+      description: `Path to a YAML or JSON file containing an array of action objects.
+
+JSON example:
+[
+  { "type": "tap", "x": 100, "y": 200 },
+  { "type": "typeText", "text": "Hello World" }
+]
+
+YAML example:
+- type: tap
+  x: 100
+  y: 200
+- type: typeText
+  text: "Hello World"`,
+    }),
+    timeout: Flags.integer({
+      description:
+        'Override the total batch timeout in milliseconds. By default the CLI grows the timeout based on waits and action count.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(ExecPerform);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const id = this.resolveId(flags.id);
+      if (detectInstanceType(id) !== 'ios') {
+        this.error('perform is only supported on iOS instances');
+      }
+
+      const actions = await readActions(flags);
+      const timeoutMs = estimateTimeoutMs(actions, flags.timeout);
+
+      let result: PerformActionsResult;
+      if (hasActiveSession(id)) {
+        result = (await sendSessionCommand(
+          id,
+          'perform-actions',
+          [actions, flags.timeout],
+          timeoutMs,
+        )) as PerformActionsResult;
+      } else {
+        const { type, client, disconnect } = await getInstanceClient(this.client, id);
+        try {
+          if (type !== 'ios') {
+            this.error('perform is only supported on iOS instances');
+          }
+          result = (await (client as any).performActions(
+            actions,
+            flags.timeout !== undefined ? { timeoutMs: flags.timeout } : undefined,
+          )) as PerformActionsResult;
+        } finally {
+          disconnect();
+        }
+      }
+
+      if (flags.json) {
+        this.outputJson(result);
+      } else {
+        this.log(`Performed ${result.results.length} action${result.results.length === 1 ? '' : 's'}`);
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/exec/perform.ts
+++ b/packages/cli/src/commands/exec/perform.ts
@@ -19,6 +19,8 @@ type PerformActionsResult = {
   results: Array<Record<string, unknown>>;
 };
 
+const IPC_TIMEOUT_BUFFER_MS = 5_000;
+
 function splitActionFields(raw: string): string[] {
   const fields: string[] = [];
   let current = '';
@@ -245,14 +247,17 @@ YAML example:
 
       const actions = await readActions(flags);
       const timeoutMs = estimateTimeoutMs(actions, flags.timeout);
+      const ipcTimeoutMs = timeoutMs + IPC_TIMEOUT_BUFFER_MS;
 
       let result: PerformActionsResult;
       if (hasActiveSession(id)) {
+        // Keep the local socket alive slightly longer than the server-side
+        // request timeout so the daemon can return the real API outcome.
         result = (await sendSessionCommand(
           id,
           'perform-actions',
           [actions, flags.timeout],
-          timeoutMs,
+          ipcTimeoutMs,
         )) as PerformActionsResult;
       } else {
         const { type, client, disconnect } = await getInstanceClient(this.client, id);

--- a/packages/cli/src/commands/exec/press-key.ts
+++ b/packages/cli/src/commands/exec/press-key.ts
@@ -4,10 +4,13 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecPressKey extends BaseCommand {
   static summary = 'Press a key on a running instance';
+  static description =
+    'Send a keyboard key press to the focused app or text field on a running iOS or Android instance. You can repeat `--modifier` to combine keys such as Command, Shift, or Alt.';
   static aliases = ['ios press-key', 'android press-key'];
   static examples = [
     '<%= config.bin %> ios press-key enter',
     '<%= config.bin %> ios press-key a --modifier shift --id <instance-ID>',
+    '<%= config.bin %> android press-key tab',
   ];
 
   static args = {
@@ -16,8 +19,14 @@ export default class ExecPressKey extends BaseCommand {
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
-    modifier: Flags.string({ description: 'Modifier key (e.g. shift, command, alt)', multiple: true }),
+    id: Flags.string({
+      description: 'Instance ID to target. Defaults to the last created instance of the command alias type.',
+    }),
+    modifier: Flags.string({
+      description:
+        'Modifier key to hold during the press, such as shift, command, control, or alt. Repeat for multiple modifiers.',
+      multiple: true,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/record.ts
+++ b/packages/cli/src/commands/exec/record.ts
@@ -5,6 +5,8 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecRecord extends BaseCommand {
   static summary = 'Start or stop video recording on a running instance';
+  static description =
+    'Control screen recording on a running iOS or Android instance. Start recording first, then stop recording to download the file locally or upload it directly with `--presigned-url`.';
   static aliases = ['ios record', 'android record'];
   static examples = [
     '<%= config.bin %> ios record start',
@@ -17,15 +19,33 @@ export default class ExecRecord extends BaseCommand {
   ];
 
   static args = {
-    action: Args.string({ description: 'start or stop', required: true, options: ['start', 'stop'] }),
+    action: Args.string({
+      description:
+        'Recording action to perform: `start` begins capturing and `stop` finalizes the video file',
+      required: true,
+      options: ['start', 'stop'],
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
-    quality: Flags.integer({ description: 'Recording quality (5-10)', default: 5 }),
-    output: Flags.string({ char: 'o', description: 'Save recording to file (for stop action)' }),
-    'presigned-url': Flags.string({ description: 'Upload the recording directly using this presigned URL' }),
+    id: Flags.string({
+      description: 'Instance ID to record. Defaults to the last created instance of the command alias type.',
+    }),
+    quality: Flags.integer({
+      description:
+        'Recording quality from 5 to 10. Higher values increase quality and file size when starting a recording.',
+      default: 5,
+    }),
+    output: Flags.string({
+      char: 'o',
+      description:
+        'Local file path for the finished recording when using the `stop` action. Defaults to a timestamped mp4 in the current directory.',
+    }),
+    'presigned-url': Flags.string({
+      description:
+        'Presigned upload URL to receive the recording when using the `stop` action. Use this if you will upload the recording to a bucket.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/screenshot.ts
+++ b/packages/cli/src/commands/exec/screenshot.ts
@@ -6,18 +6,26 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecScreenshot extends BaseCommand {
   static summary = 'Capture a screenshot from a running instance';
+  static description =
+    'Capture the current screen from a running iOS or Android instance. Save the image to a file with `-o`, or use `--json` to inspect the raw response payload.';
   static aliases = ['ios screenshot', 'android screenshot', 'screenshot'];
   static examples = [
     '<%= config.bin %> ios screenshot -o screenshot.png',
     '<%= config.bin %> android screenshot --id <instance-ID>',
+    '<%= config.bin %> ios screenshot --json',
   ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
-    output: Flags.string({ char: 'o', description: 'Save screenshot to file path' }),
+    id: Flags.string({
+      description: 'Instance ID to capture. Defaults to the last created instance of the command alias type.',
+    }),
+    output: Flags.string({
+      char: 'o',
+      description: 'File path where the screenshot should be written instead of printing the raw image data',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/scroll.ts
+++ b/packages/cli/src/commands/exec/scroll.ts
@@ -4,15 +4,18 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecScroll extends BaseCommand {
   static summary = 'Scroll on a running instance';
+  static description =
+    'Scroll the current screen on a running iOS or Android instance. The amount uses pixels on iOS and the Android client scroll units on Android.';
   static aliases = ['ios scroll', 'android scroll'];
   static examples = [
     '<%= config.bin %> ios scroll down --amount 500',
     '<%= config.bin %> ios scroll down --amount 500 --id <instance-ID>',
+    '<%= config.bin %> android scroll up --amount 300',
   ];
 
   static args = {
     direction: Args.string({
-      description: 'Scroll direction',
+      description: 'Scroll direction to apply',
       required: true,
       options: ['up', 'down', 'left', 'right'],
     }),
@@ -20,9 +23,11 @@ export default class ExecScroll extends BaseCommand {
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description: 'Instance ID to target. Defaults to the last created instance of the command alias type.',
+    }),
     amount: Flags.integer({
-      description: 'Scroll amount (pixels for iOS, abstract units for Android)',
+      description: 'Scroll amount. Uses pixels on iOS and Android scroll units on Android.',
       default: 300,
     }),
   };

--- a/packages/cli/src/commands/exec/tap-element.ts
+++ b/packages/cli/src/commands/exec/tap-element.ts
@@ -4,21 +4,35 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecTapElement extends BaseCommand {
   static summary = 'Tap an element by accessibility selector';
+  static description =
+    'Find an element on the current screen and tap it using accessibility metadata. The selector fields differ slightly by platform, so choose the flags that match the target instance type.';
   static aliases = ['ios tap-element', 'android tap-element'];
   static examples = [
     '<%= config.bin %> ios tap-element --label "Submit"',
+    '<%= config.bin %> ios tap-element --accessibility-id login_button --id <instance-ID>',
     '<%= config.bin %> android tap-element --accessibility-id btn_ok --id <instance-ID>',
+    '<%= config.bin %> android tap-element --resource-id com.example:id/submit',
   ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
-    label: Flags.string({ description: 'Element label text' }),
-    'accessibility-id': Flags.string({ description: 'Accessibility identifier' }),
-    'resource-id': Flags.string({ description: 'Android resource ID' }),
-    text: Flags.string({ description: 'Android text content' }),
+    id: Flags.string({
+      description: 'Instance ID to target. Defaults to the last created instance of the command alias type.',
+    }),
+    label: Flags.string({
+      description:
+        'Visible accessibility label to match. Works as AXLabel on iOS and content description on Android.',
+    }),
+    'accessibility-id': Flags.string({
+      description:
+        'Accessibility identifier to match. Maps to accessibilityId on iOS and resource ID matching on Android.',
+    }),
+    'resource-id': Flags.string({
+      description: 'Android resource ID to match, such as com.example:id/submit',
+    }),
+    text: Flags.string({ description: 'Android visible text to match exactly' }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/tap.ts
+++ b/packages/cli/src/commands/exec/tap.ts
@@ -4,20 +4,31 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecTap extends BaseCommand {
   static summary = 'Tap at coordinates on a running instance';
+  static description =
+    'Tap a specific coordinate on the current screen of a running iOS or Android instance. Use this when element selectors are unavailable or when automating canvas-style UIs.';
   static aliases = ['ios tap', 'android tap', 'tap'];
   static examples = [
     '<%= config.bin %> ios tap 100 200',
     '<%= config.bin %> ios tap 100 200 --id <instance-ID>',
+    '<%= config.bin %> android tap 540 1200',
   ];
 
   static args = {
-    x: Args.integer({ description: 'X coordinate', required: true }),
-    y: Args.integer({ description: 'Y coordinate', required: true }),
+    x: Args.integer({
+      description: 'X coordinate in screen points or pixels for the current device view',
+      required: true,
+    }),
+    y: Args.integer({
+      description: 'Y coordinate in screen points or pixels for the current device view',
+      required: true,
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description: 'Instance ID to target. Defaults to the last created instance of the command alias type.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/exec/type.ts
+++ b/packages/cli/src/commands/exec/type.ts
@@ -4,20 +4,28 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class ExecType extends BaseCommand {
   static summary = 'Type text into the focused input field';
+  static description =
+    'Type text into the currently focused input field on a running iOS or Android instance. On iOS, `--enter` can submit the field after typing.';
   static aliases = ['ios type', 'android type'];
   static examples = [
     '<%= config.bin %> ios type "Hello World"',
     '<%= config.bin %> ios type "Hello World" --id <instance-ID>',
+    '<%= config.bin %> ios type "search query" --enter',
   ];
 
   static args = {
-    text: Args.string({ description: 'Text to type', required: true }),
+    text: Args.string({ description: 'Text to type into the focused field', required: true }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
-    'press-enter': Flags.boolean({ description: 'Press Enter after typing (iOS only)', default: false }),
+    id: Flags.string({
+      description: 'Instance ID to target. Defaults to the last created instance of the command alias type.',
+    }),
+    enter: Flags.boolean({
+      description: 'Press Enter after typing on iOS. Ignored on Android.',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -27,12 +35,12 @@ export default class ExecType extends BaseCommand {
     await this.withAuth(async () => {
       const id = this.resolveId(flags.id);
       if (hasActiveSession(id)) {
-        await sendSessionCommand(id, 'type', [args.text, flags['press-enter']]);
+        await sendSessionCommand(id, 'type', [args.text, flags.enter]);
       } else {
         const { type, client, disconnect } = await getInstanceClient(this.client, id);
         try {
           if (type === 'ios') {
-            await (client as any).typeText(args.text, flags['press-enter']);
+            await (client as any).typeText(args.text, flags.enter);
           } else {
             await (client as any).setText(undefined, args.text);
           }

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -7,34 +7,54 @@ import { type IosInstanceCreateParams } from '@limrun/api/resources/ios-instance
 
 export default class IosCreate extends BaseCommand {
   static summary = 'Create a new iOS instance';
-  static description = 'Creates a new iOS simulator instance in the cloud.';
+  static description =
+    'Create a new cloud iOS simulator instance and wait for it to become ready. You can attach labels, install apps, choose a device model, and optionally enable an Xcode sandbox.';
   static aliases = ['run ios'];
 
   static examples = [
     '<%= config.bin %> ios create',
     '<%= config.bin %> ios create --rm --model ipad',
     '<%= config.bin %> ios create --region us-west --install-asset my-app.ipa',
+    '<%= config.bin %> ios create --install ./MyApp.ipa --xcode',
   ];
 
   static flags = {
     ...BaseCommand.baseFlags,
-    rm: Flags.boolean({ description: 'Delete instance on exit', default: false }),
-    'display-name': Flags.string({ description: 'Display name for the instance' }),
-    region: Flags.string({ description: 'Region where the instance will be created' }),
+    rm: Flags.boolean({
+      description: 'Delete the instance automatically when this CLI process exits',
+      default: false,
+    }),
+    'display-name': Flags.string({
+      description: 'Human-friendly display name shown in listings and the console',
+    }),
+    region: Flags.string({ description: 'Region where the instance should be created, such as us-west' }),
     'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
     'inactivity-timeout': Flags.string({ description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default: 3m' }),
-    label: Flags.string({ description: 'Labels in key=value format', multiple: true }),
+    label: Flags.string({
+      description: 'Metadata label in key=value format. Repeat to attach multiple labels.',
+      multiple: true,
+    }),
     model: Flags.string({
-      description: 'Device model (iphone, ipad, watch)',
+      description: 'Device model to create',
       options: ['iphone', 'ipad', 'watch'],
     }),
     'reuse-if-exists': Flags.boolean({
-      description: 'Reuse existing instance with same labels/region',
+      description: 'Reuse an existing matching instance instead of creating a new one',
       default: false,
     }),
-    'install-asset': Flags.string({ description: 'Asset name to install', multiple: true }),
-    install: Flags.string({ description: 'Local file to install (auto-uploads if needed)', multiple: true }),
-    xcode: Flags.boolean({ description: 'Enable Xcode sandbox on this iOS instance', default: false }),
+    'install-asset': Flags.string({
+      description: 'Existing asset name to install onto the instance after creation',
+      multiple: true,
+    }),
+    install: Flags.string({
+      description:
+        'Local app file to upload and install automatically after creation. Repeat for multiple files.',
+      multiple: true,
+    }),
+    xcode: Flags.boolean({
+      description: 'Enable an attached Xcode sandbox for build and sync workflows',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/ios/delete.ts
+++ b/packages/cli/src/commands/ios/delete.ts
@@ -4,11 +4,12 @@ import { clearInstanceCache } from '../../lib/config';
 
 export default class IosDelete extends BaseCommand {
   static summary = 'Delete an iOS instance';
+  static description = 'Delete an existing iOS instance by ID and remove any cached local metadata for it.';
   static aliases = ['delete ios'];
-  static examples = ['<%= config.bin %> ios delete <ID>'];
+  static examples = ['<%= config.bin %> ios delete <ID>', '<%= config.bin %> ios delete ios_abc123'];
 
   static args = {
-    id: Args.string({ description: 'Instance ID to delete', required: true }),
+    id: Args.string({ description: 'iOS instance ID to delete', required: true }),
   };
 
   static flags = { ...BaseCommand.baseFlags };

--- a/packages/cli/src/commands/ios/get.ts
+++ b/packages/cli/src/commands/ios/get.ts
@@ -3,11 +3,13 @@ import { BaseCommand } from '../../base-command';
 
 export default class IosGet extends BaseCommand {
   static summary = 'Get details for a specific iOS instance';
+  static description =
+    'Fetch detailed metadata for a single iOS instance, including region, state, and display name. Use `--json` to inspect the full API response.';
   static aliases = ['get ios', 'get i'];
-  static examples = ['<%= config.bin %> ios get <ID>'];
+  static examples = ['<%= config.bin %> ios get <ID>', '<%= config.bin %> ios get <ID> --json'];
 
   static args = {
-    id: Args.string({ description: 'Instance ID to get', required: true }),
+    id: Args.string({ description: 'iOS instance ID to fetch', required: true }),
   };
 
   static flags = { ...BaseCommand.baseFlags };

--- a/packages/cli/src/commands/ios/info.ts
+++ b/packages/cli/src/commands/ios/info.ts
@@ -1,0 +1,76 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import {
+  detectInstanceType,
+  getInstanceClient,
+  hasActiveSession,
+  sendSessionCommand,
+} from '../../lib/instance-client-factory';
+
+type DeviceInfo = {
+  udid: string;
+  screenWidth: number;
+  screenHeight: number;
+  model: string;
+};
+
+export default class IosInfo extends BaseCommand {
+  static summary = 'Get device information from a running iOS instance';
+  static description =
+    'Show basic simulator metadata for a running iOS instance, including UDID, model, and screen dimensions. This is useful when building coordinate-based automation or debugging device-specific behavior.';
+  static examples = [
+    '<%= config.bin %> ios info',
+    '<%= config.bin %> ios info --id <instance-ID>',
+    '<%= config.bin %> ios info --json',
+  ];
+
+  static args = {};
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to inspect. Defaults to the last created iOS instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosInfo);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const id = this.resolveId(flags.id);
+      if (detectInstanceType(id) !== 'ios') {
+        this.error('info is only supported on iOS instances');
+      }
+
+      let info: DeviceInfo;
+      if (hasActiveSession(id)) {
+        info = (await sendSessionCommand(id, 'device-info')) as DeviceInfo;
+      } else {
+        const { type, client, disconnect } = await getInstanceClient(this.client, id);
+        try {
+          if (type !== 'ios') {
+            this.error('info is only supported on iOS instances');
+          }
+          info = (client as unknown as { deviceInfo: DeviceInfo }).deviceInfo;
+        } finally {
+          disconnect();
+        }
+      }
+
+      if (flags.json) {
+        this.outputJson(info);
+      } else {
+        this.outputTable(
+          ['Field', 'Value'],
+          [
+            ['UDID', info.udid],
+            ['Model', info.model],
+            ['Screen Width', String(info.screenWidth)],
+            ['Screen Height', String(info.screenHeight)],
+          ],
+        );
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/ios/launch-app.ts
+++ b/packages/cli/src/commands/ios/launch-app.ts
@@ -4,6 +4,8 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class IosLaunchApp extends BaseCommand {
   static summary = 'Launch an app on a running iOS instance';
+  static description =
+    'Launch an installed app on a running iOS instance by bundle identifier. Choose `ForegroundIfRunning` to bring an already-running app to the front or `RelaunchIfRunning` to restart it.';
   static aliases = ['exec launch-app'];
   static examples = [
     '<%= config.bin %> ios launch-app com.example.app',
@@ -16,9 +18,11 @@ export default class IosLaunchApp extends BaseCommand {
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
     mode: Flags.string({
-      description: 'Launch mode',
+      description: 'Launch behavior to use when the app may already be running',
       options: ['ForegroundIfRunning', 'RelaunchIfRunning'],
       default: 'ForegroundIfRunning',
     }),

--- a/packages/cli/src/commands/ios/list-apps.ts
+++ b/packages/cli/src/commands/ios/list-apps.ts
@@ -4,14 +4,22 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class IosListApps extends BaseCommand {
   static summary = 'List installed apps on a running iOS instance';
+  static description =
+    'List the apps currently installed on a running iOS instance, including bundle identifiers, display names, and install types. Use this before `launch-app` if you need to discover the correct bundle ID.';
   static aliases = ['exec list-apps'];
-  static examples = ['<%= config.bin %> ios list-apps', '<%= config.bin %> ios list-apps --id <instance-ID>'];
+  static examples = [
+    '<%= config.bin %> ios list-apps',
+    '<%= config.bin %> ios list-apps --id <instance-ID>',
+    '<%= config.bin %> ios list-apps --json',
+  ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description: 'iOS instance ID to inspect. Defaults to the last created iOS instance.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/ios/list.ts
+++ b/packages/cli/src/commands/ios/list.ts
@@ -3,16 +3,29 @@ import { BaseCommand } from '../../base-command';
 
 export default class IosList extends BaseCommand {
   static summary = 'List iOS instances';
-  static examples = ['<%= config.bin %> ios list'];
+  static description =
+    'List iOS instances in your account. By default only ready instances are shown; use `--all` or `--state` to inspect other lifecycle states.';
+  static examples = [
+    '<%= config.bin %> ios list',
+    '<%= config.bin %> ios list --all',
+    '<%= config.bin %> ios list --region us-west --label-selector env=prod',
+  ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    state: Flags.string({ description: 'Filter by state (unknown, creating, ready, terminated)' }),
-    region: Flags.string({ description: 'Filter by region' }),
-    'label-selector': Flags.string({ description: 'Filter by labels (e.g. env=prod,region=us-west)' }),
-    all: Flags.boolean({ description: 'Show all states, not just ready', default: false }),
+    state: Flags.string({
+      description: 'Lifecycle state to filter by: unknown, creating, ready, or terminated',
+    }),
+    region: Flags.string({ description: 'Region to filter by, such as us-west' }),
+    'label-selector': Flags.string({
+      description: 'Comma-separated label filters, for example env=prod,team=mobile',
+    }),
+    all: Flags.boolean({
+      description: 'Show all states instead of defaulting to ready instances only',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/ios/log.ts
+++ b/packages/cli/src/commands/ios/log.ts
@@ -4,6 +4,8 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class IosLog extends BaseCommand {
   static summary = 'Stream or tail app logs from a running iOS instance';
+  static description =
+    'Read logs from an installed app on a running iOS instance. Use the default tail mode for a snapshot of recent lines, or `--follow` to keep streaming logs until you stop the command.';
   static aliases = ['exec log'];
   static examples = [
     '<%= config.bin %> ios log com.example.app',
@@ -12,14 +14,26 @@ export default class IosLog extends BaseCommand {
   ];
 
   static args = {
-    bundleId: Args.string({ description: 'App bundle identifier', required: true }),
+    bundleId: Args.string({
+      description: 'Bundle identifier of the installed app whose logs should be read',
+      required: true,
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
-    follow: Flags.boolean({ char: 'f', description: 'Stream logs continuously', default: false }),
-    lines: Flags.integer({ description: 'Number of lines to tail (non-streaming)', default: 100 }),
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    follow: Flags.boolean({
+      char: 'f',
+      description: 'Keep streaming log lines until interrupted',
+      default: false,
+    }),
+    lines: Flags.integer({
+      description: 'Number of recent lines to fetch when not using `--follow`',
+      default: 100,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/ios/terminate-app.ts
+++ b/packages/cli/src/commands/ios/terminate-app.ts
@@ -4,19 +4,27 @@ import { getInstanceClient, hasActiveSession, sendSessionCommand } from '../../l
 
 export default class IosTerminateApp extends BaseCommand {
   static summary = 'Terminate an app on a running iOS instance';
+  static description =
+    'Stop a running app on an iOS instance by bundle identifier. This is useful when resetting application state or ending a foreground app before another automation step.';
   static aliases = ['exec terminate-app'];
   static examples = [
     '<%= config.bin %> ios terminate-app com.example.app',
     '<%= config.bin %> ios terminate-app com.example.app --id <instance-ID>',
+    '<%= config.bin %> ios terminate-app com.example.app --id ios_abc123',
   ];
 
   static args = {
-    bundleId: Args.string({ description: 'App bundle identifier', required: true }),
+    bundleId: Args.string({
+      description: 'Bundle identifier of the running app to terminate',
+      required: true,
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID (defaults to last created)' }),
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -6,7 +6,9 @@ const VERSION = require('../../package.json').version;
 
 export default class Login extends Command {
   static summary = 'Log in to Limrun';
-  static description = 'Opens your browser to authenticate with Limrun and stores the API key locally.';
+  static description =
+    'Open your browser to authenticate with Limrun and store the resulting API key locally for future CLI commands.';
+  static examples = ['<%= config.bin %> login'];
 
   async run(): Promise<void> {
     const config = readConfig();

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -3,7 +3,8 @@ import { clearApiKey } from '../lib/config';
 
 export default class Logout extends Command {
   static summary = 'Log out of Limrun';
-  static description = 'Removes the stored API key.';
+  static description = 'Remove the stored API key so future CLI commands must authenticate again.';
+  static examples = ['<%= config.bin %> logout'];
 
   async run(): Promise<void> {
     clearApiKey();

--- a/packages/cli/src/commands/session/start.ts
+++ b/packages/cli/src/commands/session/start.ts
@@ -23,7 +23,9 @@ export default class SessionStart extends BaseCommand {
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Instance ID to connect to (defaults to last created)' }),
+    id: Flags.string({
+      description: 'Instance ID to connect to. Defaults to the last created Android or iOS instance.',
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/session/status.ts
+++ b/packages/cli/src/commands/session/status.ts
@@ -5,7 +5,9 @@ import { loadInstanceCache } from '../../lib/config';
 
 export default class SessionStatus extends BaseCommand {
   static summary = 'Show active sessions';
-  static examples = ['<%= config.bin %> session status'];
+  static description =
+    'List background session daemons started with `lim session start`, including instance type, daemon PID, and live connection state. Use `--json` for agent-friendly structured output.';
+  static examples = ['<%= config.bin %> session status', '<%= config.bin %> session status --json'];
 
   static flags = { ...BaseCommand.baseFlags };
 

--- a/packages/cli/src/commands/session/stop.ts
+++ b/packages/cli/src/commands/session/stop.ts
@@ -4,7 +4,8 @@ import { isDaemonRunning, getDaemonPid, clearSession, listActiveSessions } from 
 
 export default class SessionStop extends Command {
   static summary = 'Stop one or all active sessions';
-  static description = 'Stops background daemons and disconnects from instances.';
+  static description =
+    'Stop a single background session daemon or all active session daemons. If you omit `--id` and only one session is running, that session is stopped automatically.';
 
   static examples = [
     '<%= config.bin %> session stop',
@@ -15,8 +16,14 @@ export default class SessionStop extends Command {
   static args = {};
 
   static flags = {
-    id: Flags.string({ description: 'Instance ID to stop session for' }),
-    all: Flags.boolean({ description: 'Stop all active sessions', default: false }),
+    id: Flags.string({
+      description:
+        'Instance ID whose session should be stopped. If omitted, the command can auto-select the only active session.',
+    }),
+    all: Flags.boolean({
+      description: 'Stop all active sessions instead of a single instance session',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -4,7 +4,7 @@ import { detectInstanceType } from '../lib/instance-client-factory';
 import { loadInstanceCache } from '../lib/config';
 
 export default class Sync extends BaseCommand {
-  static summary = 'Sync local code to a Xcode sandbox';
+  static summary = 'Sync local code to an Xcode sandbox';
   static aliases = ['ios sync', 'xcode sync'];
   static description =
     'Pushes a local project path (or the current working directory if omitted) to a remote Xcode sandbox with optional watch mode. ' +
@@ -16,17 +16,32 @@ export default class Sync extends BaseCommand {
     '<%= config.bin %> sync --id <xcode-instance-ID>',
     '<%= config.bin %> sync ./MyProject --id <xcode-instance-ID>',
     '<%= config.bin %> sync --watch',
+    '<%= config.bin %> sync ./MyProject --id <ios-instance-ID> --no-install',
   ];
 
   static args = {
-    path: Args.string({ description: 'Local project path (defaults to current directory)', required: false }),
+    path: Args.string({
+      description: 'Local project path to sync. Defaults to the current working directory.',
+      required: false,
+    }),
   };
 
   static flags = {
     ...BaseCommand.baseFlags,
-    id: Flags.string({ description: 'Xcode or iOS instance ID (defaults to last created)' }),
-    watch: Flags.boolean({ description: 'Watch for changes and re-sync', default: false, allowNo: true }),
-    install: Flags.boolean({ description: 'Install after syncing', default: true, allowNo: true }),
+    id: Flags.string({
+      description:
+        'Xcode instance ID or iOS instance ID with `--xcode` enabled. Defaults to the last created matching instance.',
+    }),
+    watch: Flags.boolean({
+      description: 'Keep watching the local project and push changes automatically',
+      default: false,
+      allowNo: true,
+    }),
+    install: Flags.boolean({
+      description: 'Run install behavior after each sync when the sandbox supports it',
+      default: true,
+      allowNo: true,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/commands/xcode/create.ts
+++ b/packages/cli/src/commands/xcode/create.ts
@@ -6,24 +6,34 @@ import { type XcodeInstanceCreateParams } from '@limrun/api/resources/xcode-inst
 
 export default class XcodeCreate extends BaseCommand {
   static summary = 'Create a new Xcode instance';
-  static description = 'Creates a new Xcode build sandbox instance in the cloud.';
+  static description =
+    'Create a new cloud Xcode sandbox for remote sync and build workflows. You can attach labels, choose a region, and optionally delete the sandbox automatically when the CLI exits.';
   static aliases = ['run xcode'];
 
   static examples = [
     '<%= config.bin %> xcode create',
     '<%= config.bin %> xcode create --rm --region us-west',
+    '<%= config.bin %> xcode create --label env=dev --display-name ci-builder',
   ];
 
   static flags = {
     ...BaseCommand.baseFlags,
-    rm: Flags.boolean({ description: 'Delete instance on exit', default: false }),
-    'display-name': Flags.string({ description: 'Display name for the instance' }),
-    region: Flags.string({ description: 'Region where the instance will be created' }),
+    rm: Flags.boolean({
+      description: 'Delete the instance automatically when this CLI process exits',
+      default: false,
+    }),
+    'display-name': Flags.string({
+      description: 'Human-friendly display name shown in listings and the console',
+    }),
+    region: Flags.string({ description: 'Region where the sandbox should be created, such as us-west' }),
     'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
     'inactivity-timeout': Flags.string({ description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default: 3m' }),
-    label: Flags.string({ description: 'Labels in key=value format', multiple: true }),
+    label: Flags.string({
+      description: 'Metadata label in key=value format. Repeat to attach multiple labels.',
+      multiple: true,
+    }),
     'reuse-if-exists': Flags.boolean({
-      description: 'Reuse existing instance with same labels/region',
+      description: 'Reuse an existing matching instance instead of creating a new one',
       default: false,
     }),
   };

--- a/packages/cli/src/commands/xcode/delete.ts
+++ b/packages/cli/src/commands/xcode/delete.ts
@@ -2,12 +2,13 @@ import { Args } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 
 export default class XcodeDelete extends BaseCommand {
-  static summary = 'Delete a Xcode instance';
+  static summary = 'Delete an Xcode instance';
+  static description = 'Delete an existing Xcode sandbox instance by ID.';
   static aliases = ['delete xcode'];
-  static examples = ['<%= config.bin %> xcode delete <ID>'];
+  static examples = ['<%= config.bin %> xcode delete <ID>', '<%= config.bin %> xcode delete xcode_abc123'];
 
   static args = {
-    id: Args.string({ description: 'Instance ID to delete', required: true }),
+    id: Args.string({ description: 'Xcode instance ID to delete', required: true }),
   };
 
   static flags = { ...BaseCommand.baseFlags };

--- a/packages/cli/src/commands/xcode/get.ts
+++ b/packages/cli/src/commands/xcode/get.ts
@@ -3,11 +3,13 @@ import { BaseCommand } from '../../base-command';
 
 export default class XcodeGet extends BaseCommand {
   static summary = 'Get details for a specific Xcode instance';
+  static description =
+    'Fetch detailed metadata for a single Xcode sandbox instance, including region, state, and display name. Use `--json` to inspect the full API response.';
   static aliases = ['get xcode'];
-  static examples = ['<%= config.bin %> xcode get <ID>'];
+  static examples = ['<%= config.bin %> xcode get <ID>', '<%= config.bin %> xcode get <ID> --json'];
 
   static args = {
-    id: Args.string({ description: 'Instance ID to get', required: true }),
+    id: Args.string({ description: 'Xcode instance ID to fetch', required: true }),
   };
 
   static flags = { ...BaseCommand.baseFlags };

--- a/packages/cli/src/commands/xcode/list.ts
+++ b/packages/cli/src/commands/xcode/list.ts
@@ -3,15 +3,28 @@ import { BaseCommand } from '../../base-command';
 
 export default class XcodeList extends BaseCommand {
   static summary = 'List Xcode instances';
-  static examples = ['<%= config.bin %> xcode list'];
+  static description =
+    'List Xcode sandbox instances in your account. By default only ready sandboxes are shown; use `--all` or `--state` to inspect other lifecycle states.';
+  static examples = [
+    '<%= config.bin %> xcode list',
+    '<%= config.bin %> xcode list --all',
+    '<%= config.bin %> xcode list --label-selector env=prod',
+  ];
 
   static args = {};
 
   static flags = {
     ...BaseCommand.baseFlags,
-    state: Flags.string({ description: 'Filter by state (unknown, creating, ready, terminated)' }),
-    'label-selector': Flags.string({ description: 'Filter by labels (e.g. env=prod,region=us-west)' }),
-    all: Flags.boolean({ description: 'Show all states, not just ready', default: false }),
+    state: Flags.string({
+      description: 'Lifecycle state to filter by: unknown, creating, ready, or terminated',
+    }),
+    'label-selector': Flags.string({
+      description: 'Comma-separated label filters, for example env=prod,team=mobile',
+    }),
+    all: Flags.boolean({
+      description: 'Show all states instead of defaulting to ready instances only',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {

--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -15,6 +15,7 @@ export async function sendCommand(
   instanceId: string,
   command: string,
   args: unknown[] = [],
+  timeoutMs?: number,
 ): Promise<unknown> {
   if (!isDaemonRunning(instanceId)) {
     throw new Error(`No active session for ${instanceId}. Run \`lim session start ${instanceId}\` first.`);
@@ -79,6 +80,6 @@ export async function sendCommand(
       reject(new Error('Daemon request timed out'));
     });
 
-    socket.setTimeout(30000);
+    socket.setTimeout(timeoutMs ?? 30000);
   });
 }

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -346,12 +346,27 @@ export function startDaemonServer(): void {
           result = { scrolled: true, direction: args[0] };
           break;
 
+        case 'perform-actions': {
+          if (type !== 'ios') throw new Error('perform-actions is only supported on iOS instances');
+          const timeoutMs = typeof args[1] === 'number' ? args[1] : undefined;
+          result = await (client as any).performActions(
+            args[0],
+            timeoutMs !== undefined ? { timeoutMs } : undefined,
+          );
+          break;
+        }
+
         case 'element-tree':
           if (type === 'ios') {
             result = await (client as any).elementTree();
           } else {
             result = await (client as any).getElementTree();
           }
+          break;
+
+        case 'device-info':
+          if (type !== 'ios') throw new Error('info is only supported on iOS instances');
+          result = (client as any).deviceInfo;
           break;
 
         case 'open-url':

--- a/packages/cli/src/lib/instance-client-factory.ts
+++ b/packages/cli/src/lib/instance-client-factory.ts
@@ -35,8 +35,9 @@ export function sendSessionCommand(
   instanceId: string,
   command: string,
   args: unknown[] = [],
+  timeoutMs?: number,
 ): Promise<unknown> {
-  return sendCommand(instanceId, command, args);
+  return sendCommand(instanceId, command, args, timeoutMs);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new iOS interaction surface area (`ios perform` batching + `ios info`) and extends the session daemon/IPC to support longer-running requests, which could affect session stability and timeouts if misconfigured.
> 
> **Overview**
> Adds two new iOS automation commands: `lim ios perform` to batch multiple actions (inline `--action` or YAML/JSON `--file`, with timeout estimation/override) and `lim ios info` to fetch simulator metadata (UDID/model/screen size), both working via direct API calls or an active `session` daemon.
> 
> Extends session IPC to support configurable socket timeouts and adds daemon handlers for `perform-actions` and `device-info`. Updates `ios type` flag from `--press-enter` to `--enter` and broadly refreshes CLI help text (descriptions/examples/flag docs) plus README docs to be more agent- and scripting-friendly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ba6dae5fbfdc35a1d927fdcc156268bb8ab286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->