### PR TITLE
xcode: let additional files to be synced to home dir

### DIFF
--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -462,7 +462,7 @@ async function syncFolderOnce(
 
   const files = await walkFiles(localFolderPath, opts.ignoreFn);
   const additionalFiles = await collectAdditionalFiles(opts.additionalFiles);
-  const allFiles = [...files, ...additionalFiles];
+  const allFiles = [...files, ...additionalFiles].sort((a, b) => a.path.localeCompare(b.path));
   const fileMap = new Map(allFiles.map((f) => [f.path, f]));
 
   const syncId = genId('sync');

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -47,6 +47,11 @@ export type FolderSyncOptions = {
    * ignoreFn: (path) => !(path.startsWith('src/') || path.endsWith('.json'))
    */
   ignoreFn: IgnoreFn;
+  /**
+   * Extra files to sync into limbuild. These are included
+   * in every sync pass but are not watched directly.
+   */
+  additionalFiles?: AdditionalFileSyncEntry[];
 };
 
 export type SyncFolderResult = {
@@ -56,7 +61,15 @@ export type SyncFolderResult = {
   stopWatching?: () => void;
 };
 
-type FileEntry = { path: string; size: number; sha256: string; absPath: string; mode: number };
+export type AdditionalFileSyncEntry = { localPath: string; remotePath: string };
+
+type FileEntry = {
+  path: string;
+  size: number;
+  sha256: string;
+  absPath: string;
+  mode: number;
+};
 
 type FolderSyncHttpPayload = {
   kind: 'delta' | 'full';
@@ -284,6 +297,33 @@ async function walkFiles(root: string, ignoreFn: IgnoreFn): Promise<FileEntry[]>
   return out;
 }
 
+async function collectAdditionalFiles(
+  additionalFiles: AdditionalFileSyncEntry[] | undefined,
+): Promise<FileEntry[]> {
+  if (!additionalFiles || additionalFiles.length === 0) {
+    return [];
+  }
+  const out: FileEntry[] = [];
+  for (const additionalFile of additionalFiles) {
+    const remotePath = additionalFile.remotePath;
+    const absPath = path.resolve(additionalFile.localPath);
+    const st = await fs.promises.stat(absPath);
+    if (!st.isFile()) {
+      throw new Error(`additional file localPath must be a file: ${additionalFile.localPath}`);
+    }
+    const sha256 = await sha256FileHex(absPath);
+    out.push({
+      path: remotePath,
+      size: st.size,
+      sha256,
+      absPath,
+      mode: st.mode & 0o7777,
+    });
+  }
+  out.sort((a, b) => a.path.localeCompare(b.path));
+  return out;
+}
+
 // xdelta3 encoder backed by a WASM build of the upstream xdelta3 library.
 // Produces VCDIFF-compatible patches identical to `xdelta3 -e -s basis target`,
 // so the server-side decoder continues to apply them without changes.
@@ -421,7 +461,9 @@ async function syncFolderOnce(
   const maxPatchBytes = opts.maxPatchBytes ?? 4 * 1024 * 1024;
 
   const files = await walkFiles(localFolderPath, opts.ignoreFn);
-  const fileMap = new Map(files.map((f) => [f.path, f]));
+  const additionalFiles = await collectAdditionalFiles(opts.additionalFiles);
+  const allFiles = [...files, ...additionalFiles];
+  const fileMap = new Map(allFiles.map((f) => [f.path, f]));
 
   const syncId = genId('sync');
   const rootName = path.basename(path.resolve(localFolderPath));
@@ -439,7 +481,7 @@ async function syncFolderOnce(
   // Build payload list by comparing against local basis cache (single-flight/watch assumes server matches cache).
   const encodeLimit = concurrencyLimit();
   const changed: FileEntry[] = [];
-  for (const f of files) {
+  for (const f of allFiles) {
     const basisPath = cacheGet(opts.basisCacheDir, f.path);
     if (!fs.existsSync(basisPath)) {
       changed.push(f);
@@ -489,7 +531,12 @@ async function syncFolderOnce(
     slog('debug', `full(file): ${f.path} size=${f.size}`);
     bytesSentFull += f.size;
     return {
-      payload: { kind: 'full', path: f.path, targetSha256: f.sha256.toLowerCase(), length: f.size },
+      payload: {
+        kind: 'full',
+        path: f.path,
+        targetSha256: f.sha256.toLowerCase(),
+        length: f.size,
+      },
       filePath: f.absPath,
     };
   });
@@ -499,14 +546,19 @@ async function syncFolderOnce(
     rootName,
     install: opts.install,
     ...(opts.launchMode ? { launchMode: opts.launchMode } : {}),
-    files: files.map((f) => ({ path: f.path, size: f.size, sha256: f.sha256.toLowerCase(), mode: f.mode })),
+    files: allFiles.map((f) => ({
+      path: f.path,
+      size: f.size,
+      sha256: f.sha256.toLowerCase(),
+      mode: f.mode,
+    })),
     payloads: encodedPayloads.map((p) => p.payload),
   };
   const hasDelta = encodedPayloads.some((p) => p.payload.kind === 'delta');
   const compression: 'zstd' | 'gzip' | 'identity' = hasDelta ? 'identity' : preferredCompression;
   slog(
     'debug',
-    `sync started files=${files.length}${reason ? ` reason=${reason}` : ''} compression=${compression}`,
+    `sync started files=${allFiles.length}${reason ? ` reason=${reason}` : ''} compression=${compression}`,
   );
 
   const sendStart = nowMs();
@@ -583,7 +635,7 @@ async function syncFolderOnce(
   const totalBytes = bytesSentFull + bytesSentDelta;
   slog(
     'debug',
-    `sync finished files=${files.length} sent=${fmtBytes(totalBytes)} syncWork=${fmtMs(
+    `sync finished files=${allFiles.length} sent=${fmtBytes(totalBytes)} syncWork=${fmtMs(
       syncWorkMs,
     )} total=${fmtMs(tookMs)}`,
   );
@@ -595,7 +647,7 @@ async function syncFolderOnce(
     out.installedBundleId = resp.bundleId;
   }
   // Update local cache optimistically: after a successful sync, cache reflects current local tree.
-  for (const f of files) {
+  for (const f of allFiles) {
     await cachePut(opts.basisCacheDir, f.path, f.absPath);
   }
   return out;

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -5,7 +5,11 @@ import crypto from 'crypto';
 import { XcodeInstances as GeneratedXcodeInstances, type XcodeInstance } from './xcode-instances';
 import { type IosInstance } from './ios-instances';
 import { exec, type ExecChildProcess, type ExecRequest } from '../exec-client';
-import { syncFolder as syncFolderImpl, type FolderSyncOptions } from '../folder-sync';
+import {
+  syncFolder as syncFolderImpl,
+  type AdditionalFileSyncEntry,
+  type FolderSyncOptions,
+} from '../folder-sync';
 import { createIgnoreFn } from '../folder-sync-ignore';
 import { nodeProxyTransport } from '../internal/proxy-transport';
 
@@ -32,6 +36,10 @@ export type SyncOptions = {
    * Return true to ignore, false to keep.
    */
   ignore?: (relativePath: string) => boolean;
+  /**
+   * Extra files to sync on every sync pass.
+   */
+  additionalFiles?: AdditionalFileSyncEntry[];
 };
 
 export type SyncResult = {
@@ -94,6 +102,42 @@ function createLogger(logLevel: LogLevel) {
   };
 }
 
+function normalizeWorkspaceRelativePath(remotePath: string): string {
+  if (
+    remotePath === '' ||
+    remotePath.startsWith('/') ||
+    remotePath.includes('\\') ||
+    remotePath.includes('\0')
+  ) {
+    throw new Error(`invalid sandbox home path from server: ${remotePath}`);
+  }
+  const parts = remotePath.split('/');
+  if (parts.some((part) => part === '' || part === '.' || part === '..')) {
+    throw new Error(`invalid sandbox home path from server: ${remotePath}`);
+  }
+  return parts.join('/');
+}
+
+async function fetchSandboxInfo(apiUrl: string, token: string): Promise<{ homeDir: string }> {
+  const res = await nodeProxyTransport.fetch(`${apiUrl}/info`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`GET /info failed: ${res.status} ${text}`);
+  }
+  const body = JSON.parse(text) as { homeDir?: string };
+  if (!body.homeDir) {
+    throw new Error('GET /info response is missing homeDir');
+  }
+  return {
+    homeDir: normalizeWorkspaceRelativePath(body.homeDir),
+  };
+}
+
 export class XcodeInstances extends GeneratedXcodeInstances {
   async createClient(params: XcodeCreateClientParams): Promise<XcodeClient> {
     let apiUrl: string;
@@ -111,6 +155,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
 
     const log = createLogger(params.logLevel ?? 'info');
     const client = this._client;
+    const sandboxInfo = await fetchSandboxInfo(apiUrl, token);
 
     return {
       async sync(localCodePath: string, opts?: SyncOptions): Promise<SyncResult> {
@@ -119,6 +164,13 @@ export class XcodeInstances extends GeneratedXcodeInstances {
         const hash = crypto.createHash('sha1').update(resolvedPath).digest('hex').slice(0, 8);
         const cacheKey = `limsync-cache-${folderName}-${hash}`;
         const basisCacheDir = opts?.basisCacheDir ?? path.join(os.tmpdir(), cacheKey);
+        const additionalFiles = opts?.additionalFiles?.map((file) => ({
+          localPath: file.localPath,
+          remotePath:
+            file.remotePath.startsWith('~/') ?
+              `${sandboxInfo.homeDir}/${file.remotePath.slice(2)}`
+            : file.remotePath,
+        }));
         const codeSyncOpts: FolderSyncOptions = {
           apiUrl,
           token,
@@ -162,6 +214,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           maxPatchBytes: opts?.maxPatchBytes ?? 4 * 1024 * 1024,
           launchMode: 'ForegroundIfRunning',
           log,
+          ...(additionalFiles ? { additionalFiles } : {}),
         };
 
         const result = await syncFolderImpl(localCodePath, codeSyncOpts);


### PR DESCRIPTION
Used for authentication tokens like`.netrc` and `.npmrc`. We sync these additional files to home dir of the sandbox.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends the sync manifest/upload set and introduces a new `GET /info` call to resolve `~/` paths; mistakes could sync to unintended remote paths or fail sync when the info endpoint is unavailable.
> 
> **Overview**
> Adds support for syncing *extra, out-of-tree files* on every folder sync pass via a new `additionalFiles` option (`localPath` → `remotePath`). These files are hashed, included in the sync manifest, and cached for delta detection, but are *not* watched for changes.
> 
> Xcode sync now accepts `additionalFiles` and resolves `~/...` remote paths by calling `GET /info` to fetch the sandbox `homeDir`, with path normalization/validation before constructing the final remote path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f9efb9190f8827d10d0262bf8ab6072d581951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->