### PR TITLE
Accept signedUrls in xcodebuild

### DIFF
--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -47,7 +47,7 @@ export type XcodeProjectConfig = {
 };
 
 export type XcodeBuildOptions = {
-  upload?: { assetName: string };
+  upload?: { assetName: string } | { signedUploadUrl: string; signedDownloadUrl: string };
 };
 
 export type XcodeClient = {
@@ -176,7 +176,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ...(settings && { xcodebuild: settings }),
         };
 
-        if (options?.upload) {
+        if (options?.upload && 'assetName' in options.upload) {
           const uploadName = options.upload.assetName;
           const requestPromise = client.assets
             .getOrCreate({ name: uploadName })
@@ -193,6 +193,11 @@ export class XcodeInstances extends GeneratedXcodeInstances {
               );
             });
           return exec(requestPromise, { apiUrl, token, log });
+        }
+
+        if (options?.upload && 'signedUploadUrl' in options.upload && 'signedDownloadUrl' in options.upload) {
+          request.signedUploadUrl = options.upload.signedUploadUrl;
+          request.additionalMetadata = { signedDownloadUrl: options.upload.signedDownloadUrl };
         }
 
         return exec(request, { apiUrl, token, log });


### PR DESCRIPTION
We're creating XcodeSandboxClient inside a sandboxed environment by passing token and xcodeurl (we don't pass the Limrun API key there, since users have access to this environment as well).  But to create an asset on Limrun, the API key is needed. 

With this change, we can create signed urls on the backend and pass those to the sandbox, for the simulator build to be cached later

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2fbdfde1aa49a9bf99c1c22ac1a782f414ab3a0a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->