### PR TITLE
cli: add 'lim skills install' command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -649,7 +649,7 @@ lim skills install --agents claude --scope project --json
 | Agent       | Project                   | Global                                                                     |
 | ----------- | ------------------------- | -------------------------------------------------------------------------- |
 | Claude Code | `.claude/skills/<skill>/` | `$CLAUDE_CONFIG_DIR/skills/<skill>/` (default `~/.claude/skills/<skill>/`) |
-| Cursor      | `.cursor/skills/<skill>/` | `~/.cursor/skills/<skill>/`                                                |
+| Cursor      | `.agents/skills/<skill>/` | `~/.agents/skills/<skill>/`                                                |
 | Codex       | `.codex/skills/<skill>/`  | `$CODEX_HOME/skills/<skill>/` (default `~/.codex/skills/<skill>/`)         |
 
 **Behavior:**
@@ -659,7 +659,7 @@ lim skills install --agents claude --scope project --json
 - Non-interactive runs are all-or-nothing: if any selected target conflicts and `--force` is not set, no files are written for any target, and the command exits with status 1.
 - Ctrl-C cancellation at any prompt exits cleanly without writing.
 
-**Cursor third-party skills toggle:** Cursor also supports loading skills from Claude and Codex paths via a "Third-party skills" setting (enabled by default). If your Cursor isn't picking up an installed skill, check that toggle in Cursor Settings.
+Cursor reads `.agents/skills/` natively, so we install there rather than `.cursor/skills/`. As a bonus, the same install reaches OpenCode and any other tool that follows the AGENTS.md convention - no extra menu options needed.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,7 +33,7 @@ The CLI stores configuration in `~/.lim/config.yaml`. This file is compatible wi
 
 ## Global Flags
 
-Every command supports these flags:
+Most commands support these flags (exceptions: `lim skills install` does not take `--api-key` because it does not talk to the API):
 
 | Flag                | Description                                                |
 | ------------------- | ---------------------------------------------------------- |
@@ -86,6 +86,7 @@ This avoids relying on locally cached "last created" state and keeps the target 
 - [Assets](#assets) — Upload and download files (APKs, IPAs, etc.)
 - [Sessions](#sessions) — Persistent connections for fast, interactive device control
 - [Xcode Build Pipeline](#xcode-build-pipeline) — Sync code and run xcodebuild remotely
+- [Skills](#skills) — Install Limrun skills for AI coding agents (Claude Code, Cursor, Codex)
 
 ---
 
@@ -610,6 +611,55 @@ lim asset pull my-app-build -o ./build-output
 `lim xcode build [PATH]` automatically performs a one-shot code sync for the given project path before invoking `xcodebuild`. The sync step automatically ignores build artifacts (`build/`, `DerivedData/`, `.build/`), dependency folders (`Pods/`, `Carthage/Build/`, `.swiftpm/`), and user-specific files (`xcuserdata/`, `.dSYM/`).
 
 Provide `--certificate-p12`, `--certificate-password`, and `--provisioning-profile` together to sign a real-device build. When signing assets are provided without `--sdk`, the CLI builds with `iphoneos`; pass `--sdk watchos` for signed watchOS device builds.
+
+---
+
+### Skills
+
+Install Limrun skills into the native skills directory of AI coding agents (Claude Code, Cursor, Codex). After installation, the agent auto-discovers the skill and triggers it when you ask things like "build the iOS app" or "show me a screenshot."
+
+```bash
+# Interactive: prompts for agents (with detected ones pre-checked) and scope
+lim skills install
+
+# Non-interactive
+lim skills install --agents claude --scope project
+lim skills install --agents claude --agents cursor --scope project
+lim skills install --agents codex --scope global
+
+# Overwrite existing skill files (otherwise the command refuses on non-interactive runs)
+lim skills install --agents claude --scope project --force
+
+# Machine-readable output for scripts
+lim skills install --agents claude --scope project --json
+```
+
+**Flags:**
+
+| Flag                        | Description                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`.                |
+| `--scope <project\|global>` | `project` writes into the current directory; `global` writes into the user's home directory. |
+| `--force`                   | Overwrite existing skill files without confirmation.                                         |
+| `--json`                    | Emit structured JSON instead of the human summary.                                           |
+| `--quiet`                   | Suppress non-result output.                                                                  |
+
+**Install paths:**
+
+| Agent       | Project                   | Global                                                                     |
+| ----------- | ------------------------- | -------------------------------------------------------------------------- |
+| Claude Code | `.claude/skills/<skill>/` | `$CLAUDE_CONFIG_DIR/skills/<skill>/` (default `~/.claude/skills/<skill>/`) |
+| Cursor      | `.cursor/skills/<skill>/` | `~/.cursor/skills/<skill>/`                                                |
+| Codex       | `.codex/skills/<skill>/`  | `$CODEX_HOME/skills/<skill>/` (default `~/.codex/skills/<skill>/`)         |
+
+**Behavior:**
+
+- The command compares bundled vs existing content byte-for-byte. Identical content is reported as `Unchanged` (no writes).
+- Different content: in interactive mode you are asked to confirm each overwrite; in non-interactive mode the command refuses unless `--force` is passed.
+- Non-interactive runs are all-or-nothing: if any selected target conflicts and `--force` is not set, no files are written for any target, and the command exits with status 1.
+- Ctrl-C cancellation at any prompt exits cleanly without writing.
+
+**Cursor third-party skills toggle:** Cursor also supports loading skills from Claude and Codex paths via a "Third-party skills" setting (enabled by default). If your Cursor isn't picking up an installed skill, check that toggle in Cursor Settings.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,6 +68,7 @@
   "files": [
     "dist",
     "bin",
+    "skills",
     "README.md"
   ]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,13 +30,15 @@
     "cli-table3": "^0.6.5",
     "dotenv": "^17.4.2",
     "js-yaml": "^4.1.0",
-    "open": "^10.1.0"
+    "open": "^10.1.0",
+    "prompts": "^2.4.2"
   },
   "devDependencies": {
     "@oclif/test": "^4",
     "@types/cli-progress": "^3.11.6",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22",
+    "@types/prompts": "^2.4.9",
     "typescript": "^5.8.3"
   },
   "oclif": {
@@ -59,6 +61,9 @@
       },
       "session": {
         "description": "Manage persistent background sessions for device interaction: start, status, stop. Sessions are used to execute commands on remote devices without the need to reconnect to the device after each command."
+      },
+      "skills": {
+        "description": "Install Limrun skills for AI coding agents (Claude Code, Cursor, Codex). Run `lim skills install` to set up."
       }
     }
   },

--- a/packages/cli/skills/limrun-ios/SKILL.md
+++ b/packages/cli/skills/limrun-ios/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: limrun-ios
+description: "Replaces xcodebuild with remote XCode and Simulators. Use when the user wants to build or run an iOS app, test iOS UI, see their app on a simulator, or says 'run it', 'build it', 'test it', 'show me a screenshot', or 'launch on simulator'."
+---
+
+# Remote XCode & iOS Simulator
+
+You are an iOS build-and-test operator. Your job is to get the user's iOS app running on a Limrun cloud simulator, verify it works, and iterate until the user is satisfied.
+
+All builds and simulator operations run on Limrun and that's why you can build iOS
+apps from any environments; linux, windows, macos, VM, container etc. Never try to
+use local Xcode, local simulators, or local macOS build tools.
+
+If `lim` CLI is not installed, you can install it with the following:
+
+```bash
+npm install --global @limrun/cli
+```
+
+## Build and Reload
+
+First, create an XCode & iOS Simulator pair:
+
+```bash
+# Add label selector depending on your identifiers. For example, Linear issue, repo name etc.
+lim ios create --xcode \
+  --reuse-if-exists \
+  --label issue=<ISSUE ID> \
+  --label repo=<Repo Name> \
+  --label agent=<Your Agent Name>
+# Example call: lim xcode create --reuse-if-exists --label issue=LIM-34 --label repo=sample-native-app --label agent=cursor
+```
+
+In the command output, there will be a signed stream URL. Share that with user so that they can watch the simulator while you are working.
+If you have a browser that user can see, open the signed stream URL in that browser and notify the user.
+
+### Build
+
+Instead of `xcodebuild` command, you MUST use the following to build the iOS app.
+
+```bash
+lim xcode build .
+```
+
+Use `--scheme` and `--workspace` flags if the project has multiple schemes or uses a workspace file. This makes sure the files are synced with the remote xcode and triggers
+a build where the build logs are streamed through stdout and stderr.
+
+Every successful build will automatically re-install the app in iOS Simulator and re-launch it.
+
+## Interacting with the App
+
+Prefer tapping by accessibility identifier, then by label, then by coordinates as a last resort:
+
+```bash
+lim ios tap-element --ax-unique-id startButton
+lim ios tap-element --ax-label "Save"
+lim ios tap 201 450
+```
+
+After every interaction, re-run `element-tree` to confirm the UI transitioned correctly. No sleep is needed between a tap and element-tree.
+
+For text input:
+
+```bash
+lim ios type "hello world"
+```
+
+## Testing Changes
+
+After every build, test new or changed functionality by using interaction commands. Focus on what changed plus a quick smoke test of core flows.
+
+Use element tree for functional assertions (element existence, labels, state changes). Use screenshots only for visual-only properties.
+Use video recording for most accurate interaction tests such as animations, gameplay,
+real experience etc.
+
+Generally, start with getting an element tree:
+
+```bash
+lim ios element-tree
+```
+
+Then if a single action will be taken, just call it. For example:
+
+```bash
+lim ios tap-element --ax-label Continue
+```
+
+If you will take multiple actions, you can create a chain of actions to be executed
+with precise timing.
+
+Some examples:
+
+```bash
+lim ios perform --action type=tap,x=100,y=200 --action "type=typeText,text=Hello World"
+
+lim ios perform --action type=wait,durationMs=1000 --action type=pressKey,key=enter
+```
+
+You can write to a file and execute that too:
+
+```bash
+lim ios perform --file ./actions.yaml
+```
+
+Use `lim ios perform --help` for more details on how to use it.
+
+Video recording is available so you can review what the user sees while you are taking actions. For
+any testing involving motion prefer video over screenshots for review.
+
+Always include a demo video in the pull request so that user can see how it works.
+
+Start recording (non-blocking):
+
+```bash
+lim ios record start
+```
+
+Stop and save recording:
+
+```bash
+lim ios record stop -o /tmp/recording.mp4
+```
+
+## Finalize
+
+When you are done with the changes and present to the user, you should provide a
+preview link to the user so they can test it.
+
+If you will open a PR, make sure to do this and add the preview link to PR.
+
+First build and make remote xcode upload the build:
+
+```
+ASSET_NAME="<bundle id/pr number/ or any session identifier>.zip"
+lim xcode build . --upload ${ASSET_NAME}
+```
+
+And construct this link for preview:
+
+```
+# Change ${ASSET_NAME} with asset name given above
+https://console.limrun.com/preview?asset=${ASSET_NAME}&platform=ios
+```
+
+Always provide this in your last message.
+
+## Cleanup
+
+When the user is satisfied or the conversation is ending, always clean up:
+
+```bash
+lim ios delete
+```
+
+## Gotchas
+
+These are common failure points. Check here first when something goes wrong.
+
+- **Instance ID is optional.** The CLI remembers the last created instance. You only need to pass an ID explicitly when controlling multiple instances.
+- **No sleep needed between `tap-element` and `element-tree`.** The tap blocks until complete.
+- **`element-tree` can be large.** Pipe through `grep` or `jq` to extract what you need rather than dumping the full tree into context.
+- **Build errors are your job to fix.** If a build fails, read the error output, fix the code, and rebuild. Do not ask the user to fix build errors.
+- **Bundle ID discovery.** If you don't know the bundle ID, check the Xcode project files or run `lim ios list-apps` after a successful build.
+
+## References
+
+```bash
+> lim ios
+Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, record, perform, simctl, cp, xcrun, xcodebuild, lsof
+
+USAGE
+  $ lim ios COMMAND
+
+COMMANDS
+  ios app-log          Stream or tail app logs from a running iOS instance
+  ios cp               Copy a local file into the iOS sandbox
+  ios create           Create a new iOS instance
+  ios delete           Delete an iOS instance
+  ios element-tree     Get the UI element tree from a running iOS instance
+  ios get              Get details for a specific iOS instance
+  ios info             Get device information from a running iOS instance
+  ios install-app      Install an app on a running iOS instance
+  ios launch-app       Launch an app on a running iOS instance
+  ios list             List iOS instances
+  ios list-apps        List installed apps on a running iOS instance
+  ios lsof             List open files on a running iOS instance
+  ios open-url         Open a URL on a running iOS instance
+  ios perform          Perform multiple iOS actions in a single batch
+  ios press-key        Press a key on a running iOS instance
+  ios record           Start or stop video recording on a running iOS instance
+  ios screenshot       Capture a screenshot from a running iOS instance
+  ios scroll           Scroll on a running iOS instance
+  ios simctl           Run simctl on a running iOS instance
+  ios sync             Sync a built app bundle to a running iOS instance
+  ios syslog           Stream syslog from a running iOS instance
+  ios tap              Tap at coordinates on a running iOS instance
+  ios tap-element      Tap an iOS element by accessibility selector
+  ios terminate-app    Terminate an app on a running iOS instance
+  ios toggle-keyboard  Toggle the iOS software keyboard
+  ios type             Type text into the focused iOS input field
+  ios xcodebuild       Run xcodebuild on a running iOS instance
+  ios xcrun            Run xcrun on a running iOS instance
+```
+
+```bash
+> lim ios perform --help
+Perform multiple iOS actions in a single batch
+
+USAGE
+  $ lim ios perform [--api-key <value>] [--json] [--quiet] [--create]
+    [--id <value>] [--action <value>...] [-f <value>] [--timeout <value>]
+
+FLAGS
+  -f, --file=<value>
+      Path to a YAML or JSON file containing an array of action objects.
+
+      JSON example:
+      [
+      { "type": "tap", "x": 100, "y": 200 },
+      { "type": "typeText", "text": "Hello World" }
+      ]
+
+      YAML example:
+      - type: tap
+        x: 100
+        y: 200
+      - type: typeText
+        text: "Hello World"
+
+  --action=<value>...
+      Action definition as comma-separated key=value pairs; repeat for multiple
+      actions.
+
+      Available action types:
+      - Tap on coordinate: type=tap,x=100,y=200
+      - Tap on element by using a selector:
+      type=tapElement,selector={"AXLabel":"Submit"}
+      - Increment an element by using a selector:
+      type=incrementElement,selector={"AXLabel":"Volume"}
+      - Decrement an element by using a selector:
+      type=decrementElement,selector={"AXLabel":"Volume"}
+      - Set an element value by using a selector:
+      type=setElementValue,text=42,selector={"AXLabel":"Counter"}
+      - Type text into the focused field: type=typeText,text=Hello
+      World,pressEnter=true
+      - Press a key with optional modifiers:
+      type=pressKey,key=a,modifiers=["shift"]
+      - Scroll the screen:
+      type=scroll,direction=down,pixels=300,coordinate=[200,400],momentum=0.2
+      - Toggle the software keyboard: type=toggleKeyboard
+      - Open a URL or deep link: type=openUrl,url=https://example.com
+      - Set device orientation: type=setOrientation,orientation=Landscape
+      - Wait before the next action: type=wait,durationMs=1000
+      - Start a touch gesture: type=touchDown,x=100,y=200
+      - Move a touch gesture: type=touchMove,x=120,y=220
+      - End a touch gesture: type=touchUp,x=120,y=220
+      - Press a raw key code down: type=keyDown,keyCode=4
+      - Release a raw key code: type=keyUp,keyCode=4
+      - Press a hardware button down: type=buttonDown,button=home
+      - Release a hardware button: type=buttonUp,button=home
+
+      Use JSON values for complex fields like selector, modifiers, and coordinate.
+
+  --api-key=<value>
+      [env: LIM_API_KEY] API key to use for this command. Overrides the saved
+      login and can also be provided via LIM_API_KEY.
+
+  --[no-]create
+      Create a replacement instance automatically if the target instance is not
+      found.
+
+  --id=<value>
+      iOS instance ID to target. Defaults to the last created iOS instance.
+
+  --json
+      Output structured JSON instead of human-readable tables or plain text when
+      the command supports it.
+
+  --quiet
+      Suppress intermediate human-readable logs and only emit the final result.
+
+  --timeout=<value>
+      Override the total batch timeout in milliseconds. By default the CLI grows
+      the timeout based on waits and action count.
+
+DESCRIPTION
+  Perform multiple iOS actions in a single batch
+
+  Run a batch of iOS actions in a single CLI invocation using repeated
+  `--action` flags or a JSON/YAML action file. This is the best choice for
+  agent-driven multi-step interactions that should execute without reconnecting
+  between steps.
+
+EXAMPLES
+  $ lim ios perform --action type=tap,x=100,y=200 --action "type=typeText,text=Hello World"
+
+  $ lim ios perform --action type=wait,durationMs=1000 --action type=pressKey,key=enter
+
+  $ lim ios perform --file ./actions.yaml
+```
+
+```bash
+> lim xcode
+Execute any task on remote XCode sandboxes: create, list, get, delete, sync, build, attach-simulator
+
+USAGE
+  $ lim xcode COMMAND
+
+COMMANDS
+  xcode attach-simulator  Attach an iOS simulator to an Xcode instance
+  xcode build             Run xcodebuild on an Xcode sandbox
+  xcode create            Create a new Xcode instance
+  xcode delete            Delete an Xcode instance
+  xcode get               Get details for a specific Xcode instance
+  xcode list              List Xcode instances
+  xcode sync              Continuously sync local source code to an Xcode
+                          sandbox
+```

--- a/packages/cli/skills/limrun-ios/SKILL.md
+++ b/packages/cli/skills/limrun-ios/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: limrun-ios
-description: "Replaces xcodebuild with remote XCode and Simulators. Use when the user wants to build or run an iOS app, test iOS UI, see their app on a simulator, or says 'run it', 'build it', 'test it', 'show me a screenshot', or 'launch on simulator'."
+description: "Replaces xcodebuild with remote XCode and Simulators, plus full iOS UI control. Use when the user wants to build, run, or launch an iOS app, test iOS UI, interact with the simulator (tap, click, type into, scroll), inspect the screen, capture a screenshot, or record a video. Triggers on phrases like 'run it', 'build it', 'test it', 'show me a screenshot', 'launch on simulator', 'tap the button', or 'type into the field'."
 ---
 
 # Remote XCode & iOS Simulator
@@ -17,6 +17,19 @@ If `lim` CLI is not installed, you can install it with the following:
 npm install --global @limrun/cli
 ```
 
+## Check the CLI for current commands and flags
+
+The CLI is the source of truth for command names, flags, and behavior. Before invoking any `lim` command you have not already used in this session, MUST run its `--help` first. The examples below are happy-path only; this skill intentionally does not embed the full reference because it would rot. Use:
+
+```bash
+lim ios --help                  # list all iOS subcommands
+lim ios <subcommand> --help     # flags and examples for one iOS subcommand
+lim xcode --help                # list all xcode subcommands
+lim xcode <subcommand> --help   # flags and examples for one xcode subcommand
+lim session --help              # list all session subcommands
+lim session <subcommand> --help # flags and examples for one session subcommand
+```
+
 ## Build and Reload
 
 First, create an XCode & iOS Simulator pair:
@@ -28,11 +41,20 @@ lim ios create --xcode \
   --label issue=<ISSUE ID> \
   --label repo=<Repo Name> \
   --label agent=<Your Agent Name>
-# Example call: lim xcode create --reuse-if-exists --label issue=LIM-34 --label repo=sample-native-app --label agent=cursor
 ```
 
-In the command output, there will be a signed stream URL. Share that with user so that they can watch the simulator while you are working.
-If you have a browser that user can see, open the signed stream URL in that browser and notify the user.
+The command output includes the instance ID (e.g. `ios_abc123`) and a `Signed Stream URL:`. Share that URL with the user so they can watch the simulator while you work. If you have a browser you can drive, open the URL in that browser and notify the user.
+
+### Start a session for fast interaction
+
+Right after creating the instance, start a session so subsequent interaction commands are fast:
+
+```bash
+# ID comes from the create output above. Always pass --id explicitly in agent workflows.
+lim session start --id <instance-id>
+```
+
+Every `tap`, `type`, `element-tree`, `screenshot`, `record`, and `perform` command auto-routes through this session at ~50ms instead of ~2s. `lim ios delete` will auto-stop the session at cleanup; no separate `session stop` step is required.
 
 ### Build
 
@@ -92,7 +114,9 @@ Some examples:
 
 ```bash
 lim ios perform --action type=tap,x=100,y=200 --action "type=typeText,text=Hello World"
+```
 
+```bash
 lim ios perform --action type=wait,durationMs=1000 --action type=pressKey,key=enter
 ```
 
@@ -123,22 +147,16 @@ lim ios record stop -o /tmp/recording.mp4
 
 ## Finalize
 
-When you are done with the changes and present to the user, you should provide a
-preview link to the user so they can test it.
+When you are wrapping up changes, produce a shareable build artifact so the user can test it themselves:
 
-If you will open a PR, make sure to do this and add the preview link to PR.
-
-First build and make remote xcode upload the build:
-
-```
-ASSET_NAME="<bundle id/pr number/ or any session identifier>.zip"
+```bash
+ASSET_NAME="<bundle-id-or-pr-number-or-session-identifier>.zip"
 lim xcode build . --upload ${ASSET_NAME}
 ```
 
-And construct this link for preview:
+Then share a preview link with the user (substitute the asset name above):
 
 ```
-# Change ${ASSET_NAME} with asset name given above
 https://console.limrun.com/preview?asset=${ASSET_NAME}&platform=ios
 ```
 
@@ -161,158 +179,3 @@ These are common failure points. Check here first when something goes wrong.
 - **`element-tree` can be large.** Pipe through `grep` or `jq` to extract what you need rather than dumping the full tree into context.
 - **Build errors are your job to fix.** If a build fails, read the error output, fix the code, and rebuild. Do not ask the user to fix build errors.
 - **Bundle ID discovery.** If you don't know the bundle ID, check the Xcode project files or run `lim ios list-apps` after a successful build.
-
-## References
-
-```bash
-> lim ios
-Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, record, perform, simctl, cp, xcrun, xcodebuild, lsof
-
-USAGE
-  $ lim ios COMMAND
-
-COMMANDS
-  ios app-log          Stream or tail app logs from a running iOS instance
-  ios cp               Copy a local file into the iOS sandbox
-  ios create           Create a new iOS instance
-  ios delete           Delete an iOS instance
-  ios element-tree     Get the UI element tree from a running iOS instance
-  ios get              Get details for a specific iOS instance
-  ios info             Get device information from a running iOS instance
-  ios install-app      Install an app on a running iOS instance
-  ios launch-app       Launch an app on a running iOS instance
-  ios list             List iOS instances
-  ios list-apps        List installed apps on a running iOS instance
-  ios lsof             List open files on a running iOS instance
-  ios open-url         Open a URL on a running iOS instance
-  ios perform          Perform multiple iOS actions in a single batch
-  ios press-key        Press a key on a running iOS instance
-  ios record           Start or stop video recording on a running iOS instance
-  ios screenshot       Capture a screenshot from a running iOS instance
-  ios scroll           Scroll on a running iOS instance
-  ios simctl           Run simctl on a running iOS instance
-  ios sync             Sync a built app bundle to a running iOS instance
-  ios syslog           Stream syslog from a running iOS instance
-  ios tap              Tap at coordinates on a running iOS instance
-  ios tap-element      Tap an iOS element by accessibility selector
-  ios terminate-app    Terminate an app on a running iOS instance
-  ios toggle-keyboard  Toggle the iOS software keyboard
-  ios type             Type text into the focused iOS input field
-  ios xcodebuild       Run xcodebuild on a running iOS instance
-  ios xcrun            Run xcrun on a running iOS instance
-```
-
-```bash
-> lim ios perform --help
-Perform multiple iOS actions in a single batch
-
-USAGE
-  $ lim ios perform [--api-key <value>] [--json] [--quiet] [--create]
-    [--id <value>] [--action <value>...] [-f <value>] [--timeout <value>]
-
-FLAGS
-  -f, --file=<value>
-      Path to a YAML or JSON file containing an array of action objects.
-
-      JSON example:
-      [
-      { "type": "tap", "x": 100, "y": 200 },
-      { "type": "typeText", "text": "Hello World" }
-      ]
-
-      YAML example:
-      - type: tap
-        x: 100
-        y: 200
-      - type: typeText
-        text: "Hello World"
-
-  --action=<value>...
-      Action definition as comma-separated key=value pairs; repeat for multiple
-      actions.
-
-      Available action types:
-      - Tap on coordinate: type=tap,x=100,y=200
-      - Tap on element by using a selector:
-      type=tapElement,selector={"AXLabel":"Submit"}
-      - Increment an element by using a selector:
-      type=incrementElement,selector={"AXLabel":"Volume"}
-      - Decrement an element by using a selector:
-      type=decrementElement,selector={"AXLabel":"Volume"}
-      - Set an element value by using a selector:
-      type=setElementValue,text=42,selector={"AXLabel":"Counter"}
-      - Type text into the focused field: type=typeText,text=Hello
-      World,pressEnter=true
-      - Press a key with optional modifiers:
-      type=pressKey,key=a,modifiers=["shift"]
-      - Scroll the screen:
-      type=scroll,direction=down,pixels=300,coordinate=[200,400],momentum=0.2
-      - Toggle the software keyboard: type=toggleKeyboard
-      - Open a URL or deep link: type=openUrl,url=https://example.com
-      - Set device orientation: type=setOrientation,orientation=Landscape
-      - Wait before the next action: type=wait,durationMs=1000
-      - Start a touch gesture: type=touchDown,x=100,y=200
-      - Move a touch gesture: type=touchMove,x=120,y=220
-      - End a touch gesture: type=touchUp,x=120,y=220
-      - Press a raw key code down: type=keyDown,keyCode=4
-      - Release a raw key code: type=keyUp,keyCode=4
-      - Press a hardware button down: type=buttonDown,button=home
-      - Release a hardware button: type=buttonUp,button=home
-
-      Use JSON values for complex fields like selector, modifiers, and coordinate.
-
-  --api-key=<value>
-      [env: LIM_API_KEY] API key to use for this command. Overrides the saved
-      login and can also be provided via LIM_API_KEY.
-
-  --[no-]create
-      Create a replacement instance automatically if the target instance is not
-      found.
-
-  --id=<value>
-      iOS instance ID to target. Defaults to the last created iOS instance.
-
-  --json
-      Output structured JSON instead of human-readable tables or plain text when
-      the command supports it.
-
-  --quiet
-      Suppress intermediate human-readable logs and only emit the final result.
-
-  --timeout=<value>
-      Override the total batch timeout in milliseconds. By default the CLI grows
-      the timeout based on waits and action count.
-
-DESCRIPTION
-  Perform multiple iOS actions in a single batch
-
-  Run a batch of iOS actions in a single CLI invocation using repeated
-  `--action` flags or a JSON/YAML action file. This is the best choice for
-  agent-driven multi-step interactions that should execute without reconnecting
-  between steps.
-
-EXAMPLES
-  $ lim ios perform --action type=tap,x=100,y=200 --action "type=typeText,text=Hello World"
-
-  $ lim ios perform --action type=wait,durationMs=1000 --action type=pressKey,key=enter
-
-  $ lim ios perform --file ./actions.yaml
-```
-
-```bash
-> lim xcode
-Execute any task on remote XCode sandboxes: create, list, get, delete, sync, build, attach-simulator
-
-USAGE
-  $ lim xcode COMMAND
-
-COMMANDS
-  xcode attach-simulator  Attach an iOS simulator to an Xcode instance
-  xcode build             Run xcodebuild on an Xcode sandbox
-  xcode create            Create a new Xcode instance
-  xcode delete            Delete an Xcode instance
-  xcode get               Get details for a specific Xcode instance
-  xcode list              List Xcode instances
-  xcode sync              Continuously sync local source code to an Xcode
-                          sandbox
-```

--- a/packages/cli/src/commands/android/get.ts
+++ b/packages/cli/src/commands/android/get.ts
@@ -33,7 +33,8 @@ export default class AndroidGet extends BaseCommand {
         this.output(`State: ${instance.status.state}`);
         this.output(`Console URL: ${this.consoleStreamUrl(instance.metadata.id)}`);
         if (instance.status.apiUrl) this.output(`API URL: ${instance.status.apiUrl}`);
-        if (instance.status.adbWebSocketUrl) this.output(`ADB WebSocket URL: ${instance.status.adbWebSocketUrl}`);
+        if (instance.status.adbWebSocketUrl)
+          this.output(`ADB WebSocket URL: ${instance.status.adbWebSocketUrl}`);
         if (signedStreamUrl) this.output(`Signed Stream URL: ${signedStreamUrl}`);
       }
     });

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -1,0 +1,340 @@
+import fs from 'fs';
+import path from 'path';
+import prompts from 'prompts';
+import { Command, Flags } from '@oclif/core';
+import {
+  AGENTS,
+  AGENT_IDS,
+  type AgentId,
+  type AgentSpec,
+  type Scope,
+  sourceSkillMd,
+  targetSkillMd,
+  planSkillFileCopy,
+  applySkillFileCopy,
+} from '../../lib/skills';
+
+const SKILL_NAME = 'limrun-ios';
+const SKIPPED_REASON_CONFLICT = 'existing content differs; re-run with --force to overwrite';
+const SKIPPED_REASON_BLOCKED = 'blocked: another target requires --force to proceed';
+const SKIPPED_REASON_DECLINED = 'user declined overwrite confirmation';
+
+type Status = 'installed' | 'updated' | 'unchanged' | 'skipped';
+
+interface PlannedTarget {
+  agent: AgentSpec;
+  scope: Scope;
+  source: string;
+  target: string;
+  kind: 'install' | 'unchanged' | 'conflict';
+}
+
+interface ResultRow {
+  agent: AgentId;
+  scope: Scope;
+  path: string;
+  status: Status;
+  reason?: string;
+}
+
+class PromptCancelled extends Error {
+  constructor() {
+    super('cancelled');
+    this.name = 'PromptCancelled';
+  }
+}
+
+function detectAgentsForScope(scope: Scope): Set<AgentId> {
+  const detected = new Set<AgentId>();
+  for (const id of AGENT_IDS) {
+    const agent = AGENTS[id];
+    for (const p of agent.detectionPaths(scope)) {
+      if (fs.existsSync(p)) {
+        detected.add(id);
+        break;
+      }
+    }
+  }
+  return detected;
+}
+
+function detectAgentsAcrossScopes(): Set<AgentId> {
+  const merged = new Set<AgentId>([...detectAgentsForScope('project'), ...detectAgentsForScope('global')]);
+  return merged;
+}
+
+async function promptAgents(preselected: Set<AgentId>): Promise<AgentId[]> {
+  // Loop to enforce "at least one agent" without crashing.
+  while (true) {
+    const response = await prompts(
+      {
+        type: 'multiselect',
+        name: 'agents',
+        message: 'Which agents do you want to set up?',
+        instructions: false,
+        choices: AGENT_IDS.map((id) => ({
+          title: AGENTS[id].displayName,
+          value: id,
+          selected: preselected.has(id),
+        })),
+        hint: 'Space to toggle, Enter to confirm',
+      },
+      {
+        onCancel: () => {
+          throw new PromptCancelled();
+        },
+      },
+    );
+    const picked = (response.agents ?? []) as AgentId[];
+    if (picked.length > 0) {
+      return picked;
+    }
+    // Re-prompt with a visible inline warning.
+    process.stderr.write('Select at least one agent.\n');
+  }
+}
+
+async function promptScope(): Promise<Scope> {
+  const response = await prompts(
+    {
+      type: 'select',
+      name: 'scope',
+      message: 'Install location?',
+      choices: [
+        { title: 'Project', value: 'project', description: 'Install into the current directory' },
+        { title: 'Global', value: 'global', description: 'Install into your home directory' },
+      ],
+      initial: 0,
+    },
+    {
+      onCancel: () => {
+        throw new PromptCancelled();
+      },
+    },
+  );
+  return response.scope as Scope;
+}
+
+async function promptOverwrite(targetPath: string): Promise<boolean> {
+  const response = await prompts(
+    {
+      type: 'confirm',
+      name: 'ok',
+      message: `Overwrite existing ${targetPath}?`,
+      initial: false,
+    },
+    {
+      onCancel: () => {
+        throw new PromptCancelled();
+      },
+    },
+  );
+  return Boolean(response.ok);
+}
+
+function humanPath(absolutePath: string, scope: Scope): string {
+  if (scope !== 'project') {
+    return absolutePath;
+  }
+  const relative = path.relative(process.cwd(), absolutePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return absolutePath;
+  }
+  return relative;
+}
+
+function statusLabel(status: Status): string {
+  switch (status) {
+    case 'installed':
+      return 'Installed';
+    case 'updated':
+      return 'Updated';
+    case 'unchanged':
+      return 'Unchanged';
+    case 'skipped':
+      return 'Skipped';
+  }
+}
+
+export default class SkillsInstall extends Command {
+  static summary = 'Install Limrun skills for AI coding agents';
+  static description =
+    'Copy the bundled Limrun skill into the native skills directory for each selected agent (Claude Code, Cursor, Codex). Pre-checks detected agents and lets you pick project or global scope.';
+  static examples = [
+    '<%= config.bin %> skills install',
+    '<%= config.bin %> skills install --agents claude --agents cursor --scope project',
+    '<%= config.bin %> skills install --agents codex --scope global --force',
+  ];
+  static flags = {
+    agents: Flags.string({
+      description: 'Target agent. Repeat to pick multiple.',
+      multiple: true,
+      options: ['claude', 'cursor', 'codex'],
+    }),
+    scope: Flags.string({
+      description: 'Install scope.',
+      options: ['project', 'global'],
+    }),
+    force: Flags.boolean({
+      description: 'Overwrite existing skill files without confirmation.',
+      default: false,
+    }),
+    json: Flags.boolean({
+      description: 'Emit structured JSON output.',
+      default: false,
+    }),
+    quiet: Flags.boolean({
+      description: 'Suppress non-result output.',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    try {
+      await this.runInner();
+    } catch (err) {
+      if (err instanceof PromptCancelled) {
+        this.exit(130);
+      }
+      throw err;
+    }
+  }
+
+  private async runInner(): Promise<void> {
+    const { flags } = await this.parse(SkillsInstall);
+
+    const interactive = process.stdin.isTTY === true && !flags.json && !flags.quiet;
+
+    let agents: AgentId[];
+    let scope: Scope;
+
+    if (flags.agents && flags.agents.length > 0) {
+      agents = Array.from(new Set(flags.agents)) as AgentId[];
+    } else if (interactive) {
+      agents = await promptAgents(detectAgentsAcrossScopes());
+    } else {
+      this.error('--agents requires at least one of: claude, cursor, codex.', { exit: 2 });
+    }
+
+    if (flags.scope) {
+      scope = flags.scope as Scope;
+    } else if (interactive) {
+      scope = await promptScope();
+    } else {
+      this.error('Specify --agents and --scope in non-interactive mode.', { exit: 2 });
+    }
+
+    const source = sourceSkillMd(this.config, SKILL_NAME);
+    if (!fs.existsSync(source)) {
+      this.error(`Bundled skill source missing at ${source}.`, { exit: 1 });
+    }
+
+    // Phase 1: Plan.
+    const planned: PlannedTarget[] = agents.map((id) => {
+      const agent = AGENTS[id];
+      const target = targetSkillMd(agent, scope, SKILL_NAME);
+      const { kind } = planSkillFileCopy(source, target);
+      return { agent, scope, source, target, kind };
+    });
+
+    // Phase 2: Confirm.
+    const results: ResultRow[] = [];
+    const anyConflict = planned.some((t) => t.kind === 'conflict');
+
+    if (anyConflict && !flags.force && !interactive) {
+      // Non-interactive + conflict + no force: all-or-nothing. Skip all targets.
+      for (const t of planned) {
+        results.push({
+          agent: t.agent.id,
+          scope: t.scope,
+          path: t.target,
+          status: 'skipped',
+          reason: t.kind === 'conflict' ? SKIPPED_REASON_CONFLICT : SKIPPED_REASON_BLOCKED,
+        });
+      }
+      if (!flags.json) {
+        // --quiet still suppresses the human summary, but a hard refusal needs to be visible.
+        process.stderr.write(
+          'Existing skill files would be overwritten. Re-run with --force, or run interactively to confirm per target.\n',
+        );
+      }
+      this.emitOutput(results, flags);
+      this.exit(1);
+    }
+
+    // Decide final status per target (no writes yet).
+    const finalDecisions: Array<{ target: PlannedTarget; status: Status; reason?: string }> = [];
+    for (const t of planned) {
+      if (t.kind === 'install') {
+        finalDecisions.push({ target: t, status: 'installed' });
+      } else if (t.kind === 'unchanged') {
+        finalDecisions.push({ target: t, status: 'unchanged' });
+      } else if (flags.force) {
+        finalDecisions.push({ target: t, status: 'updated' });
+      } else {
+        // Interactive conflict without --force: prompt per target.
+        const displayPath = humanPath(t.target, t.scope);
+        const ok = await promptOverwrite(displayPath);
+        if (ok) {
+          finalDecisions.push({ target: t, status: 'updated' });
+        } else {
+          finalDecisions.push({
+            target: t,
+            status: 'skipped',
+            reason: SKIPPED_REASON_DECLINED,
+          });
+        }
+      }
+    }
+
+    // Phase 3: Apply.
+    for (const decision of finalDecisions) {
+      if (decision.status === 'installed' || decision.status === 'updated') {
+        applySkillFileCopy(decision.target.source, decision.target.target);
+      }
+      results.push({
+        agent: decision.target.agent.id,
+        scope: decision.target.scope,
+        path: decision.target.target,
+        status: decision.status,
+        ...(decision.reason ? { reason: decision.reason } : {}),
+      });
+    }
+
+    this.emitOutput(results, flags);
+  }
+
+  private emitOutput(results: ResultRow[], flags: { json: boolean; quiet: boolean }): void {
+    if (flags.json) {
+      this.log(
+        JSON.stringify(
+          {
+            skill: SKILL_NAME,
+            results,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+    if (flags.quiet) {
+      return;
+    }
+
+    // Human summary.
+    this.log('');
+    this.log(`  ${SKILL_NAME}`);
+    const colWidth = Math.max(
+      ...results.map((r) => AGENTS[r.agent].displayName.length),
+      'Claude Code'.length,
+    );
+    for (const r of results) {
+      const agentLabel = AGENTS[r.agent].displayName.padEnd(colWidth);
+      const displayPath = humanPath(r.path, r.scope);
+      const reason = r.reason ? `  (${r.reason})` : '';
+      this.log(`    ${agentLabel}  ->  ${displayPath}    ${statusLabel(r.status)}${reason}`);
+    }
+    this.log('');
+  }
+}

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -58,11 +58,6 @@ function detectAgentsForScope(scope: Scope): Set<AgentId> {
   return detected;
 }
 
-function detectAgentsAcrossScopes(): Set<AgentId> {
-  const merged = new Set<AgentId>([...detectAgentsForScope('project'), ...detectAgentsForScope('global')]);
-  return merged;
-}
-
 async function promptAgents(preselected: Set<AgentId>): Promise<AgentId[]> {
   // Loop to enforce "at least one agent" without crashing.
   while (true) {
@@ -211,7 +206,10 @@ export default class SkillsInstall extends Command {
     if (flags.agents && flags.agents.length > 0) {
       agents = Array.from(new Set(flags.agents)) as AgentId[];
     } else if (interactive) {
-      agents = await promptAgents(detectAgentsAcrossScopes());
+      // Pre-check based on project-local presence only. Global installs of
+      // agents (e.g. ~/.claude on a dev machine) are too weak a signal to
+      // auto-select them for this specific project's install.
+      agents = await promptAgents(detectAgentsForScope('project'));
     } else {
       this.error('--agents requires at least one of: claude, cursor, codex.', { exit: 2 });
     }

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -61,30 +61,68 @@ function detectAgentsForScope(scope: Scope): Set<AgentId> {
 async function promptAgents(preselected: Set<AgentId>): Promise<AgentId[]> {
   // Loop to enforce "at least one agent" without crashing.
   while (true) {
-    const response = await prompts(
-      {
-        type: 'multiselect',
-        name: 'agents',
-        message: 'Which agents do you want to set up?',
-        instructions: false,
-        choices: AGENT_IDS.map((id) => ({
-          title: AGENTS[id].displayName,
-          value: id,
-          selected: preselected.has(id),
-        })),
-        hint: 'Space to toggle, Enter to confirm',
-      },
-      {
-        onCancel: () => {
-          throw new PromptCancelled();
+    // `prompts` does not expose the multiselect cursor in onState - the state
+    // event only carries {value, aborted, exited}. Track cursor ourselves by
+    // listening to keypress events on stdin and mirror prompts' own dispatch
+    // (see prompts/lib/util/action.js and multiselect.js):
+    //   - up / k  : wrap (cursor === 0 ? last : cursor - 1)
+    //   - down / j / tab : wrap (cursor === last ? 0 : cursor + 1)
+    //   - ctrl+a  : first
+    //   - ctrl+e  : last
+    // Anything else (page nav, home/end) is rare for a 3-row list and not
+    // tracked here; the worst case is the same as the previous clamp bug.
+    let cursor = 0;
+    const onKeypress = (_str: string, key: { name?: string; ctrl?: boolean; meta?: boolean }) => {
+      if (!key || !key.name) return;
+      if (key.meta && key.name !== 'escape') return;
+      const last = AGENT_IDS.length - 1;
+      if (key.ctrl) {
+        if (key.name === 'a') cursor = 0;
+        else if (key.name === 'e') cursor = last;
+        return;
+      }
+      if (key.name === 'up' || key.name === 'k') {
+        cursor = cursor === 0 ? last : cursor - 1;
+      } else if (key.name === 'down' || key.name === 'j' || key.name === 'tab') {
+        cursor = cursor === last ? 0 : cursor + 1;
+      }
+    };
+    process.stdin.on('keypress', onKeypress);
+    let response;
+    try {
+      response = await prompts(
+        {
+          type: 'multiselect',
+          name: 'agents',
+          message: 'Which agents do you want to set up?',
+          instructions: false,
+          choices: AGENT_IDS.map((id) => ({
+            title: AGENTS[id].displayName,
+            value: id,
+            selected: preselected.has(id),
+          })),
+          hint: 'Space to toggle, Enter to confirm (Enter alone picks the highlighted agent)',
         },
-      },
-    );
-    const picked = (response.agents ?? []) as AgentId[];
+        {
+          onCancel: () => {
+            throw new PromptCancelled();
+          },
+        },
+      );
+    } finally {
+      process.stdin.off('keypress', onKeypress);
+    }
+    let picked = (response.agents ?? []) as AgentId[];
+    // If the user hit Enter without toggling anything, treat the highlighted
+    // row as their pick. Saves a Space keystroke for the common single-agent case.
+    if (picked.length === 0 && cursor >= 0 && cursor < AGENT_IDS.length) {
+      picked = [AGENT_IDS[cursor]];
+    }
     if (picked.length > 0) {
+      process.stderr.write(`  Selected: ${picked.map((id) => AGENTS[id].displayName).join(', ')}\n`);
       return picked;
     }
-    // Re-prompt with a visible inline warning.
+    // Re-prompt with a visible inline warning (should not be reachable now).
     process.stderr.write('Select at least one agent.\n');
   }
 }

--- a/packages/cli/src/lib/skills.ts
+++ b/packages/cli/src/lib/skills.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { type Config } from '@oclif/core';
+
+export type AgentId = 'claude' | 'cursor' | 'codex';
+export type Scope = 'project' | 'global';
+
+export const AGENT_IDS: AgentId[] = ['claude', 'cursor', 'codex'];
+
+export interface AgentSpec {
+  id: AgentId;
+  displayName: string;
+  skillsDir(scope: Scope): string;
+  detectionPaths(scope: Scope): string[];
+}
+
+function claudeGlobalRoot(): string {
+  const override = process.env.CLAUDE_CONFIG_DIR;
+  if (override) return path.resolve(override);
+  return path.join(os.homedir(), '.claude');
+}
+
+function codexGlobalRoot(): string {
+  const override = process.env.CODEX_HOME;
+  if (override) return path.resolve(override);
+  return path.join(os.homedir(), '.codex');
+}
+
+export const AGENTS: Record<AgentId, AgentSpec> = {
+  claude: {
+    id: 'claude',
+    displayName: 'Claude Code',
+    skillsDir: (scope) =>
+      scope === 'project' ?
+        path.join(process.cwd(), '.claude', 'skills')
+      : path.join(claudeGlobalRoot(), 'skills'),
+    detectionPaths: (scope) =>
+      scope === 'project' ? [path.join(process.cwd(), '.claude')] : [claudeGlobalRoot()],
+  },
+  cursor: {
+    id: 'cursor',
+    displayName: 'Cursor',
+    skillsDir: (scope) =>
+      scope === 'project' ?
+        path.join(process.cwd(), '.cursor', 'skills')
+      : path.join(os.homedir(), '.cursor', 'skills'),
+    detectionPaths: (scope) =>
+      scope === 'project' ? [path.join(process.cwd(), '.cursor')] : [path.join(os.homedir(), '.cursor')],
+  },
+  codex: {
+    id: 'codex',
+    displayName: 'Codex',
+    skillsDir: (scope) =>
+      scope === 'project' ?
+        path.join(process.cwd(), '.codex', 'skills')
+      : path.join(codexGlobalRoot(), 'skills'),
+    detectionPaths: (scope) =>
+      scope === 'project' ? [path.join(process.cwd(), '.codex')] : [codexGlobalRoot()],
+  },
+};
+
+export function skillsRoot(config: Config): string {
+  return path.join(config.root, 'skills');
+}
+
+export function sourceSkillMd(config: Config, skillName: string): string {
+  return path.join(skillsRoot(config), skillName, 'SKILL.md');
+}
+
+export function targetSkillMd(agent: AgentSpec, scope: Scope, skillName: string): string {
+  return path.join(agent.skillsDir(scope), skillName, 'SKILL.md');
+}
+
+export type PlanKind = 'install' | 'unchanged' | 'conflict';
+
+export function planSkillFileCopy(sourceFile: string, targetFile: string): { kind: PlanKind } {
+  if (!fs.existsSync(targetFile)) {
+    return { kind: 'install' };
+  }
+  const sourceBuf = fs.readFileSync(sourceFile);
+  const targetBuf = fs.readFileSync(targetFile);
+  return { kind: sourceBuf.equals(targetBuf) ? 'unchanged' : 'conflict' };
+}
+
+export function applySkillFileCopy(sourceFile: string, targetFile: string): void {
+  fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+  fs.copyFileSync(sourceFile, targetFile);
+}

--- a/packages/cli/src/lib/skills.ts
+++ b/packages/cli/src/lib/skills.ts
@@ -41,12 +41,19 @@ export const AGENTS: Record<AgentId, AgentSpec> = {
   cursor: {
     id: 'cursor',
     displayName: 'Cursor',
+    // Cursor auto-discovers .agents/skills/ natively, same as .cursor/skills/.
+    // Installing into .agents/skills/ also reaches OpenCode and any other
+    // AGENTS.md-aware tool with a single copy, so prefer the broader path.
     skillsDir: (scope) =>
       scope === 'project' ?
-        path.join(process.cwd(), '.cursor', 'skills')
-      : path.join(os.homedir(), '.cursor', 'skills'),
+        path.join(process.cwd(), '.agents', 'skills')
+      : path.join(os.homedir(), '.agents', 'skills'),
+    // Detect either .cursor/ or .agents/: both are reliable signs the user
+    // is on a tool that auto-loads .agents/skills/.
     detectionPaths: (scope) =>
-      scope === 'project' ? [path.join(process.cwd(), '.cursor')] : [path.join(os.homedir(), '.cursor')],
+      scope === 'project' ?
+        [path.join(process.cwd(), '.cursor'), path.join(process.cwd(), '.agents')]
+      : [path.join(os.homedir(), '.cursor'), path.join(os.homedir(), '.agents')],
   },
   codex: {
     id: 'codex',

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -71,6 +71,14 @@
   dependencies:
     undici-types "~6.21.0"
 
+"@types/prompts@^2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.4.9.tgz#8775a31e40ad227af511aa0d7f19a044ccbd371e"
+  integrity sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==
+  dependencies:
+    "@types/node" "*"
+    kleur "^3.0.3"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
@@ -332,6 +340,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
 lilconfig@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz"
@@ -376,6 +389,14 @@ picomatch@^4.0.4:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
+prompts@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
 proxy-from-env@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz"
@@ -390,6 +411,11 @@ semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+sisteransi@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
 string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new interactive CLI command that writes files into project or home directories and can overwrite existing agent skill content, so incorrect path/overwrite handling could affect user environments.
> 
> **Overview**
> Adds a new `skills` CLI topic with `lim skills install` to copy a bundled skill (`skills/limrun-ios/SKILL.md`) into AI agent skill directories for *project* or *global* scope, with interactive selection, conflict detection, and `--force` overwrite behavior plus `--json/--quiet` outputs.
> 
> Updates packaging/docs to ship the `skills/` directory, document the new command and its flags/paths/behavior, and adds the `prompts` dependency; includes a tiny formatting-only tweak in `android get` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6ba07d3e53234e544ce4344f0b07948d72cce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->