### PR TITLE
cli: add attach-simulator command to xcode so ios instances can be attached later on

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -357,6 +357,7 @@ lim xcode create --ios    # Create an iOS instance with an attached Xcode sandbo
 lim xcode list            # List all ready Xcode instances
 lim xcode get <ID>        # Get details of a specific instance
 lim xcode delete <ID>     # Delete an instance
+lim xcode attach-simulator <IOS_ID> --id <XCODE_ID>
 ```
 
 ```bash
@@ -368,6 +369,9 @@ lim xcode build ./MyProject --scheme MyApp --workspace MyApp.xcworkspace
 
 # Build and upload artifact
 lim xcode build ./MyProject --scheme MyApp --upload my-app-build
+
+# Attach an existing simulator so builds auto-install there
+lim xcode attach-simulator ios_abc123 --id sandbox_def456
 
 # Tune sync cache, patch size, or ignore additional paths
 lim xcode sync ./MyProject --watch --basis-cache-dir ./.limsync-cache --max-patch-bytes 2097152
@@ -582,13 +586,16 @@ Use this when you only need to build (no simulator needed), or when you want to 
 # 1. Create a standalone Xcode instance
 lim xcode create --rm
 
-# 2. Build (automatically syncs the project path first)
+# 2. Optionally attach an existing simulator by ID
+lim xcode attach-simulator ios_abc123 --id sandbox_def456
+
+# 3. Build (automatically syncs the project path first)
 lim xcode build ./MyProject --scheme MyApp --workspace MyApp.xcworkspace
 
-# 3. Upload build artifact
+# 4. Upload build artifact
 lim xcode build ./MyProject --scheme MyApp --upload my-app-build
 
-# 4. Download the artifact
+# 5. Download the artifact
 lim asset pull my-app-build -o ./build-output
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
         "description": "Execute any task on remote Android Emulators: create, list, get, delete, connect, screenshot, tap, tap-element, find-element, element-tree, type, press-key, scroll, open-url, install-app, record"
       },
       "xcode": {
-        "description": "Execute any task on remote XCode sandboxes: create, list, get, delete, sync, build"
+        "description": "Execute any task on remote XCode sandboxes: create, list, get, delete, sync, build, attach-simulator"
       },
       "asset": {
         "description": "Upload, download, list, inspect, and delete files that can be used by iOS & Android as pre-installed apps: push, pull, list, delete"

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -3,6 +3,7 @@ import Limrun, { AuthenticationError, NotFoundError } from '@limrun/api';
 import {
   clearInstanceCache,
   clearLastInstanceId,
+  loadInstanceCache,
   readConfig,
   registerCreatedInstance,
   resolveInstanceId,
@@ -11,6 +12,7 @@ import {
 import { login } from './lib/auth';
 import { renderTable } from './lib/formatting';
 import { stopDaemon } from './lib/daemon';
+import { detectInstanceType } from './lib/instance-client-factory';
 
 const VERSION = require('../package.json').version;
 const INSTANCE_ID_PATTERN = /\b(?:ios|android|xcode|sandbox)_[a-z0-9]+\b/i;
@@ -163,6 +165,37 @@ export abstract class BaseCommand extends Command {
 
   protected signedStreamUrl(status: { signedStreamUrl?: string } | undefined): string | undefined {
     return status?.signedStreamUrl;
+  }
+
+  protected async resolveXcodeClient(id: string) {
+    const type = detectInstanceType(id).toString();
+
+    if (type === 'ios') {
+      const instance = await this.client.iosInstances.get(id);
+      let sandboxUrl = instance.status.sandbox?.xcode?.url;
+      let token = instance.status.token;
+
+      if (!sandboxUrl) {
+        const cached = loadInstanceCache(id);
+        if (cached?.sandboxXcodeUrl) {
+          sandboxUrl = cached.sandboxXcodeUrl;
+          token = cached.token || token;
+        }
+      }
+
+      if (!sandboxUrl) {
+        this.error(
+          `iOS instance ${id} does not have a Xcode sandbox. Create it with: lim ios create --xcode or lim xcode create --ios`,
+        );
+      }
+      return this.client.xcodeInstances.createClient({
+        apiUrl: sandboxUrl,
+        token,
+      });
+    }
+
+    const instance = await this.client.xcodeInstances.get(id);
+    return this.client.xcodeInstances.createClient({ instance });
   }
 
   /**

--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -37,7 +37,9 @@ export default class AndroidCreate extends BaseCommand {
     }),
     region: Flags.string({ description: 'Region where the instance should be created, such as us-west' }),
     'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
-    'inactivity-timeout': Flags.string({ description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default: 3m' }),
+    'inactivity-timeout': Flags.string({
+      description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default is in organization settings.',
+    }),
     label: Flags.string({
       description: 'Metadata label in key=value format. Repeat to attach multiple labels.',
       multiple: true,

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -32,7 +32,9 @@ export default class IosCreate extends BaseCommand {
     }),
     region: Flags.string({ description: 'Region where the instance should be created, such as us-west' }),
     'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
-    'inactivity-timeout': Flags.string({ description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default: 3m' }),
+    'inactivity-timeout': Flags.string({
+      description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default is in organization settings.',
+    }),
     label: Flags.string({
       description: 'Metadata label in key=value format. Repeat to attach multiple labels.',
       multiple: true,

--- a/packages/cli/src/commands/xcode/attach-simulator.ts
+++ b/packages/cli/src/commands/xcode/attach-simulator.ts
@@ -1,0 +1,58 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+
+export default class XcodeAttachSimulator extends BaseCommand {
+  static summary = 'Attach an iOS simulator to an Xcode instance';
+  static description =
+    'Attach an existing iOS simulator to an Xcode sandbox so future builds can auto-install on that simulator.';
+
+  static examples = [
+    '<%= config.bin %> xcode attach-simulator <ios-instance-ID>',
+    '<%= config.bin %> xcode attach-simulator <ios-instance-ID> --id <xcode-instance-ID>',
+  ];
+
+  static args = {
+    simulatorId: Args.string({
+      description: 'iOS simulator instance ID to attach',
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    create: Flags.boolean({
+      hidden: true,
+      default: false,
+      allowNo: true,
+    }),
+    id: Flags.string({
+      description:
+        'Xcode instance ID to attach to, or an iOS instance ID with `--xcode` enabled. Defaults to the most recently created Xcode-capable target.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(XcodeAttachSimulator);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const xcodeInstanceId = this.resolveId(flags.id);
+      const simulator = await this.client.iosInstances.get(args.simulatorId);
+      const xcodeClient = await this.resolveXcodeClient(xcodeInstanceId);
+
+      this.info(`Attaching simulator ${args.simulatorId} to Xcode target ${xcodeInstanceId}...`);
+      await xcodeClient.attachSimulator(simulator);
+
+      if (flags.json) {
+        this.outputJson({
+          xcodeInstanceId,
+          simulatorInstanceId: simulator.metadata.id,
+        });
+      } else if (this.isQuietEnabled()) {
+        this.output(simulator.metadata.id);
+      } else {
+        this.output(`Attached simulator ${simulator.metadata.id} to Xcode target ${xcodeInstanceId}`);
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -1,7 +1,5 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
-import { detectInstanceType } from '../../lib/instance-client-factory';
-import { loadInstanceCache } from '../../lib/config';
 import { compileIgnorePatterns } from '../../lib/ignore-patterns';
 import { formatDurationMs } from '../../lib/duration';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
@@ -17,7 +15,9 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build --id <xcode-instance-ID>',
     '<%= config.bin %> xcode build ./MyProject --id <xcode-instance-ID>',
     '<%= config.bin %> xcode build --scheme MyApp --workspace MyApp.xcworkspace',
+    '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
+    '<%= config.bin %> xcode build --signed-upload-url <url>',
     '<%= config.bin %> xcode build ./MyProject --basis-cache-dir ./.limsync-cache --max-patch-bytes 2097152',
     '<%= config.bin %> xcode build ./MyProject --ignore "\\\\.xcuserdata/"',
     '<%= config.bin %> xcode build ./MyProject --additional-file ~/.netrc=~/.netrc',
@@ -41,7 +41,14 @@ export default class XcodeBuild extends BaseCommand {
       description: 'Workspace file to pass to xcodebuild, such as MyApp.xcworkspace',
     }),
     project: Flags.string({ description: 'Project file to pass to xcodebuild, such as MyApp.xcodeproj' }),
+    sdk: Flags.string({
+      description: 'SDK family to build for.',
+      options: ['iphonesimulator', 'iphoneos', 'watchsimulator', 'watchos'],
+    }),
     upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
+    'signed-upload-url': Flags.string({
+      description: 'Presigned URL to upload the resulting build artifact to.',
+    }),
     'basis-cache-dir': Flags.string({
       description: 'Directory to use for the client-side delta sync cache during the pre-build sync step.',
     }),
@@ -67,16 +74,24 @@ export default class XcodeBuild extends BaseCommand {
     await this.withAuth(async () => {
       const id = this.resolveId(flags.id);
       const syncPath = args.path ?? process.cwd();
-      const xcodeClient = await this.resolveXcodeClientFromIosInstance(id);
+      const xcodeClient = await this.resolveXcodeClient(id);
 
       const settings: Record<string, string> = {};
       if (flags.scheme) settings.scheme = flags.scheme;
       if (flags.workspace) settings.workspace = flags.workspace;
       if (flags.project) settings.project = flags.project;
+      if (flags.sdk) settings.sdk = flags.sdk;
 
       const options: Record<string, unknown> = {};
+      if (flags.upload && flags['signed-upload-url']) {
+        this.error('Use either --upload or --signed-upload-url, not both.');
+      }
       if (flags.upload) {
         options.upload = { assetName: flags.upload };
+      } else if (flags['signed-upload-url']) {
+        options.upload = {
+          signedUploadUrl: flags['signed-upload-url'],
+        };
       }
 
       this.info(`Syncing ${syncPath} to instance ${id}...`);
@@ -115,37 +130,9 @@ export default class XcodeBuild extends BaseCommand {
       }
 
       this.output(`\nBuild succeeded (exit code ${result.exitCode})`);
+      if (flags.upload && result.signedDownloadUrl) {
+        this.output(`Artifact download URL: ${result.signedDownloadUrl}`);
+      }
     });
-  }
-
-  private async resolveXcodeClientFromIosInstance(id: string) {
-    const type = detectInstanceType(id).toString();
-
-    if (type === 'ios') {
-      const instance = await this.client.iosInstances.get(id);
-      let sandboxUrl = instance.status.sandbox?.xcode?.url;
-      let token = instance.status.token;
-
-      if (!sandboxUrl) {
-        const cached = loadInstanceCache(id);
-        if (cached?.sandboxXcodeUrl) {
-          sandboxUrl = cached.sandboxXcodeUrl;
-          token = cached.token || token;
-        }
-      }
-
-      if (!sandboxUrl) {
-        this.error(
-          `iOS instance ${id} does not have a Xcode sandbox. Create it with: lim ios create --xcode or lim xcode create --ios`,
-        );
-      }
-      return this.client.xcodeInstances.createClient({
-        apiUrl: sandboxUrl,
-        token,
-      });
-    }
-
-    const instance = await this.client.xcodeInstances.get(id);
-    return this.client.xcodeInstances.createClient({ instance });
   }
 }

--- a/packages/cli/src/commands/xcode/create.ts
+++ b/packages/cli/src/commands/xcode/create.ts
@@ -32,7 +32,9 @@ export default class XcodeCreate extends BaseCommand {
     }),
     region: Flags.string({ description: 'Region where the sandbox should be created, such as us-west' }),
     'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
-    'inactivity-timeout': Flags.string({ description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default: 3m' }),
+    'inactivity-timeout': Flags.string({
+      description: 'Inactivity timeout (e.g. 1m, 10m, 3h). Default is in organization settings.',
+    }),
     label: Flags.string({
       description: 'Metadata label in key=value format. Repeat to attach multiple labels.',
       multiple: true,

--- a/packages/cli/src/commands/xcode/sync.ts
+++ b/packages/cli/src/commands/xcode/sync.ts
@@ -1,8 +1,6 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { compileIgnorePatterns } from '../../lib/ignore-patterns';
-import { detectInstanceType } from '../../lib/instance-client-factory';
-import { loadInstanceCache } from '../../lib/config';
 import { formatDurationMs } from '../../lib/duration';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
 
@@ -100,36 +98,5 @@ export default class XcodeSync extends BaseCommand {
         });
       }
     });
-  }
-
-  private async resolveXcodeClient(id: string) {
-    const type = detectInstanceType(id).toString();
-
-    if (type === 'ios') {
-      const instance = await this.client.iosInstances.get(id);
-      let sandboxUrl = instance.status.sandbox?.xcode?.url;
-      let token = instance.status.token;
-
-      if (!sandboxUrl) {
-        const cached = loadInstanceCache(id);
-        if (cached?.sandboxXcodeUrl) {
-          sandboxUrl = cached.sandboxXcodeUrl;
-          token = cached.token || token;
-        }
-      }
-
-      if (!sandboxUrl) {
-        this.error(
-          `iOS instance ${id} does not have a Xcode sandbox. Create it with: lim ios create --xcode or lim xcode create --ios`,
-        );
-      }
-      return this.client.xcodeInstances.createClient({
-        apiUrl: sandboxUrl,
-        token,
-      });
-    }
-
-    const instance = await this.client.xcodeInstances.get(id);
-    return this.client.xcodeInstances.createClient({ instance });
   }
 }

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -18,6 +18,12 @@ export type ExecRequest = {
     workspace?: string;
     project?: string;
     scheme?: string;
+    sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos';
+  };
+  signing?: {
+    certificateP12Base64?: string;
+    certificatePassword?: string;
+    provisioningProfileBase64?: string;
   };
   signedUploadUrl?: string;
   additionalMetadata?: {

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -51,11 +51,18 @@ export type XcodeProjectConfig = {
   workspace?: string;
   project?: string;
   scheme?: string;
-  sdk?: 'iphonesimulator' | 'iphoneos';
+  sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos';
+};
+
+export type XcodeSigningConfig = {
+  certificateP12Base64?: string;
+  certificatePassword?: string;
+  provisioningProfileBase64?: string;
 };
 
 export type XcodeBuildOptions = {
-  upload?: { assetName: string } | { signedUploadUrl: string; signedDownloadUrl: string };
+  upload?: { assetName: string } | { signedUploadUrl: string };
+  signing?: XcodeSigningConfig;
 };
 
 export type XcodeClient = {
@@ -228,6 +235,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
         const request: ExecRequest = {
           command: 'xcodebuild',
           ...(settings && { xcodebuild: settings }),
+          ...(options?.signing && { signing: options.signing }),
         };
 
         if (options?.upload && 'assetName' in options.upload) {
@@ -249,9 +257,8 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           return exec(requestPromise, { apiUrl, token, log });
         }
 
-        if (options?.upload && 'signedUploadUrl' in options.upload && 'signedDownloadUrl' in options.upload) {
+        if (options?.upload && 'signedUploadUrl' in options.upload) {
           request.signedUploadUrl = options.upload.signedUploadUrl;
-          request.additionalMetadata = { signedDownloadUrl: options.upload.signedDownloadUrl };
         }
 
         return exec(request, { apiUrl, token, log });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core Xcode command plumbing (client resolution) and build upload behavior, which could affect existing build/sync workflows if ID/type detection or upload option handling is wrong.
> 
> **Overview**
> Adds `lim xcode attach-simulator` to attach an existing iOS simulator to an Xcode sandbox so future builds can auto-install on that simulator, and documents the workflow in the CLI README.
> 
> Refactors Xcode-target resolution by moving iOS-vs-Xcode client selection (including cached sandbox URL fallback) into `BaseCommand.resolveXcodeClient`, and updates `xcode build`/`xcode sync` to use it.
> 
> Extends `lim xcode build` with `--sdk` selection and mutually exclusive artifact upload modes (`--upload` asset name vs `--signed-upload-url`), and updates create command flag help text for `--inactivity-timeout` to reflect org-level defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad1f0b98882c947ec315027c4365a99696d96d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->