### PR TITLE
limulator: add soft reset capability to sdk

### DIFF
--- a/examples/websocket-ios/index.ts
+++ b/examples/websocket-ios/index.ts
@@ -192,6 +192,25 @@ try {
   }
 
   // ========================================================================
+  // softReset — wipe Safari's data container and relaunch.
+  //
+  // `data` strategy (default) terminates the app, removes its data container
+  // contents, and relaunches it. Use this to start a scenario over without
+  // paying for a full reinstall. `full` strategy additionally uninstalls and
+  // reinstalls from the cached source `.app`, clears keychain, privacy, the
+  // NSUserDefaults cache, and shared App Group containers — closer to a
+  // freshly-opened-simulator state.
+  // ========================================================================
+  console.log('\n--- Testing softReset ---');
+  const reset = await client.softReset('com.apple.mobilesafari', { strategy: 'data' });
+  console.log(
+    `Soft reset ${reset.bundleId} (strategy=${reset.strategy}, items=${reset.itemsCleared ?? 0}, ${
+      reset.durationMs
+    }ms)`,
+  );
+  await sleep(3 * 1000);
+
+  // ========================================================================
   // Take final screenshot
   // ========================================================================
   console.log('\n--- Taking final screenshot ---');

--- a/examples/websocket-ios/package.json
+++ b/examples/websocket-ios/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@limrun/api": "0.25.2"
+    "@limrun/api": "file:../../dist"
   },
   "devDependencies": {
     "tsx": "^4.20.5",

--- a/examples/websocket-ios/yarn.lock
+++ b/examples/websocket-ios/yarn.lock
@@ -132,10 +132,8 @@
   resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@limrun/api@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.npmjs.org/@limrun/api/-/api-0.25.2.tgz#3f7df7cf6399af25e4a8027dc31016f911ba7913"
-  integrity sha512-0uRJbVebeYIwyMzN4DT9mB2E1gHx92ZwC5vp9a7RH+v2xuKQ4NVK5BV7IZM8W9zFzBLsb9sNLOFN49B/SZdzEQ==
+"@limrun/api@file:../../dist":
+  version "0.27.1"
   dependencies:
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"
@@ -143,6 +141,7 @@
     proxy-from-env "^2.1.0"
     undici "7.24.7"
     ws "^8.18.3"
+    xdelta3-wasm "^1.0.0"
 
 agent-base@^7.1.2:
   version "7.1.4"
@@ -264,3 +263,8 @@ ws@^8.18.3:
   version "8.18.3"
   resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+
+xdelta3-wasm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xdelta3-wasm/-/xdelta3-wasm-1.0.0.tgz#43b6ef9e9649830e25713914e40324217f8565fd"
+  integrity sha512-vhS28BhVaE3S/PGG1KQIwjBVqJecuS5Sdh82UAZysbnYaU93KS6l8ZPtsqonNZMeuyFgrGW9D44hh2lwQCsidA==

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -205,6 +205,46 @@ export type StoreKitDiscoverOptions = {
 };
 
 /**
+ * Strategy used by {@link InstanceClient.softReset}.
+ *
+ * - `data` (default): terminate + wipe the app's data container only.
+ *   Fast; intended for "start the scenario over" loops.
+ * - `full`: take the app back to freshly-opened-simulator state —
+ *   terminate + wipe shared App Group containers + `simctl uninstall`
+ *   (bundle + data container) + drop cfprefsd's NSUserDefaults cache
+ *   + `simctl keychain reset` + `simctl privacy reset all` +
+ *   reinstall from the last cached source .app path.
+ *
+ * Both strategies relaunch the app after the reset completes.
+ */
+export type SoftResetStrategy = 'data' | 'full';
+
+/**
+ * Options for {@link InstanceClient.softReset}.
+ */
+export type SoftResetOptions = {
+  /** Reset strategy. Defaults to `data` server-side. */
+  strategy?: SoftResetStrategy;
+};
+
+/**
+ * Result of a {@link InstanceClient.softReset} call.
+ */
+export type SoftResetResult = {
+  /** Strategy that was actually applied. */
+  strategy: SoftResetStrategy;
+  /** Bundle ID that was reset. */
+  bundleId: string;
+  /**
+   * Top-level entries removed from the app's data container.
+   * Only populated when `strategy === 'data'`.
+   */
+  itemsCleared?: number;
+  /** Wall-clock duration of the reset on the server. */
+  durationMs: number;
+};
+
+/**
  * Result from a command execution (xcrun, xcodebuild, etc.)
  */
 export type CommandResult = {
@@ -564,6 +604,24 @@ export type InstanceClient = {
     bundleId: string,
     options?: StoreKitDiscoverOptions,
   ) => Promise<StoreKitDiscoverResult>;
+
+  /**
+   * Soft-reset an installed app on the simulator.
+   *
+   * Strategies (see {@link SoftResetStrategy} for details):
+   * - `data` (default): wipe the app's data container only.
+   * - `full`: restore freshly-opened-simulator state (uninstall +
+   *   reinstall from the cached source `.app`, clear keychain, privacy,
+   *   NSUserDefaults cache, and shared App Group containers).
+   *
+   * Both strategies relaunch the app after the reset completes.
+   *
+   * @param bundleId Bundle ID of the installed app to reset.
+   * @param options Reset options (currently just `strategy`).
+   * @throws If the app is not installed (404), the reinstall source is
+   *   missing for `strategy: 'full'` (409), or the request is malformed (400).
+   */
+  softReset: (bundleId: string, options?: SoftResetOptions) => Promise<SoftResetResult>;
 
   /**
    * Disconnect from the Limrun instance
@@ -1491,6 +1549,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             setStoreKitConfig,
             clearStoreKitConfig,
             discoverStoreKitConfig,
+            softReset,
             disconnect,
             getConnectionState,
             onConnectionStateChange,
@@ -1913,6 +1972,42 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       } finally {
         clearTimeout(timer);
       }
+    };
+
+    const softReset = async (bundleId: string, resetOptions?: SoftResetOptions): Promise<SoftResetResult> => {
+      const body: { bundleId: string; strategy?: SoftResetStrategy } = { bundleId };
+      if (resetOptions?.strategy) {
+        body.strategy = resetOptions.strategy;
+      }
+      const url = `${options.apiUrl}/softReset`;
+      const response = await nodeProxyTransport.fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${options.token}`,
+        },
+        body: JSON.stringify(body),
+      } as any);
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`softReset failed: ${response.status} ${errorBody}`);
+      }
+      const result = (await response.json()) as {
+        ok: boolean;
+        strategy: SoftResetStrategy;
+        bundleId: string;
+        itemsCleared?: number;
+        durationMs: number;
+      };
+      const out: SoftResetResult = {
+        strategy: result.strategy,
+        bundleId: result.bundleId,
+        durationMs: result.durationMs,
+      };
+      if (result.itemsCleared !== undefined) {
+        out.itemsCleared = result.itemsCleared;
+      }
+      return out;
     };
 
     const disconnect = (): void => {


### PR DESCRIPTION
Adds softReset capability to SDK

```ts
// Fast: terminate + wipe the app's data container, then relaunch
await client.softReset('com.apple.mobilesafari');

// Or, fully back to a freshly-opened-simulator state
await client.softReset('com.apple.mobilesafari', { strategy: 'full' });
```

*Two strategies:*
• `data` (default) — terminates the app, wipes its data container, relaunches. Quick loops between scenarios.
• `full` — also uninstalls + reinstalls from the cached `.app`, clears keychain, privacy, NSUserDefaults, and shared App Group containers. Use when you need state outside the data container gone too.

*Returns* `{ strategy, bundleId, itemsCleared, durationMs }`

End-to-end sample lives at `examples/websocket-ios/index.ts`.
