### PR TITLE
Add iOS reverse tunnel support

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "file:../..",
+    "@limrun/api": "0.28.5",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.28.4",
+    "@limrun/api": "file:../..",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",
@@ -48,7 +48,7 @@
     "topicSeparator": " ",
     "topics": {
       "ios": {
-        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, record, perform, simctl, cp, xcrun, xcodebuild, lsof"
+        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, record, perform, simctl, cp, xcrun, xcodebuild, lsof, reverse"
       },
       "android": {
         "description": "Execute any task on remote Android Emulators: create, list, get, delete, connect, screenshot, tap, tap-element, find-element, element-tree, type, press-key, scroll, open-url, install-app, record"

--- a/packages/cli/src/commands/ios/reverse.ts
+++ b/packages/cli/src/commands/ios/reverse.ts
@@ -1,0 +1,104 @@
+import { Args, Flags } from '@oclif/core';
+import type { Ios } from '@limrun/api';
+import { BaseCommand } from '../../base-command';
+import { getIosInstanceClient } from '../../lib/instance-client-factory';
+import { parseReversePortMapping } from '../../lib/reverse-port-mapping';
+
+export default class IosReverse extends BaseCommand {
+  static summary = 'Reverse-forward a simulator port to a local TCP service';
+  static description =
+    'Open a long-lived reverse TCP tunnel so an app in the remote iOS Simulator can connect to LISTEN_IP:remotePort and reach a local service on your machine. Remote ports must be in the reserved Limrun range 57090-57099.';
+  static examples = [
+    '<%= config.bin %> ios reverse 57090:8081 --id <instance-ID>',
+    '<%= config.bin %> ios reverse 57091:3000 --id <instance-ID>',
+    '<%= config.bin %> ios reverse 57090:8081 --local-host 127.0.0.1',
+  ];
+
+  static args = {
+    mapping: Args.string({
+      description: 'Port mapping as <remotePort> or <remotePort>:<localPort>. remotePort must be 57090-57099.',
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description:
+        'iOS instance ID to target. Defaults to the last created iOS instance, but `--id` is recommended for scripts and agents.',
+    }),
+    'local-host': Flags.string({
+      description:
+        'Host for the local service on your machine. Defaults to 127.0.0.1; non-loopback hosts are intended for debugging.',
+      default: '127.0.0.1',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(IosReverse);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const { remotePort, localPort } = parseReversePortMapping(args.mapping);
+      const localHost = flags['local-host'];
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      let tunnel: Ios.ReverseTunnel | undefined;
+
+      try {
+        tunnel = await client.startReverseTunnel({
+          remotePort,
+          localPort,
+          localHost,
+          logLevel: flags.json || flags.quiet ? 'none' : 'info',
+        });
+
+        const ready = {
+          instanceId: resolvedInstance.id,
+          remoteHost: tunnel.remoteAddress.address,
+          remotePort: tunnel.remoteAddress.port,
+          localHost,
+          localPort,
+        };
+
+        if (flags.json) {
+          this.outputJson(ready);
+        } else {
+          this.output(`Remote endpoint: ${ready.remoteHost}:${ready.remotePort}`);
+          this.output(`${ready.remoteHost}:${ready.remotePort} -> ${ready.localHost}:${ready.localPort}`);
+          this.output(`Use ${ready.remoteHost}:${ready.remotePort} from the simulator (for example exp://${ready.remoteHost}:${ready.remotePort}).`);
+          this.info('Reverse tunnel started. Press Ctrl+C to stop.');
+        }
+
+        const activeTunnel: Ios.ReverseTunnel = tunnel;
+        await new Promise<void>((resolve, reject) => {
+          const keepAlive = setInterval(() => {}, 1 << 30);
+          let stopping = false;
+          const cleanup = () => {
+            clearInterval(keepAlive);
+            unsubscribe();
+            process.off('SIGINT', shutdown);
+            process.off('SIGTERM', shutdown);
+          };
+          const shutdown = () => {
+            stopping = true;
+            cleanup();
+            this.info('Stopping reverse tunnel...');
+            resolve();
+          };
+          const unsubscribe = activeTunnel.onConnectionStateChange((state) => {
+            if (state === 'disconnected' && !stopping) {
+              cleanup();
+              reject(new Error('Reverse tunnel disconnected unexpectedly'));
+            }
+          });
+          process.once('SIGINT', shutdown);
+          process.once('SIGTERM', shutdown);
+        });
+      } finally {
+        tunnel?.close();
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/ios/reverse.ts
+++ b/packages/cli/src/commands/ios/reverse.ts
@@ -16,7 +16,8 @@ export default class IosReverse extends BaseCommand {
 
   static args = {
     mapping: Args.string({
-      description: 'Port mapping as <remotePort> or <remotePort>:<localPort>. remotePort must be 57090-57099.',
+      description:
+        'Port mapping as <remotePort> or <remotePort>:<localPort>. remotePort must be 57090-57099.',
       required: true,
     }),
   };
@@ -66,7 +67,9 @@ export default class IosReverse extends BaseCommand {
         } else {
           this.output(`Remote endpoint: ${ready.remoteHost}:${ready.remotePort}`);
           this.output(`${ready.remoteHost}:${ready.remotePort} -> ${ready.localHost}:${ready.localPort}`);
-          this.output(`Use ${ready.remoteHost}:${ready.remotePort} from the simulator (for example exp://${ready.remoteHost}:${ready.remotePort}).`);
+          this.output(
+            `Use ${ready.remoteHost}:${ready.remotePort} from the simulator (for example exp://${ready.remoteHost}:${ready.remotePort}).`,
+          );
           this.info('Reverse tunnel started. Press Ctrl+C to stop.');
         }
 

--- a/packages/cli/src/commands/ios/reverse.ts
+++ b/packages/cli/src/commands/ios/reverse.ts
@@ -5,9 +5,9 @@ import { getIosInstanceClient } from '../../lib/instance-client-factory';
 import { parseReversePortMapping } from '../../lib/reverse-port-mapping';
 
 export default class IosReverse extends BaseCommand {
-  static summary = 'Reverse-forward a simulator port to a local TCP service';
+  static summary = 'Expose a local client-first service to the simulator';
   static description =
-    'Open a long-lived reverse TCP tunnel so an app in the remote iOS Simulator can connect to LISTEN_IP:remotePort and reach a local service on your machine. Remote ports must be in the reserved Limrun range 57090-57099.';
+    'Open a long-lived reverse tunnel so an app in the remote iOS Simulator can connect to LISTEN_IP:remotePort and reach a local client-first service such as an HTTP or WebSocket dev server. Remote ports must be in the reserved Limrun range 57090-57099.';
   static examples = [
     '<%= config.bin %> ios reverse 57090:8081 --id <instance-ID>',
     '<%= config.bin %> ios reverse 57091:3000 --id <instance-ID>',

--- a/packages/cli/src/lib/reverse-port-mapping.ts
+++ b/packages/cli/src/lib/reverse-port-mapping.ts
@@ -1,0 +1,34 @@
+import { Ios } from '@limrun/api';
+
+export type ReversePortMapping = {
+  remotePort: number;
+  localPort: number;
+};
+
+function parsePort(value: string, name: string, min: number, max: number): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${name} must be a number`);
+  }
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < min || port > max) {
+    throw new Error(`${name} must be between ${min} and ${max}`);
+  }
+  return port;
+}
+
+export function parseReversePortMapping(mapping: string): ReversePortMapping {
+  const parts = mapping.split(':');
+  if (parts.length < 1 || parts.length > 2 || parts.some((part) => part.length === 0)) {
+    throw new Error('Mapping must be <remotePort> or <remotePort>:<localPort>');
+  }
+
+  const remotePort = parsePort(
+    parts[0]!,
+    'remotePort',
+    Ios.REVERSE_TUNNEL_REMOTE_PORT_MIN,
+    Ios.REVERSE_TUNNEL_REMOTE_PORT_MAX,
+  );
+  const localPort = parts[1] ? parsePort(parts[1], 'localPort', 1, 65535) : remotePort;
+
+  return { remotePort, localPort };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,6 +10,11 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@limrun/api": ["../../dist/index.d.ts"],
+      "@limrun/api/*": ["../../dist/*.d.ts"]
+    },
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -7,8 +7,8 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@limrun/api@file:../..":
-  version "0.28.4"
+"@limrun/api@0.28.5":
+  version "0.28.5"
   dependencies:
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -7,10 +7,8 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@limrun/api@0.28.4":
+"@limrun/api@file:../..":
   version "0.28.4"
-  resolved "https://registry.npmjs.org/@limrun/api/-/api-0.28.4.tgz#5da2e353160416204cb601c95c2beeae308fea6a"
-  integrity sha512-ZvMvSBKzBneWzTUDV0PFNs22LWAgUY2QEPPlhjyYuNaj7ujktewgDJ0hZ09p1B11H9m+vz9KJOgiWGEjQWeX7w==
   dependencies:
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"

--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -10,14 +10,14 @@
         padding: 0;
         box-sizing: border-box;
       }
-      
+
       body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         min-height: 100vh;
         padding: 20px;
       }
-      
+
       #root {
         display: flex;
         flex-direction: column;
@@ -25,50 +25,50 @@
         max-width: 1400px;
         margin: 0 auto;
       }
-      
+
       .header {
         text-align: center;
         color: white;
         padding: 20px;
       }
-      
+
       .header h1 {
         font-size: 2.5rem;
         margin-bottom: 10px;
         text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
       }
-      
+
       .header p {
         font-size: 1.1rem;
         opacity: 0.9;
       }
-      
+
       .demo-container {
         background: white;
         border-radius: 20px;
         padding: 30px;
         box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
       }
-      
+
       .controls {
         display: flex;
         flex-direction: column;
         gap: 15px;
         margin-bottom: 30px;
       }
-      
+
       .control-group {
         display: flex;
         flex-direction: column;
         gap: 8px;
       }
-      
+
       .control-group label {
         font-weight: 600;
         font-size: 0.9rem;
         color: #374151;
       }
-      
+
       .control-group input,
       .control-group select {
         padding: 10px 15px;
@@ -77,18 +77,18 @@
         font-size: 0.95rem;
         transition: border-color 0.2s;
       }
-      
+
       .control-group input:focus,
       .control-group select:focus {
         outline: none;
         border-color: #667eea;
       }
-      
+
       .button-group {
         display: flex;
         gap: 10px;
       }
-      
+
       button {
         padding: 12px 24px;
         border: none;
@@ -98,52 +98,52 @@
         cursor: pointer;
         transition: all 0.2s;
       }
-      
+
       button.primary {
         background: #667eea;
         color: white;
       }
-      
+
       button.primary:hover {
         background: #5568d3;
         transform: translateY(-1px);
         box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
       }
-      
+
       button.secondary {
         background: #e5e7eb;
         color: #374151;
       }
-      
+
       button.secondary:hover {
         background: #d1d5db;
       }
-      
+
       button:disabled {
         opacity: 0.5;
         cursor: not-allowed;
       }
-      
+
       .device-preview {
         display: flex;
         gap: 30px;
         justify-content: center;
         flex-wrap: wrap;
       }
-      
+
       .preview-item {
         flex: 1 1 420px;
         max-width: 520px;
         height: min(75vh, 900px);
       }
-      
+
       .preview-item h3 {
         text-align: center;
         margin-bottom: 15px;
         font-size: 1.2rem;
         color: #374151;
       }
-      
+
       .device-wrapper {
         height: 100%;
         width: 100%;
@@ -170,7 +170,7 @@
           height: 70vh;
         }
       }
-      
+
       .info-box {
         background: #fef3c7;
         border: 2px solid #fbbf24;
@@ -178,13 +178,13 @@
         padding: 15px;
         margin-bottom: 20px;
       }
-      
+
       .info-box h4 {
         color: #92400e;
         margin-bottom: 8px;
         font-size: 0.95rem;
       }
-      
+
       .info-box p {
         color: #78350f;
         font-size: 0.9rem;

--- a/packages/ui/src/demo.tsx
+++ b/packages/ui/src/demo.tsx
@@ -9,20 +9,20 @@ function Demo() {
   const [isConnected, setIsConnected] = useState(false);
   const [key, setKey] = useState(0);
   const [showDebugInfo, setShowDebugInfo] = useState(false);
-  
+
   const remoteControlRef = useRef<RemoteControlHandle>(null);
 
   const handleConnect = () => {
     if (url) {
       setIsConnected(true);
       // Force remount by changing key
-      setKey(prev => prev + 1);
+      setKey((prev) => prev + 1);
     }
   };
 
   const handleDisconnect = () => {
     setIsConnected(false);
-    setKey(prev => prev + 1);
+    setKey((prev) => prev + 1);
   };
 
   const handleScreenshot = async () => {
@@ -52,13 +52,13 @@ function Demo() {
         <div className="info-box">
           <h4>ℹ️ How to Use:</h4>
           <p>
-            Enter your WebSocket URL and authentication token below, select iOS or Android platform,
-            then click Connect to see the remote control in action. The iOS platform will display
-            a realistic iPhone frame around the stream.
+            Enter your WebSocket URL and authentication token below, select iOS or Android platform, then
+            click Connect to see the remote control in action. The iOS platform will display a realistic
+            iPhone frame around the stream.
           </p>
           <p style={{ marginTop: '10px', fontWeight: 600 }}>
-            ✨ iOS Feature: Touches can start from the bottom bezel area (below the screen, near the 
-            home indicator) to enable authentic iOS swipe-up gestures for going home or switching apps!
+            ✨ iOS Feature: Touches can start from the bottom bezel area (below the screen, near the home
+            indicator) to enable authentic iOS swipe-up gestures for going home or switching apps!
           </p>
         </div>
 
@@ -113,16 +113,11 @@ function Demo() {
           </div>
 
           <div className="button-group">
-            {!isConnected ? (
-              <button 
-                className="primary" 
-                onClick={handleConnect}
-                disabled={!url}
-              >
+            {!isConnected ?
+              <button className="primary" onClick={handleConnect} disabled={!url}>
                 Connect
               </button>
-            ) : (
-              <>
+            : <>
                 <button className="secondary" onClick={handleDisconnect}>
                   Disconnect
                 </button>
@@ -130,18 +125,20 @@ function Demo() {
                   Take Screenshot
                 </button>
               </>
-            )}
+            }
           </div>
         </div>
 
         {showDebugInfo && platform === 'ios' && (
-          <div style={{
-            background: '#e0f2fe',
-            border: '2px solid #0284c7',
-            borderRadius: '8px',
-            padding: '15px',
-            marginBottom: '20px'
-          }}>
+          <div
+            style={{
+              background: '#e0f2fe',
+              border: '2px solid #0284c7',
+              borderRadius: '8px',
+              padding: '15px',
+              marginBottom: '20px',
+            }}
+          >
             <h4 style={{ color: '#0c4a6e', marginBottom: '8px', fontSize: '0.95rem' }}>
               🔧 iOS Extended Touch Area
             </h4>
@@ -155,30 +152,26 @@ function Demo() {
           </div>
         )}
 
-        {isConnected ? (
+        {isConnected ?
           <div className="device-preview">
             <div className="preview-item">
               <h3>{platform === 'ios' ? '📱 iOS with Frame' : '🤖 Android (No Frame)'}</h3>
               <div className="device-wrapper">
-                <RemoteControl
-                  key={key}
-                  ref={remoteControlRef}
-                  url={url}
-                  token={token}
-                />
+                <RemoteControl key={key} ref={remoteControlRef} url={url} token={token} />
               </div>
             </div>
           </div>
-        ) : (
-          <div style={{ 
-            textAlign: 'center', 
-            padding: '60px 20px', 
-            color: '#9ca3af',
-            fontSize: '1.1rem'
-          }}>
+        : <div
+            style={{
+              textAlign: 'center',
+              padding: '60px 20px',
+              color: '#9ca3af',
+              fontSize: '1.1rem',
+            }}
+          >
             Enter your connection details above and click Connect to start
           </div>
-        )}
+        }
       </div>
     </>
   );

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import { WebSocket, Data } from 'ws';
 import { EventEmitter } from 'events';
-import { isNonRetryableError } from './tunnel';
+import { assertPort, isNonRetryableError, startReverseTcpTunnel, type ReverseTunnel } from './tunnel';
 import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './folder-sync';
 import { createIgnoreFn } from './folder-sync-ignore';
 import { downloadFileToLocalPath } from './internal/download-file';
@@ -21,10 +21,30 @@ export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'rec
 export type ConnectionStateCallback = (state: ConnectionState) => void;
 
 const ACTIVE_RECORDING_FILENAME = 'recording.mp4';
+export const REVERSE_TUNNEL_REMOTE_PORT_MIN = 57090;
+export const REVERSE_TUNNEL_REMOTE_PORT_MAX = 57099;
 
 function buildDownloadUrl(apiUrl: string): string {
   return `${apiUrl}/files?name=${encodeURIComponent(ACTIVE_RECORDING_FILENAME)}`;
 }
+
+export function deriveReverseTunnelUrl(apiUrl: string, remotePort: number): string {
+  const url = new URL(apiUrl);
+  if (url.protocol === 'https:') {
+    url.protocol = 'wss:';
+  } else if (url.protocol === 'http:') {
+    url.protocol = 'ws:';
+  } else {
+    throw new Error(`Unsupported apiUrl protocol for reverse tunnel: ${url.protocol}`);
+  }
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/reverse-tunnel`;
+  url.search = '';
+  url.hash = '';
+  url.searchParams.set('remotePort', String(remotePort));
+  return url.toString();
+}
+
+export type { ReverseTunnel } from './tunnel';
 
 /**
  * Events emitted by a simctl execution
@@ -242,6 +262,17 @@ export type SoftResetResult = {
   itemsCleared?: number;
   /** Wall-clock duration of the reset on the server. */
   durationMs: number;
+};
+
+export type ReverseTunnelOptions = {
+  /** Port to listen on near the simulator. Must be in 57090-57099. */
+  remotePort: number;
+  /** Local port on the user's machine. Defaults to remotePort. */
+  localPort?: number;
+  /** Local host on the user's machine. Defaults to 127.0.0.1. */
+  localHost?: string;
+  /** Controls tunnel logging verbosity. Defaults to the instance client's log level. */
+  logLevel?: LogLevel;
 };
 
 /**
@@ -624,6 +655,12 @@ export type InstanceClient = {
    *   missing for `strategy: 'full'` (409), or the request is malformed (400).
    */
   softReset: (bundleId: string, options?: SoftResetOptions) => Promise<SoftResetResult>;
+
+  /**
+   * Start a reverse TCP tunnel from the simulator-facing LISTEN_IP:remotePort
+   * to a user-local TCP service.
+   */
+  startReverseTunnel: (options: ReverseTunnelOptions) => Promise<ReverseTunnel>;
 
   /**
    * Disconnect from the Limrun instance
@@ -1552,6 +1589,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             clearStoreKitConfig,
             discoverStoreKitConfig,
             softReset,
+            startReverseTunnel,
             disconnect,
             getConnectionState,
             onConnectionStateChange,
@@ -2016,6 +2054,24 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         out.itemsCleared = result.itemsCleared;
       }
       return out;
+    };
+
+    const startReverseTunnel = async (tunnelOptions: ReverseTunnelOptions): Promise<ReverseTunnel> => {
+      assertPort(
+        tunnelOptions.remotePort,
+        'remotePort',
+        REVERSE_TUNNEL_REMOTE_PORT_MIN,
+        REVERSE_TUNNEL_REMOTE_PORT_MAX,
+      );
+      const localPort = tunnelOptions.localPort ?? tunnelOptions.remotePort;
+      assertPort(localPort, 'localPort', 1, 65535);
+
+      const remoteURL = deriveReverseTunnelUrl(options.apiUrl, tunnelOptions.remotePort);
+      return startReverseTcpTunnel(remoteURL, options.token, {
+        localHost: tunnelOptions.localHost ?? '127.0.0.1',
+        localPort,
+        logLevel: tunnelOptions.logLevel ?? logLevel,
+      });
     };
 
     const disconnect = (): void => {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -267,7 +267,7 @@ export type SoftResetResult = {
 export type ReverseTunnelOptions = {
   /** Port to listen on near the simulator. Must be in 57090-57099. */
   remotePort: number;
-  /** Local port on the user's machine. Defaults to remotePort. */
+  /** Local port for a client-first service on the user's machine. Defaults to remotePort. */
   localPort?: number;
   /** Local host on the user's machine. Defaults to 127.0.0.1. */
   localHost?: string;
@@ -657,8 +657,8 @@ export type InstanceClient = {
   softReset: (bundleId: string, options?: SoftResetOptions) => Promise<SoftResetResult>;
 
   /**
-   * Start a reverse TCP tunnel from the simulator-facing LISTEN_IP:remotePort
-   * to a user-local TCP service.
+   * Start a reverse tunnel from the simulator-facing LISTEN_IP:remotePort
+   * to a user-local client-first TCP service, such as HTTP or WebSocket.
    */
   startReverseTunnel: (options: ReverseTunnelOptions) => Promise<ReverseTunnel>;
 

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -42,6 +42,16 @@ export interface Tunnel {
   onConnectionStateChange: (callback: TunnelConnectionStateCallback) => () => void;
 }
 
+export interface ReverseTunnel {
+  remoteAddress: {
+    address: string;
+    port: number;
+  };
+  close: () => void;
+  getConnectionState: () => TunnelConnectionState;
+  onConnectionStateChange: (callback: TunnelConnectionStateCallback) => () => void;
+}
+
 export interface TcpTunnelOptions {
   /**
    * Maximum number of reconnection attempts
@@ -71,6 +81,38 @@ export interface TcpTunnelOptions {
    * @default 'singleton'
    */
   mode?: TunnelMode;
+}
+
+export interface ReverseTcpTunnelOptions {
+  /**
+   * Hostname or IP address of the user-local service.
+   * @default '127.0.0.1'
+   */
+  localHost?: string;
+  /**
+   * Port of the user-local service.
+   */
+  localPort: number;
+  /**
+   * Controls logging verbosity
+   * @default 'info'
+   */
+  logLevel?: LogLevel;
+  /**
+   * Maximum concurrent remote TCP connections.
+   * @default 64
+   */
+  maxConnections?: number;
+  /**
+   * Maximum bytes buffered per connection while the local TCP connect is pending.
+   * @default 16777216
+   */
+  maxPendingBytesPerConnection?: number;
+  /**
+   * Local TCP connect timeout in milliseconds.
+   * @default 10000
+   */
+  connectTimeoutMs?: number;
 }
 
 /**
@@ -103,6 +145,376 @@ export async function startTcpTunnel(
   }
 
   return startSingletonTcpTunnel(remoteURL, token, hostname, port, options);
+}
+
+/**
+ * Starts a reverse TCP tunnel.
+ *
+ * The remote endpoint accepts TCP connections near the simulator and sends them
+ * through `remoteURL` as multiplexed WebSocket frames. For each remote connID,
+ * this client opens a TCP connection to `localHost:localPort` on the user's
+ * machine and pipes bytes in both directions.
+ */
+export async function startReverseTcpTunnel(
+  remoteURL: string,
+  token: string,
+  options: ReverseTcpTunnelOptions,
+): Promise<ReverseTunnel> {
+  assertPort(options.localPort, 'localPort', 1, 65535);
+
+  const localHost = options.localHost ?? '127.0.0.1';
+  const localPort = options.localPort;
+  const logLevel = options.logLevel ?? 'info';
+  const maxConnections = options.maxConnections ?? 64;
+  const maxPendingBytesPerConnection = options.maxPendingBytesPerConnection ?? 16 * 1024 * 1024;
+  const connectTimeoutMs = options.connectTimeoutMs ?? 10_000;
+
+  const logger = {
+    debug: (...args: any[]) => {
+      if (logLevel === 'debug') console.log('[ReverseTunnel]', ...args);
+    },
+    info: (...args: any[]) => {
+      if (logLevel === 'info' || logLevel === 'debug') console.log('[ReverseTunnel]', ...args);
+    },
+    warn: (...args: any[]) => {
+      if (logLevel === 'warn' || logLevel === 'info' || logLevel === 'debug')
+        console.warn('[ReverseTunnel]', ...args);
+    },
+    error: (...args: any[]) => {
+      if (logLevel !== 'none') console.error('[ReverseTunnel]', ...args);
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const connections: Map<number, net.Socket> = new Map();
+    const connecting: Set<number> = new Set();
+    const pendingPerConn: Map<number, Buffer[]> = new Map();
+    const pendingBytesPerConn: Map<number, number> = new Map();
+    const connectTimers: Map<number, NodeJS.Timeout> = new Map();
+    const closedConnIds: Set<number> = new Set();
+    const stateChangeCallbacks: Set<TunnelConnectionStateCallback> = new Set();
+
+    let ws: WebSocket | undefined;
+    let pingInterval: NodeJS.Timeout | undefined;
+    let intentionalDisconnect = false;
+    let connectionState: TunnelConnectionState = 'connecting';
+    let hasResolved = false;
+    let remoteAddress: ReverseTunnel['remoteAddress'] | undefined;
+
+    const updateConnectionState = (newState: TunnelConnectionState): void => {
+      if (connectionState !== newState) {
+        connectionState = newState;
+        logger.debug(`Connection state changed to: ${newState}`);
+        stateChangeCallbacks.forEach((callback) => {
+          try {
+            callback(newState);
+          } catch (err) {
+            logger.error('Error in connection state callback:', err);
+          }
+        });
+      }
+    };
+
+    const sendCloseSignal = (connId: number): void => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(encodeConnectionHeader(connId));
+      }
+    };
+
+    const removeConnection = (connId: number, sendClose: boolean, graceful = false): void => {
+      const socket = connections.get(connId);
+      const connectTimer = connectTimers.get(connId);
+      connections.delete(connId);
+      connecting.delete(connId);
+      pendingPerConn.delete(connId);
+      pendingBytesPerConn.delete(connId);
+      connectTimers.delete(connId);
+      closedConnIds.add(connId);
+      if (connectTimer) {
+        clearTimeout(connectTimer);
+      }
+      if (sendClose) {
+        sendCloseSignal(connId);
+      }
+      if (socket && !socket.destroyed) {
+        if (graceful) {
+          socket.end();
+          setTimeout(() => {
+            if (!socket.destroyed) {
+              socket.destroy();
+            }
+          }, 1_000).unref();
+        } else {
+          socket.destroy();
+        }
+      }
+    };
+
+    const closeAllConnections = (): void => {
+      for (const connId of Array.from(connections.keys())) {
+        removeConnection(connId, false);
+      }
+      connections.clear();
+      connecting.clear();
+      pendingPerConn.clear();
+    };
+
+    const cleanupWebSocket = (): void => {
+      if (pingInterval) {
+        clearInterval(pingInterval);
+        pingInterval = undefined;
+      }
+      if (ws) {
+        ws.removeAllListeners();
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close(1000, 'close');
+        }
+        ws = undefined;
+      }
+    };
+
+    const close = (): void => {
+      intentionalDisconnect = true;
+      cleanupWebSocket();
+      closeAllConnections();
+      updateConnectionState('disconnected');
+    };
+
+    const getConnectionState = (): TunnelConnectionState => {
+      return connectionState;
+    };
+
+    const onConnectionStateChange = (callback: TunnelConnectionStateCallback): (() => void) => {
+      stateChangeCallbacks.add(callback);
+      return () => {
+        stateChangeCallbacks.delete(callback);
+      };
+    };
+
+    const resolveReady = (address: ReverseTunnel['remoteAddress']): void => {
+      remoteAddress = address;
+      hasResolved = true;
+      resolve({
+        remoteAddress,
+        close,
+        getConnectionState,
+        onConnectionStateChange,
+      });
+    };
+
+    const rejectStartup = (err: Error): void => {
+      if (!hasResolved) {
+        cleanupWebSocket();
+        closeAllConnections();
+        updateConnectionState('disconnected');
+        reject(err);
+      } else {
+        logger.error(err.message);
+      }
+    };
+
+    const flushPending = (connId: number, socket: net.Socket): void => {
+      const connectTimer = connectTimers.get(connId);
+      if (connectTimer) {
+        clearTimeout(connectTimer);
+        connectTimers.delete(connId);
+      }
+      const pending = pendingPerConn.get(connId) ?? [];
+      pendingPerConn.delete(connId);
+      pendingBytesPerConn.delete(connId);
+      connecting.delete(connId);
+      for (const payload of pending) {
+        socket.write(payload);
+      }
+    };
+
+    const connectLocal = (connId: number, firstPayload: Buffer): void => {
+      if (closedConnIds.has(connId)) {
+        logger.debug(`Ignoring payload for closed conn=${connId}`);
+        return;
+      }
+      if (connections.size >= maxConnections) {
+        logger.warn(`Rejecting reverse tunnel conn=${connId}: max connections reached`);
+        sendCloseSignal(connId);
+        closedConnIds.add(connId);
+        return;
+      }
+      if (firstPayload.length > maxPendingBytesPerConnection) {
+        logger.warn(`Rejecting reverse tunnel conn=${connId}: initial payload exceeds pending byte limit`);
+        sendCloseSignal(connId);
+        closedConnIds.add(connId);
+        return;
+      }
+
+      pendingPerConn.set(connId, [firstPayload]);
+      pendingBytesPerConn.set(connId, firstPayload.length);
+      connecting.add(connId);
+
+      const socket = net.createConnection({ host: localHost, port: localPort });
+      connections.set(connId, socket);
+      const connectTimer = setTimeout(() => {
+        logger.error(`Local TCP connect timed out conn=${connId} after ${connectTimeoutMs}ms`);
+        if (connections.has(connId)) {
+          removeConnection(connId, true);
+        }
+      }, connectTimeoutMs);
+      connectTimer.unref();
+      connectTimers.set(connId, connectTimer);
+
+      socket.on('connect', () => {
+        logger.debug(`Connected conn=${connId} to ${localHost}:${localPort}`);
+        flushPending(connId, socket);
+      });
+
+      socket.on('data', (chunk: Buffer) => {
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(Buffer.concat([encodeConnectionHeader(connId), chunk]), (err) => {
+            if (err) {
+              logger.error(`Failed to send conn=${connId} data: ${err.message}`);
+            }
+          });
+        }
+      });
+
+      socket.on('close', () => {
+        logger.debug(`Local TCP connection closed conn=${connId}`);
+        if (connections.has(connId)) {
+          removeConnection(connId, true);
+        }
+      });
+
+      socket.on('error', (err: Error) => {
+        logger.error(`Local TCP connection error conn=${connId}: ${err.message}`);
+        if (connections.has(connId)) {
+          removeConnection(connId, true);
+        }
+      });
+    };
+
+    const handleBinaryFrame = (buffer: Buffer): void => {
+      if (buffer.length < 4) {
+        logger.error('Received binary frame shorter than 4 bytes; dropping');
+        return;
+      }
+
+      const connId = decodeConnectionHeader(buffer);
+      const payload = buffer.subarray(4);
+
+      if (payload.length === 0) {
+        logger.debug(`Received remote close for conn=${connId}`);
+        removeConnection(connId, false, true);
+        return;
+      }
+      if (closedConnIds.has(connId)) {
+        logger.debug(`Ignoring payload for closed conn=${connId}`);
+        return;
+      }
+
+      const socket = connections.get(connId);
+      if (!socket) {
+        connectLocal(connId, payload);
+        return;
+      }
+
+      if (connecting.has(connId)) {
+        const pending = pendingPerConn.get(connId) ?? [];
+        const pendingBytes = (pendingBytesPerConn.get(connId) ?? 0) + payload.length;
+        if (pendingBytes > maxPendingBytesPerConnection) {
+          logger.warn(`Closing reverse tunnel conn=${connId}: pending byte limit exceeded`);
+          removeConnection(connId, true);
+          return;
+        }
+        pending.push(payload);
+        pendingPerConn.set(connId, pending);
+        pendingBytesPerConn.set(connId, pendingBytes);
+        return;
+      }
+
+      socket.write(payload);
+    };
+
+    const handleControlMessage = (data: any): void => {
+      let parsed: any;
+      try {
+        parsed = JSON.parse(data.toString());
+      } catch {
+        rejectStartup(new Error(`Malformed reverse tunnel control message: ${data.toString()}`));
+        return;
+      }
+
+      if (parsed.type === 'ready') {
+        if (typeof parsed.remoteHost !== 'string' || typeof parsed.remotePort !== 'number') {
+          rejectStartup(new Error(`Malformed reverse tunnel ready message: ${data.toString()}`));
+          return;
+        }
+        logger.info(`Reverse tunnel ready: ${parsed.remoteHost}:${parsed.remotePort}`);
+        updateConnectionState('connected');
+        resolveReady({ address: parsed.remoteHost, port: parsed.remotePort });
+        return;
+      }
+
+      if (parsed.type === 'error') {
+        rejectStartup(new Error(parsed.message || 'Reverse tunnel failed to start'));
+        return;
+      }
+
+      rejectStartup(new Error(`Unexpected reverse tunnel control message type: ${parsed.type}`));
+    };
+
+    const url = new URL(remoteURL);
+    const proxyAgent = nodeProxyTransport.getWebSocketAgent(url.toString());
+    ws = new WebSocket(url.toString(), {
+      headers: { Authorization: `Bearer ${token}` },
+      ...(proxyAgent ? { agent: proxyAgent } : {}),
+      perMessageDeflate: false,
+    });
+
+    ws.on('error', (err: Error) => {
+      logger.error('WebSocket error:', err.message);
+      rejectStartup(err);
+    });
+
+    ws.on('close', (code: number, reason: Buffer) => {
+      if (pingInterval) {
+        clearInterval(pingInterval);
+        pingInterval = undefined;
+      }
+      logger.debug(`WebSocket disconnected (code=${code}, reason=${reason.toString()})`);
+      closeAllConnections();
+      updateConnectionState('disconnected');
+      if (!intentionalDisconnect && !hasResolved) {
+        rejectStartup(new Error(`Reverse tunnel WebSocket closed before ready: ${code} ${reason.toString()}`));
+      }
+    });
+
+    ws.on('open', () => {
+      const socket = ws as WebSocket;
+      logger.debug(`Connected WebSocket to ${url.toString()}`);
+      pingInterval = setInterval(() => {
+        if (socket.readyState === WebSocket.OPEN) {
+          (socket as any).ping();
+        }
+      }, 30_000);
+    });
+
+    ws.on('message', (data: any, isBinary: boolean) => {
+      if (!hasResolved) {
+        if (isBinary) {
+          rejectStartup(new Error('Received reverse tunnel binary frame before ready control message'));
+          return;
+        }
+        handleControlMessage(data);
+        return;
+      }
+
+      if (!isBinary) {
+        logger.warn(`Ignoring unexpected reverse tunnel text message: ${data.toString()}`);
+        return;
+      }
+
+      handleBinaryFrame(Buffer.isBuffer(data) ? data : Array.isArray(data) ? Buffer.concat(data) : Buffer.from(data));
+    });
+  });
 }
 
 /**
@@ -728,6 +1140,12 @@ export const isNonRetryableError = (errMessage: string): boolean => {
   }
   return false;
 };
+
+export function assertPort(port: number, name: string, min: number, max: number): void {
+  if (!Number.isInteger(port) || port < min || port > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+}
 
 /**
  * Encode a 32-bit connection ID as a 4-byte big-endian header

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -148,12 +148,12 @@ export async function startTcpTunnel(
 }
 
 /**
- * Starts a reverse TCP tunnel.
+ * Starts a reverse TCP tunnel for client-first protocols.
  *
  * The remote endpoint accepts TCP connections near the simulator and sends them
  * through `remoteURL` as multiplexed WebSocket frames. For each remote connID,
- * this client opens a TCP connection to `localHost:localPort` on the user's
- * machine and pipes bytes in both directions.
+ * this client opens a TCP connection to `localHost:localPort` after the first
+ * payload arrives, then pipes bytes in both directions.
  */
 export async function startReverseTcpTunnel(
   remoteURL: string,
@@ -346,6 +346,10 @@ export async function startReverseTcpTunnel(
     };
 
     const connectLocal = (connId: number, firstPayload: Buffer): void => {
+      // The current wire protocol has data and close frames, but no explicit
+      // "remote TCP accepted" frame. Connect lazily on first payload, which fits
+      // HTTP/WebSocket dev servers. Server-first protocols need a protocol
+      // extension before this can behave like a transparent TCP forward.
       if (recentlyClosedConnIds.has(connId)) {
         logger.debug(`Ignoring payload for closed conn=${connId}`);
         return;

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -191,7 +191,7 @@ export async function startReverseTcpTunnel(
     const pendingPerConn: Map<number, Buffer[]> = new Map();
     const pendingBytesPerConn: Map<number, number> = new Map();
     const connectTimers: Map<number, NodeJS.Timeout> = new Map();
-    const closedConnIds: Set<number> = new Set();
+    const recentlyClosedConnIds: Map<number, NodeJS.Timeout> = new Map();
     const stateChangeCallbacks: Set<TunnelConnectionStateCallback> = new Set();
 
     let ws: WebSocket | undefined;
@@ -221,6 +221,18 @@ export async function startReverseTcpTunnel(
       }
     };
 
+    const markRecentlyClosed = (connId: number): void => {
+      const existingTimer = recentlyClosedConnIds.get(connId);
+      if (existingTimer) {
+        clearTimeout(existingTimer);
+      }
+      const timer = setTimeout(() => {
+        recentlyClosedConnIds.delete(connId);
+      }, 30_000);
+      timer.unref();
+      recentlyClosedConnIds.set(connId, timer);
+    };
+
     const removeConnection = (connId: number, sendClose: boolean, graceful = false): void => {
       const socket = connections.get(connId);
       const connectTimer = connectTimers.get(connId);
@@ -229,7 +241,7 @@ export async function startReverseTcpTunnel(
       pendingPerConn.delete(connId);
       pendingBytesPerConn.delete(connId);
       connectTimers.delete(connId);
-      closedConnIds.add(connId);
+      markRecentlyClosed(connId);
       if (connectTimer) {
         clearTimeout(connectTimer);
       }
@@ -257,6 +269,11 @@ export async function startReverseTcpTunnel(
       connections.clear();
       connecting.clear();
       pendingPerConn.clear();
+      pendingBytesPerConn.clear();
+      for (const timer of recentlyClosedConnIds.values()) {
+        clearTimeout(timer);
+      }
+      recentlyClosedConnIds.clear();
     };
 
     const cleanupWebSocket = (): void => {
@@ -329,20 +346,20 @@ export async function startReverseTcpTunnel(
     };
 
     const connectLocal = (connId: number, firstPayload: Buffer): void => {
-      if (closedConnIds.has(connId)) {
+      if (recentlyClosedConnIds.has(connId)) {
         logger.debug(`Ignoring payload for closed conn=${connId}`);
         return;
       }
       if (connections.size >= maxConnections) {
         logger.warn(`Rejecting reverse tunnel conn=${connId}: max connections reached`);
         sendCloseSignal(connId);
-        closedConnIds.add(connId);
+        markRecentlyClosed(connId);
         return;
       }
       if (firstPayload.length > maxPendingBytesPerConnection) {
         logger.warn(`Rejecting reverse tunnel conn=${connId}: initial payload exceeds pending byte limit`);
         sendCloseSignal(connId);
-        closedConnIds.add(connId);
+        markRecentlyClosed(connId);
         return;
       }
 
@@ -405,7 +422,7 @@ export async function startReverseTcpTunnel(
         removeConnection(connId, false, true);
         return;
       }
-      if (closedConnIds.has(connId)) {
+      if (recentlyClosedConnIds.has(connId)) {
         logger.debug(`Ignoring payload for closed conn=${connId}`);
         return;
       }
@@ -483,7 +500,9 @@ export async function startReverseTcpTunnel(
       closeAllConnections();
       updateConnectionState('disconnected');
       if (!intentionalDisconnect && !hasResolved) {
-        rejectStartup(new Error(`Reverse tunnel WebSocket closed before ready: ${code} ${reason.toString()}`));
+        rejectStartup(
+          new Error(`Reverse tunnel WebSocket closed before ready: ${code} ${reason.toString()}`),
+        );
       }
     });
 
@@ -512,7 +531,11 @@ export async function startReverseTcpTunnel(
         return;
       }
 
-      handleBinaryFrame(Buffer.isBuffer(data) ? data : Array.isArray(data) ? Buffer.concat(data) : Buffer.from(data));
+      handleBinaryFrame(
+        Buffer.isBuffer(data) ? data
+        : Array.isArray(data) ? Buffer.concat(data)
+        : Buffer.from(data),
+      );
     });
   });
 }

--- a/tests/cli-reverse.test.ts
+++ b/tests/cli-reverse.test.ts
@@ -10,8 +10,12 @@ describe('parseReversePortMapping', () => {
   });
 
   test('rejects empty mapping halves', () => {
-    expect(() => parseReversePortMapping('57090:')).toThrow('Mapping must be <remotePort> or <remotePort>:<localPort>');
-    expect(() => parseReversePortMapping(':8081')).toThrow('Mapping must be <remotePort> or <remotePort>:<localPort>');
+    expect(() => parseReversePortMapping('57090:')).toThrow(
+      'Mapping must be <remotePort> or <remotePort>:<localPort>',
+    );
+    expect(() => parseReversePortMapping(':8081')).toThrow(
+      'Mapping must be <remotePort> or <remotePort>:<localPort>',
+    );
   });
 
   test('rejects mappings with more than two parts', () => {

--- a/tests/cli-reverse.test.ts
+++ b/tests/cli-reverse.test.ts
@@ -1,0 +1,35 @@
+import { parseReversePortMapping } from '../packages/cli/src/lib/reverse-port-mapping';
+
+describe('parseReversePortMapping', () => {
+  test('parses a single remote port as local=remote', () => {
+    expect(parseReversePortMapping('57090')).toEqual({ remotePort: 57090, localPort: 57090 });
+  });
+
+  test('parses explicit remote:local ports', () => {
+    expect(parseReversePortMapping('57090:8081')).toEqual({ remotePort: 57090, localPort: 8081 });
+  });
+
+  test('rejects empty mapping halves', () => {
+    expect(() => parseReversePortMapping('57090:')).toThrow('Mapping must be <remotePort> or <remotePort>:<localPort>');
+    expect(() => parseReversePortMapping(':8081')).toThrow('Mapping must be <remotePort> or <remotePort>:<localPort>');
+  });
+
+  test('rejects mappings with more than two parts', () => {
+    expect(() => parseReversePortMapping('57090:8081:3000')).toThrow(
+      'Mapping must be <remotePort> or <remotePort>:<localPort>',
+    );
+  });
+
+  test('rejects ports below the reserved reverse tunnel range', () => {
+    expect(() => parseReversePortMapping('57089')).toThrow('remotePort must be between 57090 and 57099');
+  });
+
+  test('rejects ports above the reserved reverse tunnel range', () => {
+    expect(() => parseReversePortMapping('57100')).toThrow('remotePort must be between 57090 and 57099');
+  });
+
+  test('rejects non-numeric ports', () => {
+    expect(() => parseReversePortMapping('abc')).toThrow('remotePort must be a number');
+    expect(() => parseReversePortMapping('57090:abc')).toThrow('localPort must be a number');
+  });
+});

--- a/tests/reverse-tunnel.test.ts
+++ b/tests/reverse-tunnel.test.ts
@@ -1,0 +1,22 @@
+import { deriveReverseTunnelUrl } from '../src/ios-client';
+import { decodeConnectionHeader, encodeConnectionHeader } from '../src/tunnel';
+
+describe('reverse tunnel helpers', () => {
+  test('deriveReverseTunnelUrl preserves the iOS api path', () => {
+    expect(deriveReverseTunnelUrl('https://node.example/v1/ios_123/api', 8081)).toBe(
+      'wss://node.example/v1/ios_123/api/reverse-tunnel?remotePort=8081',
+    );
+  });
+
+  test('deriveReverseTunnelUrl clears existing query and hash', () => {
+    expect(deriveReverseTunnelUrl('http://node.example/v1/ios_123/api?token=old#frag', 8099)).toBe(
+      'ws://node.example/v1/ios_123/api/reverse-tunnel?remotePort=8099',
+    );
+  });
+
+  test('connection header round trips uint32 values', () => {
+    for (const connId of [1, 255, 256, 65535, 0xffffffff]) {
+      expect(decodeConnectionHeader(encodeConnectionHeader(connId))).toBe(connId);
+    }
+  });
+});


### PR DESCRIPTION
- Add an iOS reverse TCP tunnel primitive to the SDK so simulator apps can reach local TCP services through the instance WebSocket API.
- Add `lim ios reverse` with reserved remote port validation and long-running tunnel lifecycle handling.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new long-lived reverse TCP tunneling over WebSockets (connection multiplexing, buffering, and lifecycle handling) plus a new CLI command that exposes local services to remote simulators; networking changes can be failure-prone and affect stability.
> 
> **Overview**
> Adds an iOS **reverse TCP tunnel** primitive to the SDK (`startReverseTunnel`, `startReverseTcpTunnel`) so apps running in a remote iOS simulator can reach user-local client-first services (e.g., HTTP/WebSocket dev servers) via a multiplexed WebSocket tunnel, including reserved remote-port enforcement (57090–57099) and new helpers like `deriveReverseTunnelUrl`/`assertPort`.
> 
> Exposes this in the CLI as `lim ios reverse`, including `<remotePort>[:localPort]` parsing/validation, long-running tunnel lifecycle management with SIGINT/SIGTERM handling, and JSON/non-JSON output. Includes unit tests for mapping parsing and reverse-tunnel URL/header helpers, bumps `@limrun/api` to `0.28.5`, and makes minor UI demo formatting tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35d26a00dcc678ef384475b6a55f9583c8aadb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->