### PR TITLE
limulator: add autoReconnect flag and reconnect method

### DIFF
--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -10,14 +10,14 @@
         padding: 0;
         box-sizing: border-box;
       }
-      
+
       body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         min-height: 100vh;
         padding: 20px;
       }
-      
+
       #root {
         display: flex;
         flex-direction: column;
@@ -25,50 +25,50 @@
         max-width: 1400px;
         margin: 0 auto;
       }
-      
+
       .header {
         text-align: center;
         color: white;
         padding: 20px;
       }
-      
+
       .header h1 {
         font-size: 2.5rem;
         margin-bottom: 10px;
         text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
       }
-      
+
       .header p {
         font-size: 1.1rem;
         opacity: 0.9;
       }
-      
+
       .demo-container {
         background: white;
         border-radius: 20px;
         padding: 30px;
         box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
       }
-      
+
       .controls {
         display: flex;
         flex-direction: column;
         gap: 15px;
         margin-bottom: 30px;
       }
-      
+
       .control-group {
         display: flex;
         flex-direction: column;
         gap: 8px;
       }
-      
+
       .control-group label {
         font-weight: 600;
         font-size: 0.9rem;
         color: #374151;
       }
-      
+
       .control-group input,
       .control-group select {
         padding: 10px 15px;
@@ -77,18 +77,18 @@
         font-size: 0.95rem;
         transition: border-color 0.2s;
       }
-      
+
       .control-group input:focus,
       .control-group select:focus {
         outline: none;
         border-color: #667eea;
       }
-      
+
       .button-group {
         display: flex;
         gap: 10px;
       }
-      
+
       button {
         padding: 12px 24px;
         border: none;
@@ -98,52 +98,52 @@
         cursor: pointer;
         transition: all 0.2s;
       }
-      
+
       button.primary {
         background: #667eea;
         color: white;
       }
-      
+
       button.primary:hover {
         background: #5568d3;
         transform: translateY(-1px);
         box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
       }
-      
+
       button.secondary {
         background: #e5e7eb;
         color: #374151;
       }
-      
+
       button.secondary:hover {
         background: #d1d5db;
       }
-      
+
       button:disabled {
         opacity: 0.5;
         cursor: not-allowed;
       }
-      
+
       .device-preview {
         display: flex;
         gap: 30px;
         justify-content: center;
         flex-wrap: wrap;
       }
-      
+
       .preview-item {
         flex: 1 1 420px;
         max-width: 520px;
         height: min(75vh, 900px);
       }
-      
+
       .preview-item h3 {
         text-align: center;
         margin-bottom: 15px;
         font-size: 1.2rem;
         color: #374151;
       }
-      
+
       .device-wrapper {
         height: 100%;
         width: 100%;
@@ -170,7 +170,7 @@
           height: 70vh;
         }
       }
-      
+
       .info-box {
         background: #fef3c7;
         border: 2px solid #fbbf24;
@@ -178,13 +178,13 @@
         padding: 15px;
         margin-bottom: 20px;
       }
-      
+
       .info-box h4 {
         color: #92400e;
         margin-bottom: 8px;
         font-size: 0.95rem;
       }
-      
+
       .info-box p {
         color: #78350f;
         font-size: 0.9rem;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -51,6 +51,10 @@ interface RemoteControlProps {
   // showFrame controls whether to display the device frame
   // around the video. Defaults to true.
   showFrame?: boolean;
+
+  // When true, drops after a working session auto-reconnect instead of
+  // surfacing the manual "Retry" button. Defaults to false.
+  autoReconnect?: boolean;
 }
 
 interface ScreenshotData {
@@ -71,6 +75,7 @@ export interface RemoteControlHandle {
   sendKeyEvent: (event: ImperativeKeyboardEvent) => void;
   screenshot: () => Promise<ScreenshotData>;
   terminateApp: (bundleId: string) => Promise<void>;
+  reconnect: () => void;
 }
 
 const debugLog = (...args: any[]) => {
@@ -122,6 +127,7 @@ const ANDROID_TABLET_VIDEO_HEIGHT = 1200;
 const MAX_CONNECTION_ATTEMPTS = 3;
 const CONNECTION_RETRY_DELAY_MS = 1000;
 const CONNECTION_SUCCESS_TIMEOUT_MS = 15000;
+const ICE_DISCONNECTED_GRACE_MS = 3000;
 
 const isAndroidTabletVideo = (width: number, height: number): boolean =>
   (width === ANDROID_TABLET_VIDEO_WIDTH && height === ANDROID_TABLET_VIDEO_HEIGHT) ||
@@ -192,7 +198,15 @@ function getAndroidKeycodeAndMeta(event: React.KeyboardEvent): { keycode: number
 
 export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>(
   (
-    { className, url, token, sessionId: propSessionId, openUrl, showFrame = true }: RemoteControlProps,
+    {
+      className,
+      url,
+      token,
+      sessionId: propSessionId,
+      openUrl,
+      showFrame = true,
+      autoReconnect = false,
+    }: RemoteControlProps,
     ref,
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -210,9 +224,13 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     const retryTimeoutRef = useRef<number | undefined>(undefined);
     const connectionSuccessTimeoutRef = useRef<number | undefined>(undefined);
     const requestFrameIntervalRef = useRef<number | undefined>(undefined);
+    const iceDisconnectedGraceRef = useRef<number | undefined>(undefined);
     const connectionGenerationRef = useRef(0);
     const connectionAttemptRef = useRef(0);
     const controlChannelOpenedRef = useRef(false);
+    // Mirrored to a ref so stale closures in event handlers see the latest value.
+    const autoReconnectRef = useRef(autoReconnect);
+    autoReconnectRef.current = autoReconnect;
     const firstFrameShownRef = useRef(false);
     const pendingScreenshotResolversRef = useRef<
       Map<string, (value: ScreenshotData | PromiseLike<ScreenshotData>) => void>
@@ -1100,6 +1118,13 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       }
     };
 
+    const clearIceDisconnectedGrace = () => {
+      if (iceDisconnectedGraceRef.current !== undefined) {
+        window.clearTimeout(iceDisconnectedGraceRef.current);
+        iceDisconnectedGraceRef.current = undefined;
+      }
+    };
+
     const markFirstFrameShown = () => {
       if (firstFrameShownRef.current) {
         return;
@@ -1111,6 +1136,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
 
     const teardownConnection = () => {
       clearConnectionSuccessTimeout();
+      clearIceDisconnectedGrace();
       stopRequestFrameLoop();
       if (wsRef.current) {
         wsRef.current.onopen = null;
@@ -1154,10 +1180,16 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       }
 
       if (controlChannelOpenedRef.current) {
-        updateStatus(`Connection failed after it was established: ${reason}`);
-        setRetryExhausted(true);
-        teardownConnection();
-        return;
+        if (!autoReconnectRef.current) {
+          updateStatus(`Connection failed after it was established: ${reason}`);
+          setRetryExhausted(true);
+          teardownConnection();
+          return;
+        }
+        // Reset so the upcoming retry gets a fresh MAX_CONNECTION_ATTEMPTS budget.
+        updateStatus(`Reconnecting after established session dropped: ${reason}`);
+        controlChannelOpenedRef.current = false;
+        connectionAttemptRef.current = -1;
       }
 
       clearScheduledRetry();
@@ -1424,9 +1456,32 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           if (!isCurrentAttempt() || peerConnectionRef.current !== peerConnection) {
             return;
           }
-          updateStatus('ICE state: ' + peerConnection.iceConnectionState);
-          if (peerConnection.iceConnectionState === 'failed') {
+          const iceState = peerConnection.iceConnectionState;
+          updateStatus('ICE state: ' + iceState);
+          if (iceState === 'connected' || iceState === 'completed') {
+            clearIceDisconnectedGrace();
+            return;
+          }
+          if (iceState === 'failed') {
+            clearIceDisconnectedGrace();
             scheduleRetry('ICE connection entered failed state', generation);
+            return;
+          }
+          if (
+            iceState === 'disconnected' &&
+            autoReconnectRef.current &&
+            iceDisconnectedGraceRef.current === undefined
+          ) {
+            // Cap the browser's natural disconnected→failed escalation to recover faster.
+            iceDisconnectedGraceRef.current = window.setTimeout(() => {
+              iceDisconnectedGraceRef.current = undefined;
+              if (!isCurrentAttempt() || peerConnectionRef.current !== peerConnection) {
+                return;
+              }
+              if (peerConnection.iceConnectionState === 'disconnected') {
+                scheduleRetry('ICE stayed disconnected past grace period', generation);
+              }
+            }, ICE_DISCONNECTED_GRACE_MS);
           }
         };
 
@@ -1636,6 +1691,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       connectionAttemptRef.current = 0;
       controlChannelOpenedRef.current = false;
       clearScheduledRetry();
+      clearIceDisconnectedGrace();
       teardownConnection();
       updateStatus('Stopped');
     };
@@ -1885,6 +1941,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           }, 30000);
         });
       },
+      reconnect: () => start(),
     }));
 
     // Show indicators when Alt is held and we have a valid hover point (null when outside)

--- a/packages/ui/src/demo.tsx
+++ b/packages/ui/src/demo.tsx
@@ -9,20 +9,20 @@ function Demo() {
   const [isConnected, setIsConnected] = useState(false);
   const [key, setKey] = useState(0);
   const [showDebugInfo, setShowDebugInfo] = useState(false);
-  
+
   const remoteControlRef = useRef<RemoteControlHandle>(null);
 
   const handleConnect = () => {
     if (url) {
       setIsConnected(true);
       // Force remount by changing key
-      setKey(prev => prev + 1);
+      setKey((prev) => prev + 1);
     }
   };
 
   const handleDisconnect = () => {
     setIsConnected(false);
-    setKey(prev => prev + 1);
+    setKey((prev) => prev + 1);
   };
 
   const handleScreenshot = async () => {
@@ -52,13 +52,13 @@ function Demo() {
         <div className="info-box">
           <h4>ℹ️ How to Use:</h4>
           <p>
-            Enter your WebSocket URL and authentication token below, select iOS or Android platform,
-            then click Connect to see the remote control in action. The iOS platform will display
-            a realistic iPhone frame around the stream.
+            Enter your WebSocket URL and authentication token below, select iOS or Android platform, then
+            click Connect to see the remote control in action. The iOS platform will display a realistic
+            iPhone frame around the stream.
           </p>
           <p style={{ marginTop: '10px', fontWeight: 600 }}>
-            ✨ iOS Feature: Touches can start from the bottom bezel area (below the screen, near the 
-            home indicator) to enable authentic iOS swipe-up gestures for going home or switching apps!
+            ✨ iOS Feature: Touches can start from the bottom bezel area (below the screen, near the home
+            indicator) to enable authentic iOS swipe-up gestures for going home or switching apps!
           </p>
         </div>
 
@@ -113,16 +113,11 @@ function Demo() {
           </div>
 
           <div className="button-group">
-            {!isConnected ? (
-              <button 
-                className="primary" 
-                onClick={handleConnect}
-                disabled={!url}
-              >
+            {!isConnected ?
+              <button className="primary" onClick={handleConnect} disabled={!url}>
                 Connect
               </button>
-            ) : (
-              <>
+            : <>
                 <button className="secondary" onClick={handleDisconnect}>
                   Disconnect
                 </button>
@@ -130,18 +125,20 @@ function Demo() {
                   Take Screenshot
                 </button>
               </>
-            )}
+            }
           </div>
         </div>
 
         {showDebugInfo && platform === 'ios' && (
-          <div style={{
-            background: '#e0f2fe',
-            border: '2px solid #0284c7',
-            borderRadius: '8px',
-            padding: '15px',
-            marginBottom: '20px'
-          }}>
+          <div
+            style={{
+              background: '#e0f2fe',
+              border: '2px solid #0284c7',
+              borderRadius: '8px',
+              padding: '15px',
+              marginBottom: '20px',
+            }}
+          >
             <h4 style={{ color: '#0c4a6e', marginBottom: '8px', fontSize: '0.95rem' }}>
               🔧 iOS Extended Touch Area
             </h4>
@@ -155,30 +152,26 @@ function Demo() {
           </div>
         )}
 
-        {isConnected ? (
+        {isConnected ?
           <div className="device-preview">
             <div className="preview-item">
               <h3>{platform === 'ios' ? '📱 iOS with Frame' : '🤖 Android (No Frame)'}</h3>
               <div className="device-wrapper">
-                <RemoteControl
-                  key={key}
-                  ref={remoteControlRef}
-                  url={url}
-                  token={token}
-                />
+                <RemoteControl key={key} ref={remoteControlRef} url={url} token={token} />
               </div>
             </div>
           </div>
-        ) : (
-          <div style={{ 
-            textAlign: 'center', 
-            padding: '60px 20px', 
-            color: '#9ca3af',
-            fontSize: '1.1rem'
-          }}>
+        : <div
+            style={{
+              textAlign: 'center',
+              padding: '60px 20px',
+              color: '#9ca3af',
+              fontSize: '1.1rem',
+            }}
+          >
             Enter your connection details above and click Connect to start
           </div>
-        )}
+        }
       </div>
     </>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes WebRTC/WS reconnection behavior in `RemoteControl`, which can impact session stability and retry loops; new auto-reconnect timing (ICE disconnected grace) may change how quickly drops recover or fail.
> 
> **Overview**
> `RemoteControl` now supports **automatic recovery from post-connect drops** via a new `autoReconnect` prop; when enabled, established-session failures trigger a fresh retry budget instead of surfacing the manual *Retry* button.
> 
> Adds a `reconnect()` method to the imperative `RemoteControlHandle`, and tweaks ICE state handling to retry after a short `disconnected` grace period (clearing timers on teardown/stop) to recover faster.
> 
> Also bumps `@limrun/ui` to `0.8.0` and includes demo/index formatting-only cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3534785d1ae41997452bb8b10bf4e5b2dcb4c42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->