### PR TITLE
cli: update limrun ios skill

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"

--- a/packages/cli/skills/limrun-ios/SKILL.md
+++ b/packages/cli/skills/limrun-ios/SKILL.md
@@ -19,6 +19,19 @@ If `lim` CLI is not installed, you can install it with the following:
 npm install --global @limrun/cli
 ```
 
+## Check the CLI for current commands and flags
+
+The CLI is the source of truth for command names, flags, and behavior. Before invoking any `lim` command you have not already used in this session, MUST run its `--help` first. The examples below are happy-path only; this skill intentionally does not embed the full reference because it would rot. Use:
+
+```bash
+lim ios --help                  # list all iOS subcommands
+lim ios <subcommand> --help     # flags and examples for one iOS subcommand
+lim xcode --help                # list all xcode subcommands
+lim xcode <subcommand> --help   # flags and examples for one xcode subcommand
+lim session --help              # list all session subcommands
+lim session <subcommand> --help # flags and examples for one session subcommand
+```
+
 ## Build and Reload
 
 First, create an XCode & iOS Simulator pair:
@@ -46,6 +59,14 @@ lim xcode build .
 
 Use `--scheme` and `--workspace` flags if the project has multiple schemes or uses a workspace file. This makes sure the files are synced with the remote xcode and triggers
 a build where the build logs are streamed through stdout and stderr.
+
+Use `--configuration Debug` or `--configuration Release` when the app needs a specific Xcode build configuration:
+
+```bash
+lim xcode build . --configuration Debug
+```
+
+If omitted, Limrun uses limbuild's project-type default: `Debug` for native Xcode builds and `Release` for React Native / Expo builds. `--dev-server-url` is only supported with `--configuration Debug`.
 
 Every successful build will automatically re-install the app in iOS Simulator and re-launch it.
 
@@ -135,6 +156,8 @@ First build and make remote xcode upload the build:
 ```
 ASSET_NAME="<bundle id/pr number/ or any session identifier>.zip"
 lim xcode build . --upload ${ASSET_NAME}
+# For a debug preview build:
+lim xcode build . --configuration Debug --upload ${ASSET_NAME}
 ```
 
 And construct this link for preview:
@@ -163,158 +186,3 @@ These are common failure points. Check here first when something goes wrong.
 - **`element-tree` can be large.** Pipe through `grep` or `jq` to extract what you need rather than dumping the full tree into context.
 - **Build errors are your job to fix.** If a build fails, read the error output, fix the code, and rebuild. Do not ask the user to fix build errors.
 - **Bundle ID discovery.** If you don't know the bundle ID, check the Xcode project files or run `lim ios list-apps` after a successful build.
-
-## References
-
-```bash
-> lim ios
-Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, record, perform, simctl, cp, xcrun, xcodebuild, lsof
-
-USAGE
-  $ lim ios COMMAND
-
-COMMANDS
-  ios app-log          Stream or tail app logs from a running iOS instance
-  ios cp               Copy a local file into the iOS sandbox
-  ios create           Create a new iOS instance
-  ios delete           Delete an iOS instance
-  ios element-tree     Get the UI element tree from a running iOS instance
-  ios get              Get details for a specific iOS instance
-  ios info             Get device information from a running iOS instance
-  ios install-app      Install an app on a running iOS instance
-  ios launch-app       Launch an app on a running iOS instance
-  ios list             List iOS instances
-  ios list-apps        List installed apps on a running iOS instance
-  ios lsof             List open files on a running iOS instance
-  ios open-url         Open a URL on a running iOS instance
-  ios perform          Perform multiple iOS actions in a single batch
-  ios press-key        Press a key on a running iOS instance
-  ios record           Start or stop video recording on a running iOS instance
-  ios screenshot       Capture the current screen from a running Android instance and save the image to a file.
-  ios scroll           Scroll on a running iOS instance
-  ios simctl           Run simctl on a running iOS instance
-  ios sync             Sync a built app bundle to a running iOS instance
-  ios syslog           Stream syslog from a running iOS instance
-  ios tap              Tap at coordinates on a running iOS instance
-  ios tap-element      Tap an iOS element by accessibility selector
-  ios terminate-app    Terminate an app on a running iOS instance
-  ios toggle-keyboard  Toggle the iOS software keyboard
-  ios type             Type text into the focused iOS input field
-  ios xcodebuild       Run xcodebuild on a running iOS instance
-  ios xcrun            Run xcrun on a running iOS instance
-```
-
-```bash
-> lim ios perform --help
-Perform multiple iOS actions in a single batch
-
-USAGE
-  $ lim ios perform [--api-key <value>] [--json] [--quiet] [--create]
-    [--id <value>] [--action <value>...] [-f <value>] [--timeout <value>]
-
-FLAGS
-  -f, --file=<value>
-      Path to a YAML or JSON file containing an array of action objects.
-
-      JSON example:
-      [
-      { "type": "tap", "x": 100, "y": 200 },
-      { "type": "typeText", "text": "Hello World" }
-      ]
-
-      YAML example:
-      - type: tap
-        x: 100
-        y: 200
-      - type: typeText
-        text: "Hello World"
-
-  --action=<value>...
-      Action definition as comma-separated key=value pairs; repeat for multiple
-      actions.
-
-      Available action types:
-      - Tap on coordinate: type=tap,x=100,y=200
-      - Tap on element by using a selector:
-      type=tapElement,selector={"AXLabel":"Submit"}
-      - Increment an element by using a selector:
-      type=incrementElement,selector={"AXLabel":"Volume"}
-      - Decrement an element by using a selector:
-      type=decrementElement,selector={"AXLabel":"Volume"}
-      - Set an element value by using a selector:
-      type=setElementValue,text=42,selector={"AXLabel":"Counter"}
-      - Type text into the focused field: type=typeText,text=Hello
-      World,pressEnter=true
-      - Press a key with optional modifiers:
-      type=pressKey,key=a,modifiers=["shift"]
-      - Scroll the screen:
-      type=scroll,direction=down,pixels=300,coordinate=[200,400],momentum=0.2
-      - Toggle the software keyboard: type=toggleKeyboard
-      - Open a URL or deep link: type=openUrl,url=https://example.com
-      - Set device orientation: type=setOrientation,orientation=Landscape
-      - Wait before the next action: type=wait,durationMs=1000
-      - Start a touch gesture: type=touchDown,x=100,y=200
-      - Move a touch gesture: type=touchMove,x=120,y=220
-      - End a touch gesture: type=touchUp,x=120,y=220
-      - Press a raw key code down: type=keyDown,keyCode=4
-      - Release a raw key code: type=keyUp,keyCode=4
-      - Press a hardware button down: type=buttonDown,button=home
-      - Release a hardware button: type=buttonUp,button=home
-
-      Use JSON values for complex fields like selector, modifiers, and coordinate.
-
-  --api-key=<value>
-      [env: LIM_API_KEY] API key to use for this command. Overrides the saved
-      login and can also be provided via LIM_API_KEY.
-
-  --[no-]create
-      Create a replacement instance automatically if the target instance is not
-      found.
-
-  --id=<value>
-      iOS instance ID to target. Defaults to the last created iOS instance.
-
-  --json
-      Output structured JSON instead of human-readable tables or plain text when
-      the command supports it.
-
-  --quiet
-      Suppress intermediate human-readable logs and only emit the final result.
-
-  --timeout=<value>
-      Override the total batch timeout in milliseconds. By default the CLI grows
-      the timeout based on waits and action count.
-
-DESCRIPTION
-  Perform multiple iOS actions in a single batch
-
-  Run a batch of iOS actions in a single CLI invocation using repeated
-  `--action` flags or a JSON/YAML action file. This is the best choice for
-  agent-driven multi-step interactions that should execute without reconnecting
-  between steps.
-
-EXAMPLES
-  $ lim ios perform --action type=tap,x=100,y=200 --action "type=typeText,text=Hello World"
-
-  $ lim ios perform --action type=wait,durationMs=1000 --action type=pressKey,key=enter
-
-  $ lim ios perform --file ./actions.yaml
-```
-
-```bash
-> lim xcode
-Execute any task on remote XCode sandboxes: create, list, get, delete, sync, build, attach-simulator
-
-USAGE
-  $ lim xcode COMMAND
-
-COMMANDS
-  xcode attach-simulator  Attach an iOS simulator to an Xcode instance
-  xcode build             Run xcodebuild on an Xcode sandbox
-  xcode create            Create a new Xcode instance
-  xcode delete            Delete an Xcode instance
-  xcode get               Get details for a specific Xcode instance
-  xcode list              List Xcode instances
-  xcode sync              Continuously sync local source code to an Xcode
-                          sandbox
-```

--- a/packages/cli/skills/limrun-ios/SKILL.md
+++ b/packages/cli/skills/limrun-ios/SKILL.md
@@ -21,7 +21,7 @@ npm install --global @limrun/cli
 
 ## Check the CLI for current commands and flags
 
-The CLI is the source of truth for command names, flags, and behavior. Before invoking any `lim` command you have not already used in this session, MUST run its `--help` first. The examples below are happy-path only; this skill intentionally does not embed the full reference because it would rot. Use:
+The CLI is the source of truth for command names, flags, and behavior. Before invoking any `lim` command you have not already used in this session, MUST run its `--help` first. Use:
 
 ```bash
 lim ios --help                  # list all iOS subcommands


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/skill instructions plus a patch version bump, with no runtime logic changes.
> 
> **Overview**
> Updates the `limrun-ios` skill documentation to require checking `lim ... --help` before using commands, and adds guidance/examples for `lim xcode build` `--configuration` usage (including debug preview uploads and notes about defaults/`--dev-server-url`).
> 
> Removes the large embedded command-reference appendix from `SKILL.md`, and bumps `@limrun/cli` from `0.8.1` to `0.8.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff0dd7caf41287f9109fab7a7252bd2447b6125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->