### PR TITLE
limrun/ui: add AX Tree overlay components

### DIFF
--- a/examples/fullstack/frontend/package.json
+++ b/examples/fullstack/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@limrun/ui": "^0.7.0",
+    "@limrun/ui": "file:../../../packages/ui",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "spark-md5": "^3.0.2"

--- a/examples/fullstack/frontend/vite.config.ts
+++ b/examples/fullstack/frontend/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // The `@limrun/ui` file: install ships its own react in node_modules; force
+  // a single copy so hooks see the right dispatcher.
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,9 @@
     "build": "tsc && vite build",
     "prepublishOnly": "npm run build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "repository": {
     "type": "git",
@@ -32,12 +34,14 @@
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react-swc": "^4.0.1",
+    "jsdom": "^26.0.0",
     "path": "^0.12.7",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "vite": "^7.1.4",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-lib-inject-css": "^2.2.2"
+    "vite-plugin-lib-inject-css": "^2.2.2",
+    "vitest": "^2.1.9"
   },
   "dependencies": {
     "clsx": "^2.1.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui/src/components/inspect-overlay.css
+++ b/packages/ui/src/components/inspect-overlay.css
@@ -1,0 +1,223 @@
+.rc-inspect-overlay {
+  position: absolute;
+  z-index: 25;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.rc-inspect-overlay-select {
+  /* When click-to-select is enabled, the container also captures clicks
+     that fall outside any box so we can clear selection. */
+  pointer-events: auto;
+}
+
+.rc-inspect-box {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1px solid rgba(64, 169, 255, 0.55);
+  background: rgba(64, 169, 255, 0.06);
+  border-radius: 2px;
+  cursor: pointer;
+  pointer-events: none;
+  transition:
+    border-color 80ms ease,
+    border-width 80ms ease,
+    background-color 80ms ease;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  outline: none;
+}
+
+.rc-inspect-overlay-select .rc-inspect-box {
+  pointer-events: auto;
+}
+
+.rc-inspect-box-disabled {
+  opacity: 0.55;
+}
+
+.rc-inspect-box[data-highlighted='true'] {
+  border-color: rgba(255, 197, 28, 0.95);
+  border-width: 1.5px;
+  background: rgba(255, 197, 28, 0.16);
+  z-index: 1;
+}
+
+.rc-inspect-box[data-selected='true'] {
+  border-color: rgba(0, 122, 255, 1);
+  border-width: 2px;
+  background: rgba(0, 122, 255, 0.22);
+  z-index: 2;
+}
+
+.rc-inspect-card {
+  /* Card is rendered via React portal to document.body so it can escape
+     any ancestor overflow:hidden (e.g. customer-provided .device-wrapper
+     in our demo). Coordinates passed in via inline style are
+     viewport-absolute. */
+  position: fixed;
+  z-index: 2147483600;
+  pointer-events: auto;
+  background: rgba(22, 24, 30, 0.97);
+  color: #f5f5f7;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 9px 11px 11px;
+  min-width: 200px;
+  max-width: 260px;
+  /* Cap card height. Anything longer scrolls inside the card instead of
+     pushing the viewport. */
+  max-height: 220px;
+  overflow-y: auto;
+  box-shadow:
+    0 12px 36px rgba(0, 0, 0, 0.4),
+    0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  scrollbar-width: thin;
+}
+
+.rc-inspect-card-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.rc-inspect-card-role {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(245, 245, 247, 0.55);
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.rc-inspect-card-tag {
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(245, 245, 247, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.rc-inspect-card-tag-blue {
+  background: rgba(10, 132, 255, 0.18);
+  border-color: rgba(10, 132, 255, 0.45);
+  color: rgb(140, 195, 255);
+}
+
+.rc-inspect-card-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #fff;
+  margin: 0 0 7px;
+  word-break: break-word;
+  /* Clamp to 2 lines so a paragraph-long AXLabel doesn't take over. The
+     full text is available on hover via the title attribute and via the
+     value/id rows below. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.rc-inspect-card-row {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-size: 10.5px;
+  color: rgba(245, 245, 247, 0.72);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  margin: 1px 0;
+  min-width: 0;
+}
+
+.rc-inspect-card-row-label {
+  color: rgba(245, 245, 247, 0.42);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.rc-inspect-card-row-value {
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+  /* Clamp long values (selectors, IDs) to two lines, full value visible
+     via the row's title attr or via "Copy" action. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.rc-inspect-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.rc-inspect-card-btn {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5f5f7;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 4px 9px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background-color 100ms ease,
+    border-color 100ms ease,
+    color 100ms ease;
+}
+
+.rc-inspect-card-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.rc-inspect-card-btn:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.rc-inspect-card-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.rc-inspect-card-btn-primary {
+  background: rgba(0, 122, 255, 0.85);
+  border-color: rgba(0, 122, 255, 0.9);
+  color: #fff;
+}
+
+.rc-inspect-card-btn-primary:hover:not(:disabled) {
+  background: rgba(10, 132, 255, 1);
+  border-color: rgba(10, 132, 255, 1);
+}
+
+.rc-inspect-card-btn-copied {
+  background: rgba(48, 209, 88, 0.22);
+  border-color: rgba(48, 209, 88, 0.55);
+  color: rgb(159, 240, 178);
+}

--- a/packages/ui/src/components/inspect-overlay.tsx
+++ b/packages/ui/src/components/inspect-overlay.tsx
@@ -1,0 +1,437 @@
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { clsx } from 'clsx';
+import './inspect-overlay.css';
+
+import {
+  AxElement,
+  AxPlatform,
+  AxSnapshot,
+  axElementRoleLabel,
+  axElementSelectorExpression,
+  axElementSummary,
+  axElementsEqual,
+  clampAxFrameForScreen,
+} from '../core/ax-tree';
+
+// Geometry of the rendered video content inside the RemoteControl container,
+// after object-fit:contain letterboxing. All values are in container-local
+// pixels (relative to .rc-container's content box) so the overlay boxes line
+// up with the video.
+//
+// The InfoCard uses pointer-event coordinates (clientX/clientY) directly for
+// its viewport-fixed placement and does NOT need any geometry — the boxes
+// are the only thing geometry-locked.
+export interface InspectOverlayGeometry {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export type InspectMode = 'select' | 'hover-only';
+
+export interface InspectOverlayProps {
+  snapshot: AxSnapshot | null;
+  geometry: InspectOverlayGeometry | null;
+  highlightedId: string | null;
+  selectedId: string | null;
+  mode: InspectMode;
+  // Current pointer position in viewport coordinates (clientX/Y). Drives the
+  // cursor-anchored preview card while hovering. null when the pointer is
+  // outside the device.
+  cursorPosition: { x: number; y: number } | null;
+  // Position where the selection was made (viewport coords). The card stays
+  // anchored here once an element is selected so the user can interact with
+  // its action buttons.
+  frozenCursorPosition: { x: number; y: number } | null;
+  // Selection callback. `clickPosition` is the viewport-space pointer
+  // position at the moment of the click; pass null to clear selection.
+  onSelectChange: (element: AxElement | null, clickPosition?: { x: number; y: number } | null) => void;
+  // Called when the user presses "Tap" in the info card. `tapAt` is the
+  // viewport-space pointer position the user originally aimed at (i.e. the
+  // frozen click position) so we can tap that exact spot instead of an
+  // averaged center.
+  onTapElement: (element: AxElement, tapAt: { x: number; y: number }) => void;
+}
+
+const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (!text) return false;
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the textarea fallback.
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Single element box
+// ────────────────────────────────────────────────────────────────────────────
+
+interface InspectBoxProps {
+  element: AxElement;
+  screen: { width: number; height: number };
+  highlighted: boolean;
+  selected: boolean;
+  selectable: boolean;
+  onClick: (element: AxElement, clickPosition: { x: number; y: number }) => void;
+}
+
+const InspectBox = memo(
+  function InspectBox({ element, screen, highlighted, selected, selectable, onClick }: InspectBoxProps) {
+    const visible = clampAxFrameForScreen(element.frame, screen);
+    if (!visible) return null;
+    const summary = axElementSummary(element);
+    return (
+      <button
+        type="button"
+        className={clsx('rc-inspect-box', !element.enabled && 'rc-inspect-box-disabled')}
+        data-ax-id={element.id}
+        data-ax-path={element.path}
+        data-ax-label={element.label || undefined}
+        data-ax-role={element.role || undefined}
+        data-highlighted={highlighted ? 'true' : 'false'}
+        data-selected={selected ? 'true' : 'false'}
+        aria-label={summary}
+        // No onMouseEnter/Leave or `title` attr here — hover state is driven
+        // by JS hit-testing in RemoteControl's handleInteraction (single
+        // source of truth that handles overlapping boxes deterministically),
+        // and the InfoCard already shows all the info the title would.
+        onClick={(e) => {
+          if (!selectable) return;
+          e.preventDefault();
+          e.stopPropagation();
+          onClick(element, { x: e.clientX, y: e.clientY });
+        }}
+        style={{
+          left: `${(visible.x / screen.width) * 100}%`,
+          top: `${(visible.y / screen.height) * 100}%`,
+          width: `${(visible.width / screen.width) * 100}%`,
+          height: `${(visible.height / screen.height) * 100}%`,
+        }}
+      />
+    );
+  },
+  (prev, next) =>
+    prev.highlighted === next.highlighted &&
+    prev.selected === next.selected &&
+    prev.selectable === next.selectable &&
+    prev.screen.width === next.screen.width &&
+    prev.screen.height === next.screen.height &&
+    prev.onClick === next.onClick &&
+    axElementsEqual(prev.element, next.element),
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Info card (shown next to the focus element)
+// ────────────────────────────────────────────────────────────────────────────
+
+interface InfoCardProps {
+  element: AxElement;
+  platform: AxPlatform;
+  // Viewport-coordinate anchor used to position the card. When cursorAnchored
+  // is true the card sits at top-right of `anchor` and follows the cursor.
+  // When false the card stays put at `anchor` (frozen on selection).
+  anchor: { x: number; y: number };
+  cursorAnchored: boolean;
+  showActions: boolean;
+  // Receives the element AND the viewport-space coordinate to tap at
+  // (the frozen click position). Tapping at the click point — rather than
+  // the element's frame center — preserves the user's aim when the
+  // selected element is a container whose children are not exposed by the
+  // accessibility tree (e.g. iOS UITabBar's button children).
+  onTap: (element: AxElement, tapAt: { x: number; y: number }) => void;
+}
+
+// Upper bounds used only for "does the card fit on this side?" decisions.
+// We do NOT use these to compute the actual top/left coordinates — see the
+// CSS-transform-based placement below. Matches the CSS max-width /
+// max-height so flip decisions stay accurate even when the card is at its
+// largest (selected state with all action buttons visible).
+const INFO_CARD_ESTIMATED_WIDTH = 260;
+const INFO_CARD_ESTIMATED_HEIGHT = 220;
+// Gap between the cursor and the nearest card edge. Tight enough that the
+// card visibly "hangs" off the cursor, but not so tight that the OS pointer
+// arrow visually overlaps the card border.
+const CURSOR_OFFSET = 6;
+// Distance from the window edge we try to maintain so the card never gets
+// flush against the page chrome.
+const VIEWPORT_PADDING = 8;
+
+const InfoCard = memo(function InfoCard({
+  element,
+  platform,
+  anchor,
+  cursorAnchored,
+  showActions,
+  onTap,
+}: InfoCardProps) {
+  const [copied, setCopied] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = window.setTimeout(() => setCopied(null), 1100);
+    return () => window.clearTimeout(t);
+  }, [copied]);
+
+  // Anchor the nearest card corner exactly CURSOR_OFFSET px from the cursor
+  // using CSS transforms. By offsetting the card's coordinate by ±100% on
+  // each axis as needed, we don't need to know the card's actual rendered
+  // height/width — the corner that's nearest to the cursor sits at a known
+  // distance regardless of card content. This solves the "huge gap" issue
+  // that arises when the card content is much smaller than the assumed
+  // worst-case height.
+  //
+  // Default: card's bottom-left corner sits to the top-right of the cursor
+  // (so the card "hangs" off the cursor up-and-right, similar to system
+  // tooltips). Flips to bottom-right if no room to the right, top-left if
+  // no room above, and bottom-right if no room above-or-right.
+  const cardStyle = useMemo<React.CSSProperties>(() => {
+    const W = INFO_CARD_ESTIMATED_WIDTH;
+    const H = INFO_CARD_ESTIMATED_HEIGHT;
+    const O = CURSOR_OFFSET;
+    const P = VIEWPORT_PADDING;
+
+    const viewportW = typeof window !== 'undefined' ? window.innerWidth : 1024;
+    const viewportH = typeof window !== 'undefined' ? window.innerHeight : 768;
+
+    // Decide which quadrant of the cursor the card sits in. Use the
+    // estimated max dimensions as the worst-case footprint when checking
+    // for room.
+    const placeRight = anchor.x + O + W <= viewportW - P;
+    const placeAbove = anchor.y - O - H >= P;
+
+    let left = placeRight ? anchor.x + O : anchor.x - O;
+    let top = placeAbove ? anchor.y - O : anchor.y + O;
+
+    // translate(-100% …) shifts the card by its own measured width/height,
+    // which is what gives us the "corner anchored to cursor" behaviour
+    // without having to know the rendered size in JS.
+    const tx = placeRight ? '0' : '-100%';
+    const ty = placeAbove ? '-100%' : '0';
+    const transform = `translate(${tx}, ${ty})`;
+
+    // Final clamp so the card never escapes the window even on tiny
+    // viewports. Using the estimated dimensions as a safety margin.
+    left = Math.max(P + (placeRight ? 0 : W), Math.min(viewportW - P - (placeRight ? W : 0), left));
+    top = Math.max(P + (placeAbove ? H : 0), Math.min(viewportH - P - (placeAbove ? 0 : H), top));
+
+    return { left: `${left}px`, top: `${top}px`, transform };
+  }, [anchor.x, anchor.y]);
+
+  const selectorExpr = useMemo(() => axElementSelectorExpression(element, platform), [element, platform]);
+  const primaryIdField = platform === 'ios' ? element.selectors.AXUniqueId : element.selectors.resourceId;
+  const primaryIdLabel = platform === 'ios' ? 'AXUniqueId' : 'resourceId';
+
+  const handleCopy = useCallback(async (text: string | undefined, key: string) => {
+    if (!text) return;
+    const ok = await copyToClipboard(text);
+    if (ok) setCopied(key);
+  }, []);
+
+  const roleLabel = axElementRoleLabel(element);
+  // Title shows the element's label (clamped). Falls back to the role when no
+  // label exists so the card never looks empty.
+  const titleText = element.label || element.value || roleLabel;
+  // axElementSummary is used as the full tooltip (truncated to ~80 chars).
+  const fullSummary = axElementSummary(element);
+
+  // We do not guard against SSR here: RemoteControl is fundamentally a
+  // browser-only component (it instantiates RTCPeerConnection in its main
+  // effect), so the InfoCard never gets rendered in a server environment.
+
+  return createPortal(
+    <div
+      className="rc-inspect-card"
+      data-cursor-anchored={cursorAnchored ? 'true' : 'false'}
+      style={cardStyle}
+      // The card sits in document.body but is logically a child of the
+      // overlay React subtree, so events bubble back to rc-container's
+      // mousemove handler. We stop them so hovering the card doesn't make
+      // it chase itself.
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onMouseMove={(e) => e.stopPropagation()}
+    >
+      <div className="rc-inspect-card-header">
+        <span className="rc-inspect-card-role">{roleLabel}</span>
+        {!element.enabled && <span className="rc-inspect-card-tag">disabled</span>}
+        {element.focused && <span className="rc-inspect-card-tag rc-inspect-card-tag-blue">focused</span>}
+      </div>
+      <p className="rc-inspect-card-title" title={fullSummary}>
+        {titleText}
+      </p>
+      {primaryIdField && (
+        <div className="rc-inspect-card-row">
+          <span className="rc-inspect-card-row-label">{primaryIdLabel}:</span>
+          <span className="rc-inspect-card-row-value">{primaryIdField}</span>
+        </div>
+      )}
+      {element.value && element.value !== element.label && (
+        <div className="rc-inspect-card-row">
+          <span className="rc-inspect-card-row-label">value:</span>
+          <span className="rc-inspect-card-row-value">{element.value}</span>
+        </div>
+      )}
+      <div className="rc-inspect-card-row">
+        <span className="rc-inspect-card-row-label">frame:</span>
+        <span className="rc-inspect-card-row-value">
+          {Math.round(element.frame.width)}×{Math.round(element.frame.height)} @ {Math.round(element.frame.x)}
+          ,{Math.round(element.frame.y)}
+        </span>
+      </div>
+      {showActions && (
+        <div className="rc-inspect-card-actions">
+          <button
+            type="button"
+            className="rc-inspect-card-btn rc-inspect-card-btn-primary"
+            onClick={() => onTap(element, anchor)}
+          >
+            Tap
+          </button>
+          <button
+            type="button"
+            className={clsx('rc-inspect-card-btn', copied === 'selector' && 'rc-inspect-card-btn-copied')}
+            disabled={!selectorExpr}
+            title={selectorExpr ?? 'No usable selector for this element'}
+            onClick={() => handleCopy(selectorExpr ?? undefined, 'selector')}
+          >
+            {copied === 'selector' ? 'Copied!' : 'Copy selector'}
+          </button>
+          <button
+            type="button"
+            className={clsx('rc-inspect-card-btn', copied === 'id' && 'rc-inspect-card-btn-copied')}
+            disabled={!primaryIdField}
+            title={primaryIdField ?? `No ${primaryIdLabel}`}
+            onClick={() => handleCopy(primaryIdField, 'id')}
+          >
+            {copied === 'id' ? 'Copied!' : `Copy ${primaryIdLabel}`}
+          </button>
+        </div>
+      )}
+    </div>,
+    document.body,
+  );
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Overlay root
+// ────────────────────────────────────────────────────────────────────────────
+
+export const InspectOverlay = memo(function InspectOverlay({
+  snapshot,
+  geometry,
+  highlightedId,
+  selectedId,
+  mode,
+  cursorPosition,
+  frozenCursorPosition,
+  onSelectChange,
+  onTapElement,
+}: InspectOverlayProps) {
+  const selectable = mode === 'select';
+
+  // Card behaviour:
+  //   - In `hover-only` mode there is no selection. The card always follows
+  //     the cursor and only renders when something is highlighted.
+  //   - In `select` mode the card follows the cursor whenever the user is
+  //     hovering an element OTHER than the currently selected one (preview).
+  //     Hovering the selected element or moving the cursor off any box keeps
+  //     the card frozen at the click position so the action buttons remain
+  //     reachable.
+  const isPreviewingHover =
+    selectable ? highlightedId !== null && highlightedId !== selectedId : highlightedId !== null;
+  const focusId = selectable ? highlightedId ?? selectedId : highlightedId;
+
+  // Build an `id → element` index once per snapshot so focus lookups are O(1)
+  // even on max-size trees. Hooks must run unconditionally — gate rendering
+  // afterwards via the `renderable` check.
+  const elementsById = useMemo(() => {
+    const m = new Map<string, AxElement>();
+    if (!snapshot) return m;
+    for (const el of snapshot.elements) m.set(el.id, el);
+    return m;
+  }, [snapshot]);
+
+  const focusElement = useMemo(() => {
+    if (!focusId) return null;
+    return elementsById.get(focusId) ?? null;
+  }, [focusId, elementsById]);
+
+  // The overlay has nothing to draw until both a snapshot and the device
+  // geometry are available, and the snapshot has at least one usable
+  // element. Conditional rendering goes here — AFTER all hooks — so the
+  // hook-count is stable across the snapshot-arrives-after-mount transition.
+  const renderable =
+    !!snapshot &&
+    !!geometry &&
+    snapshot.screen.width > 0 &&
+    snapshot.screen.height > 0 &&
+    snapshot.elements.length > 0;
+  if (!renderable) return null;
+
+  const anchor = isPreviewingHover ? cursorPosition : frozenCursorPosition ?? cursorPosition;
+  const cursorAnchored = isPreviewingHover;
+  const showActions = selectable && !isPreviewingHover && selectedId !== null;
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    if (!selectable) return;
+    // Click was on the container itself (not a box) — clear selection.
+    if (e.target === e.currentTarget) {
+      onSelectChange(null, null);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className={clsx('rc-inspect-overlay', selectable && 'rc-inspect-overlay-select')}
+        style={{
+          left: `${geometry!.left}px`,
+          top: `${geometry!.top}px`,
+          width: `${geometry!.width}px`,
+          height: `${geometry!.height}px`,
+        }}
+        onClick={handleContainerClick}
+      >
+        {snapshot!.elements.map((element) => (
+          <InspectBox
+            key={element.id}
+            element={element}
+            screen={snapshot!.screen}
+            highlighted={element.id === highlightedId}
+            selected={element.id === selectedId}
+            selectable={selectable}
+            onClick={onSelectChange}
+          />
+        ))}
+      </div>
+      {focusElement && anchor && (
+        <InfoCard
+          element={focusElement}
+          platform={snapshot!.platform}
+          anchor={anchor}
+          cursorAnchored={cursorAnchored}
+          showActions={showActions}
+          onTap={onTapElement}
+        />
+      )}
+    </>
+  );
+});

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -18,6 +18,9 @@ import {
   createSetClipboardMessage,
   createTwoFingerTouchControlMessage,
 } from '../core/webrtc-messages';
+import { AxFetcher, AxStatus } from '../core/ax-fetcher';
+import { AxElement, AxSnapshot, axElementAtPoint, axSnapshotsEqual } from '../core/ax-tree';
+import { InspectOverlay, InspectOverlayGeometry, InspectMode } from './inspect-overlay';
 
 declare global {
   interface Window {
@@ -55,6 +58,88 @@ interface RemoteControlProps {
   // When true, drops after a working session auto-reconnect instead of
   // surfacing the manual "Retry" button. Defaults to false.
   autoReconnect?: boolean;
+
+  /**
+   * Enable the inspect overlay. When set, the component starts polling the
+   * accessibility tree and draws boxes over each element on top of the
+   * video stream.
+   *
+   * - `true` — Select mode. Boxes are clickable, click pins a selection
+   *   with action buttons (Tap / Copy selector / Copy id), ESC clears.
+   *   Device input is blocked while in this mode.
+   * - `'hover-only'` — Boxes follow the cursor as a visual preview. Device
+   *   input still passes through, so you can drive the simulator while
+   *   inspecting.
+   * - `undefined` / `false` (default) — overlay disabled, no polling.
+   */
+  inspectMode?: boolean | 'hover-only';
+
+  /**
+   * Fires whenever a fresh accessibility snapshot is delivered.
+   *
+   * Customers use this to drive their own side panels, agent prompts,
+   * analytics, etc. The built-in overlay does not require this callback —
+   * it renders from internal state regardless.
+   *
+   * Identical-to-previous snapshots (per `axSnapshotsEqual`) are NOT
+   * re-emitted, so a stable UI doesn't generate callback noise.
+   *
+   * Invoked in a microtask so customer code doesn't run synchronously
+   * inside React's commit phase.
+   */
+  onAxSnapshotChange?: (snapshot: AxSnapshot | null) => void;
+
+  /**
+   * Fires when the user clicks an overlay element (only emitted when
+   * `inspectMode === true`). `null` indicates a deselection (ESC, click
+   * outside any box, or programmatic clear).
+   *
+   * The `snapshot` field is the snapshot active at the moment of the
+   * click — useful for capturing context without races against the next
+   * poll cycle.
+   */
+  onInspectSelectionChange?: (selection: { element: AxElement; snapshot: AxSnapshot } | null) => void;
+
+  /**
+   * Fires whenever the accessibility subsystem changes coarse-grained
+   * status. Useful for rendering readiness indicators or error banners in
+   * a customer-built side panel.
+   *
+   * Transitions are deduplicated; no self-loops are emitted. The `error`
+   * argument is populated when status is `error` or `unavailable`.
+   *
+   * Lifecycle: `idle` → `starting` → `ready` (or `unavailable` / `error`).
+   * Recovery from `error` / `unavailable` is automatic — the fetcher
+   * keeps polling and transitions back to `ready` on the next success.
+   */
+  onAxStatusChange?: (status: AxStatus, error?: string) => void;
+
+  /**
+   * Base interval (ms) between successful AX-tree fetches.
+   *
+   * The fetcher will:
+   * - Wait `axPollIntervalMs` after a successful fetch with NEW data.
+   * - Double the wait (up to `axMaxBackoffMs`) when consecutive snapshots
+   *   are byte-identical (e.g. static screen).
+   * - Wait 5 s when the server reports AX is unavailable.
+   *
+   * In addition, after user input (taps, scrolls, keypresses, openUrl,
+   * terminateApp, orientation flips), the fetcher enters a short
+   * "activity boost" window (~1.2 s) during which fetches happen at
+   * ~250 ms regardless of this setting. This captures mid-animation UI
+   * changes without you having to manually call `refreshAxTree`.
+   *
+   * @default 500
+   */
+  axPollIntervalMs?: number;
+
+  /**
+   * Maximum backoff (ms) for the AX-tree polling loop when consecutive
+   * snapshots are unchanged.
+   *
+   * @default 2000
+   */
+  axMaxBackoffMs?: number;
 }
 
 interface ScreenshotData {
@@ -76,6 +161,27 @@ export interface RemoteControlHandle {
   screenshot: () => Promise<ScreenshotData>;
   terminateApp: (bundleId: string) => Promise<void>;
   reconnect: () => void;
+
+  // Inspect-mode helpers. These are no-ops when inspect mode is disabled or
+  // the WebSocket isn't open.
+
+  // Force a fresh accessibility-tree fetch outside the normal poll cadence.
+  refreshAxTree: () => Promise<AxSnapshot>;
+
+  // Pull-based access to the most recent snapshot (the same one passed to
+  // onAxSnapshotChange). Returns null when no snapshot has arrived yet or
+  // when inspect mode is off.
+  getAxSnapshot: () => AxSnapshot | null;
+
+  // Programmatically drive the overlay highlight/selection — useful when a
+  // customer's own side panel wants to cross-highlight with the overlay.
+  // Pass `null` to clear.
+  setInspectHighlight: (element: AxElement | null) => void;
+  setInspectSelection: (element: AxElement | null) => void;
+
+  // Pull-based access to the current AX subsystem status. Mirrors what
+  // onAxStatusChange reports, for customers that don't want to subscribe.
+  getAxStatus: () => AxStatus;
 }
 
 const debugLog = (...args: any[]) => {
@@ -87,6 +193,26 @@ const debugLog = (...args: any[]) => {
 const debugWarn = (...args: any[]) => {
   if (window.debugRemoteControl) {
     console.warn(...args);
+  }
+};
+
+// Invokes a customer-provided callback in isolation. A throw from the
+// customer's code must NOT propagate back into our state-update flow — that
+// would risk corrupting React reconciliation. We log the error to the
+// console so the customer can still debug, but otherwise swallow.
+const safeInvoke = <Args extends unknown[]>(
+  label: string,
+  fn: ((...args: Args) => unknown) | undefined,
+  ...args: Args
+): void => {
+  if (!fn) return;
+  try {
+    fn(...args);
+  } catch (err) {
+    // Surface to the developer regardless of debug flag — this is a bug
+    // in the customer's handler and they'll want to see it.
+    // eslint-disable-next-line no-console
+    console.error(`[RemoteControl] customer callback "${label}" threw:`, err);
   }
 };
 
@@ -206,6 +332,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       openUrl,
       showFrame = true,
       autoReconnect = false,
+      inspectMode,
+      onAxSnapshotChange,
+      onInspectSelectionChange,
+      onAxStatusChange,
+      axPollIntervalMs,
+      axMaxBackoffMs,
     }: RemoteControlProps,
     ref,
   ) => {
@@ -279,6 +411,62 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     };
     const [hoverPoint, setHoverPoint] = useState<HoverPoint | null>(null);
 
+    // Inspect-mode state.
+    //
+    // Lifecycle of `axFetcherRef`:
+    //   - Created in dataChannel.onopen (last step of WebRTC handshake)
+    //     so we know the signaling WS is healthy and the device is
+    //     responsive to control messages.
+    //   - Started immediately if `inspectMode` is already enabled, or
+    //     started later via the sibling useEffect when inspectMode flips on.
+    //   - Stopped + nulled in teardownConnection (WS close / unmount).
+    //
+    // Customers can observe readiness via the `onAxStatusChange` callback:
+    // `starting` fires when start() runs but no snapshot has landed yet;
+    // `ready` once the first snapshot arrives. Status falls back to
+    // `unavailable` / `error` if the server can't satisfy AX requests.
+    const axFetcherRef = useRef<AxFetcher | null>(null);
+    const [axSnapshot, setAxSnapshot] = useState<AxSnapshot | null>(null);
+    const [axHighlightedId, setAxHighlightedId] = useState<string | null>(null);
+    const [axSelectedId, setAxSelectedId] = useState<string | null>(null);
+    const [overlayGeometry, setOverlayGeometry] = useState<InspectOverlayGeometry | null>(null);
+    // Viewport-space cursor position used to anchor the inspect InfoCard.
+    // Throttled to one update per animation frame to avoid React reconciling
+    // on every native mousemove (~60–120Hz).
+    const [axCursorPosition, setAxCursorPosition] = useState<{ x: number; y: number } | null>(null);
+    const cursorPositionRef = useRef<{ x: number; y: number } | null>(null);
+    const cursorRafIdRef = useRef<number | undefined>(undefined);
+    const scheduleCursorFlush = (next: { x: number; y: number } | null) => {
+      cursorPositionRef.current = next;
+      if (cursorRafIdRef.current !== undefined) return;
+      cursorRafIdRef.current = window.requestAnimationFrame(() => {
+        cursorRafIdRef.current = undefined;
+        setAxCursorPosition(cursorPositionRef.current);
+      });
+    };
+    // Position captured at click-time so the InfoCard "freezes" near where
+    // the user clicked, even as they move the cursor around afterward. The
+    // action buttons (Tap / Copy) stay reachable because the card no longer
+    // chases the cursor while the click target is the active selection.
+    const [axFrozenCursorPosition, setAxFrozenCursorPosition] = useState<{
+      x: number;
+      y: number;
+    } | null>(null);
+    // Mirrors for synchronous access from event handlers without stale closures.
+    const inspectModeRef = useRef<boolean | 'hover-only' | undefined>(inspectMode);
+    inspectModeRef.current = inspectMode;
+    const axSnapshotRef = useRef<AxSnapshot | null>(null);
+    axSnapshotRef.current = axSnapshot;
+    const onAxSnapshotChangeRef = useRef(onAxSnapshotChange);
+    onAxSnapshotChangeRef.current = onAxSnapshotChange;
+    const onInspectSelectionChangeRef = useRef(onInspectSelectionChange);
+    onInspectSelectionChangeRef.current = onInspectSelectionChange;
+    const onAxStatusChangeRef = useRef(onAxStatusChange);
+    onAxStatusChangeRef.current = onAxStatusChange;
+
+    const inspectActive = inspectMode === true || inspectMode === 'hover-only';
+    const inspectModeResolved: InspectMode = inspectMode === 'hover-only' ? 'hover-only' : 'select';
+
     const sessionId = useMemo(
       () =>
         propSessionId ||
@@ -299,6 +487,72 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         return;
       }
       dataChannelRef.current.send(data);
+      // Any binary control message is an input event. Bump the AX poller so
+      // we get a fresh snapshot quickly — the UI almost certainly changed.
+      axFetcherRef.current?.bumpActivity();
+    };
+
+    // Pointer ID used by inspect-driven taps. Distinct from human pointers
+    // (-1 mouse, -2 alt-mirror) and our touch identifiers so they never
+    // interfere with an in-progress drag.
+    const AX_TAP_POINTER_ID = -10;
+
+    // Send a down+up tap at a viewport-space (clientX/Y) position. The point
+    // is mapped through the current video letterbox geometry so the
+    // simulator receives the correct in-stream coordinates regardless of
+    // how the device frame is sized in the DOM.
+    const sendTapAtClient = (clientX: number, clientY: number) => {
+      const ctx = computeVideoMappingContext();
+      if (!ctx) return;
+      const geometry = mapClientPointToVideo(ctx, clientX, clientY);
+      if (!geometry) return;
+      const { videoX, videoY, videoWidth, videoHeight } = geometry;
+      const down = createTouchControlMessage(
+        AMOTION_EVENT.ACTION_DOWN,
+        AX_TAP_POINTER_ID,
+        videoWidth,
+        videoHeight,
+        videoX,
+        videoY,
+        1.0,
+        AMOTION_EVENT.BUTTON_PRIMARY,
+        AMOTION_EVENT.BUTTON_PRIMARY,
+      );
+      if (down) sendBinaryControlMessage(down);
+      window.setTimeout(() => {
+        const up = createTouchControlMessage(
+          AMOTION_EVENT.ACTION_UP,
+          AX_TAP_POINTER_ID,
+          videoWidth,
+          videoHeight,
+          videoX,
+          videoY,
+          0,
+          AMOTION_EVENT.BUTTON_PRIMARY,
+          AMOTION_EVENT.BUTTON_PRIMARY,
+        );
+        if (up) sendBinaryControlMessage(up);
+      }, 60);
+    };
+
+    // Center-of-bounds fallback for programmatic taps when there's no
+    // user-aimed click position (e.g. customer calls `setInspectSelection`
+    // followed by their own "tap selected" handler without forwarding a
+    // pointer position). Maps the element's frame center through the AX
+    // screen-coordinate space to viewport coords, then delegates to
+    // sendTapAtClient.
+    const sendTapAtElementCenter = (element: AxElement, snapshot: AxSnapshot) => {
+      const ctx = computeVideoMappingContext();
+      if (!ctx) return;
+      if (snapshot.screen.width <= 0 || snapshot.screen.height <= 0) return;
+      const cxAx = element.frame.x + element.frame.width / 2;
+      const cyAx = element.frame.y + element.frame.height / 2;
+      // AX screen-fraction → in-video pixel offset → viewport client coord.
+      const inVideoX = (cxAx / snapshot.screen.width) * ctx.actualWidth;
+      const inVideoY = (cyAx / snapshot.screen.height) * ctx.actualHeight;
+      const clientX = ctx.videoRect.left + ctx.offsetX + inVideoX;
+      const clientY = ctx.videoRect.top + ctx.offsetY + inVideoY;
+      sendTapAtClient(clientX, clientY);
     };
 
     // Fixed pointer IDs for Alt-simulated two-finger gestures
@@ -688,6 +942,23 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       setHoverPoint(fullPoint);
     };
 
+    // Map clientX/Y to AX screen-coordinate space using the latest snapshot.
+    // Returns null if there's no snapshot or the click is outside the video.
+    const hitTestAxAtClient = (
+      ctx: VideoMappingContext,
+      clientX: number,
+      clientY: number,
+    ): AxElement | null => {
+      const snapshot = axSnapshotRef.current;
+      if (!snapshot || snapshot.screen.width <= 0 || snapshot.screen.height <= 0) return null;
+      const relX = clientX - ctx.videoRect.left - ctx.offsetX;
+      const relY = clientY - ctx.videoRect.top - ctx.offsetY;
+      if (relX < 0 || relY < 0 || relX > ctx.actualWidth || relY > ctx.actualHeight) return null;
+      const axX = (relX / ctx.actualWidth) * snapshot.screen.width;
+      const axY = (relY / ctx.actualHeight) * snapshot.screen.height;
+      return axElementAtPoint(snapshot, axX, axY);
+    };
+
     // Unified handler for both mouse and touch interactions
     const handleInteraction = (event: React.MouseEvent | React.TouchEvent) => {
       event.preventDefault();
@@ -695,6 +966,36 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
 
       // Compute mapping context once per event (reused for all pointers)
       const ctx = computeVideoMappingContext();
+
+      // Inspect-mode handling.
+      //
+      // We use JS hit-testing (not box-level onMouseEnter/Leave) as the
+      // single source of truth for which element is under the cursor — it
+      // handles overlapping rectangles deterministically by picking the
+      // smallest matching box. The overlay's InspectBox children no longer
+      // attach hover handlers; they just paint themselves based on the
+      // `highlightedId` prop driven from here.
+      //
+      // Cursor position is tracked in both modes so the cursor-anchored
+      // InfoCard can follow the pointer.
+      const isInspecting = inspectModeRef.current === true || inspectModeRef.current === 'hover-only';
+      if (isInspecting && !('touches' in event)) {
+        if (event.type === 'mousemove') {
+          scheduleCursorFlush({ x: event.clientX, y: event.clientY });
+          if (ctx) {
+            const hit = hitTestAxAtClient(ctx, event.clientX, event.clientY);
+            setAxHighlightedId(hit?.id ?? null);
+          }
+        } else if (event.type === 'mouseleave') {
+          scheduleCursorFlush(null);
+          setAxHighlightedId(null);
+        }
+      }
+      // Select mode blocks device input — clicks/drags don't reach the
+      // simulator. Hover-only mode falls through to the regular path.
+      if (inspectModeRef.current === true) {
+        return;
+      }
 
       // Handle hover point updates for mouse events (only when Alt is held)
       if (!('touches' in event) && ctx) {
@@ -1138,6 +1439,16 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       clearConnectionSuccessTimeout();
       clearIceDisconnectedGrace();
       stopRequestFrameLoop();
+      if (axFetcherRef.current) {
+        axFetcherRef.current.stop();
+        axFetcherRef.current = null;
+      }
+      // A scheduled cursor flush would otherwise call setState on a
+      // teardown component once the next frame runs.
+      if (cursorRafIdRef.current !== undefined) {
+        window.cancelAnimationFrame(cursorRafIdRef.current);
+        cursorRafIdRef.current = undefined;
+      }
       if (wsRef.current) {
         wsRef.current.onopen = null;
         wsRef.current.onmessage = null;
@@ -1372,6 +1683,44 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           controlChannelOpenedRef.current = true;
           clearConnectionSuccessTimeout();
           updateStatus('Control channel opened');
+
+          // Spin up the AX fetcher now that we have a stable WS + control
+          // channel. The fetcher's send function reuses this WS; it stops
+          // sending if the WS dies. start() is called lazily based on the
+          // inspectMode prop via a sibling useEffect.
+          if (!axFetcherRef.current) {
+            axFetcherRef.current = new AxFetcher({
+              platform,
+              baseIntervalMs: axPollIntervalMs,
+              maxBackoffMs: axMaxBackoffMs,
+              send: (payload) => {
+                if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return false;
+                try {
+                  wsRef.current.send(JSON.stringify(payload));
+                  return true;
+                } catch {
+                  return false;
+                }
+              },
+              onSnapshot: (snapshot) => {
+                setAxSnapshot((prev) => (axSnapshotsEqual(prev, snapshot) ? prev : snapshot));
+                // Defer to a microtask so customer code (which may DOM-write,
+                // start expensive work, or itself call back into ref
+                // methods) doesn't run synchronously inside our state-setter
+                // path. React then has a chance to schedule its render before
+                // the customer handler kicks off side-effects.
+                queueMicrotask(() => {
+                  safeInvoke('onAxSnapshotChange', onAxSnapshotChangeRef.current, snapshot);
+                });
+              },
+              onStatusChange: (status, error) => {
+                safeInvoke('onAxStatusChange', onAxStatusChangeRef.current, status, error);
+              },
+            });
+            if (inspectModeRef.current === true || inspectModeRef.current === 'hover-only') {
+              axFetcherRef.current.start();
+            }
+          }
           const sendRequestFrame = () => {
             if (
               !isCurrentAttempt() ||
@@ -1423,6 +1772,9 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 }),
               );
             }
+            // openUrl can take a moment to load the destination — boost
+            // AX polling so the overlay refreshes through the transition.
+            axFetcherRef.current?.bumpActivity();
           }
         };
 
@@ -1527,6 +1879,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
             message = JSON.parse(event.data);
           } catch (e) {
             debugWarn('Error parsing message:', e);
+            return;
+          }
+          // Inspect-mode responses are routed to the fetcher first so it
+          // can resolve in-flight requests regardless of which platform's
+          // protocol is in use.
+          if (axFetcherRef.current?.handleMessage(message)) {
             return;
           }
           updateStatus('Received: ' + message.type);
@@ -1724,20 +2082,52 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       };
     }, [url, token, propSessionId]);
 
+    // Recompute the inspect-overlay geometry (container-local pixel rect of
+    // the actually-rendered video content) from the current mapping context.
+    // The InfoCard places itself in viewport coordinates from pointer events
+    // directly, so no viewport-space origin is needed in the geometry.
+    const recomputeOverlayGeometry = () => {
+      const ctx = computeVideoMappingContext();
+      if (!ctx) {
+        setOverlayGeometry(null);
+        return;
+      }
+      const next: InspectOverlayGeometry = {
+        left: ctx.videoRect.left - ctx.containerRect.left + ctx.offsetX,
+        top: ctx.videoRect.top - ctx.containerRect.top + ctx.offsetY,
+        width: ctx.actualWidth,
+        height: ctx.actualHeight,
+      };
+      setOverlayGeometry((prev) =>
+        (
+          prev &&
+          prev.left === next.left &&
+          prev.top === next.top &&
+          prev.width === next.width &&
+          prev.height === next.height
+        ) ?
+          prev
+        : next,
+      );
+    };
+
     // Calculate video position and border-radius based on frame dimensions
     useEffect(() => {
       const video = videoRef.current;
       const frame = frameRef.current;
+      const container = containerRef.current;
 
       if (!video) return;
 
-      // If no frame, no positioning needed
-      if (!showFrame || !frame) {
-        setVideoStyle({});
-        return;
-      }
-
       const updateVideoPosition = () => {
+        // If no frame, just refresh overlay geometry; no inset/letterbox math
+        // is needed since the video element is its own size.
+        if (!showFrame || !frame) {
+          setVideoStyle({});
+          recomputeOverlayGeometry();
+          return;
+        }
+
         const frameWidth = frame.clientWidth;
         const frameHeight = frame.clientHeight;
 
@@ -1767,17 +2157,19 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           : frameWidth * config.videoBorderRadiusMultiplier
         }px`;
         setVideoStyle(newStyle);
+        recomputeOverlayGeometry();
       };
 
       const resizeObserver = new ResizeObserver(() => {
         updateVideoPosition();
       });
 
-      resizeObserver.observe(frame);
+      if (frame) resizeObserver.observe(frame);
       resizeObserver.observe(video);
+      if (container) resizeObserver.observe(container);
 
       // Also update when the frame image loads
-      frame.addEventListener('load', updateVideoPosition);
+      if (frame) frame.addEventListener('load', updateVideoPosition);
 
       // Update when video metadata loads (to get correct intrinsic dimensions)
       video.addEventListener('loadedmetadata', updateVideoPosition);
@@ -1786,6 +2178,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       // (videoWidth/videoHeight) can change without re-firing 'loadedmetadata'.
       // The <video> element emits 'resize' in that case.
       video.addEventListener('resize', updateVideoPosition);
+      // Orientation flips also mean every element's AX frame just changed
+      // (portrait↔landscape rotates the layout). Bump so the overlay
+      // refreshes immediately rather than waiting out the current poll
+      // cycle in a layout that no longer matches the boxes.
+      const bumpOnResize = () => axFetcherRef.current?.bumpActivity();
+      video.addEventListener('resize', bumpOnResize);
 
       // Initial calculation
       updateVideoPosition();
@@ -1794,9 +2192,59 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         resizeObserver.disconnect();
         video.removeEventListener('loadedmetadata', updateVideoPosition);
         video.removeEventListener('resize', updateVideoPosition);
-        frame.removeEventListener('load', updateVideoPosition);
+        video.removeEventListener('resize', bumpOnResize);
+        if (frame) frame.removeEventListener('load', updateVideoPosition);
       };
     }, [config, showFrame]);
+
+    // Start/stop the AX poller and reset inspect state when inspect mode
+    // toggles. Connection state is independent: the fetcher gets created on
+    // dataChannel.onopen and destroyed on teardown.
+    useEffect(() => {
+      const fetcher = axFetcherRef.current;
+      if (inspectActive) {
+        fetcher?.start();
+      } else {
+        fetcher?.stop();
+        setAxSnapshot(null);
+        setAxHighlightedId(null);
+        setAxSelectedId(null);
+        setAxCursorPosition(null);
+        setAxFrozenCursorPosition(null);
+        cursorPositionRef.current = null;
+        if (cursorRafIdRef.current !== undefined) {
+          window.cancelAnimationFrame(cursorRafIdRef.current);
+          cursorRafIdRef.current = undefined;
+        }
+        safeInvoke('onAxSnapshotChange', onAxSnapshotChangeRef.current, null);
+      }
+    }, [inspectActive]);
+
+    // Cancel any pending cursor-rAF on unmount so we don't setState on a
+    // dead component.
+    useEffect(() => {
+      return () => {
+        if (cursorRafIdRef.current !== undefined) {
+          window.cancelAnimationFrame(cursorRafIdRef.current);
+          cursorRafIdRef.current = undefined;
+        }
+      };
+    }, []);
+
+    // ESC clears overlay selection (Chrome DevTools behavior).
+    useEffect(() => {
+      if (!inspectActive) return;
+      const handleEsc = (e: KeyboardEvent) => {
+        if (e.key === 'Escape' && (axSelectedId || axHighlightedId)) {
+          setAxSelectedId(null);
+          setAxHighlightedId(null);
+          setAxFrozenCursorPosition(null);
+          safeInvoke('onInspectSelectionChange', onInspectSelectionChangeRef.current, null);
+        }
+      };
+      window.addEventListener('keydown', handleEsc);
+      return () => window.removeEventListener('keydown', handleEsc);
+    }, [inspectActive, axSelectedId, axHighlightedId]);
 
     const handleVideoClick = () => {
       if (videoRef.current) {
@@ -1831,6 +2279,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
             }),
           );
         }
+        axFetcherRef.current?.bumpActivity();
       },
 
       sendKeyEvent: (event: ImperativeKeyboardEvent) => {
@@ -1930,6 +2379,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
             reject(err);
             return;
           }
+          // Terminating the foreground app drops the user back to the home
+          // screen — bump so the overlay reflects the post-terminate state
+          // through the SpringBoard transition.
+          axFetcherRef.current?.bumpActivity();
 
           setTimeout(() => {
             if (pendingTerminateAppResolversRef.current.has(id)) {
@@ -1942,6 +2395,46 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         });
       },
       reconnect: () => start(),
+
+      refreshAxTree: async (): Promise<AxSnapshot> => {
+        const fetcher = axFetcherRef.current;
+        if (!fetcher) {
+          throw new Error('Inspect mode is not active');
+        }
+        // The fetcher's refresh() runs the result through the same
+        // change-detect path as the poll loop (via deliver()), which calls
+        // back into onSnapshot — already wired to setAxSnapshot +
+        // onAxSnapshotChange (with safe-invoke). We just return the fetched
+        // payload for callers that want it.
+        return fetcher.refresh();
+      },
+
+      getAxSnapshot: () => axSnapshotRef.current,
+
+      setInspectHighlight: (element: AxElement | null) => {
+        setAxHighlightedId(element?.id ?? null);
+      },
+
+      setInspectSelection: (element: AxElement | null) => {
+        setAxSelectedId(element?.id ?? null);
+        // Programmatic selection has no click position — anchor the card at
+        // the last known cursor position (if any), otherwise clear.
+        // Customer-facing UIs that drive selection from their own panels can
+        // call setInspectHighlight separately to move the cursor visual.
+        if (element) {
+          setAxFrozenCursorPosition(cursorPositionRef.current);
+        } else {
+          setAxFrozenCursorPosition(null);
+        }
+        const snapshot = axSnapshotRef.current;
+        if (element && snapshot) {
+          safeInvoke('onInspectSelectionChange', onInspectSelectionChangeRef.current, { element, snapshot });
+        } else {
+          safeInvoke('onInspectSelectionChange', onInspectSelectionChangeRef.current, null);
+        }
+      },
+
+      getAxStatus: () => axFetcherRef.current?.getStatus() ?? 'idle',
     }));
 
     // Show indicators when Alt is held and we have a valid hover point (null when outside)
@@ -2029,6 +2522,51 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
             }
           }}
         />
+        {inspectActive && (
+          <InspectOverlay
+            snapshot={axSnapshot}
+            geometry={overlayGeometry}
+            highlightedId={axHighlightedId}
+            selectedId={axSelectedId}
+            mode={inspectModeResolved}
+            cursorPosition={axCursorPosition}
+            frozenCursorPosition={axFrozenCursorPosition}
+            onSelectChange={(element, clickPosition) => {
+              setAxSelectedId(element?.id ?? null);
+              if (element && clickPosition) {
+                setAxFrozenCursorPosition(clickPosition);
+              } else if (!element) {
+                setAxFrozenCursorPosition(null);
+              }
+              const snapshot = axSnapshotRef.current;
+              if (element && snapshot) {
+                safeInvoke('onInspectSelectionChange', onInspectSelectionChangeRef.current, {
+                  element,
+                  snapshot,
+                });
+              } else {
+                safeInvoke('onInspectSelectionChange', onInspectSelectionChangeRef.current, null);
+              }
+            }}
+            onTapElement={(element, tapAt) => {
+              // Use the viewport-space position the user originally aimed at
+              // (the frozen click position). For containers whose children
+              // are absent from the accessibility tree — e.g. iOS UITabBar's
+              // home/diagnostics/settings buttons — this taps the specific
+              // button the user pointed at instead of the container's
+              // averaged center.
+              if (tapAt) {
+                sendTapAtClient(tapAt.x, tapAt.y);
+                return;
+              }
+              // Fallback (defensive): center of element. Should be
+              // unreachable from the InfoCard since it always passes anchor.
+              const snapshot = axSnapshotRef.current;
+              if (!snapshot) return;
+              sendTapAtElementCenter(element, snapshot);
+            }}
+          />
+        )}
         {retryExhausted && (
           <button type="button" className="rc-retry-button" onClick={handleManualRetry}>
             Retry

--- a/packages/ui/src/core/ax-fetcher.test.ts
+++ b/packages/ui/src/core/ax-fetcher.test.ts
@@ -1,0 +1,418 @@
+// Tests for the AxFetcher state machine. We mock the WebSocket boundary
+// using a fake `send` function + manual `handleMessage` injection, and
+// drive time via vitest's fake timers so the burst/backoff math is
+// deterministic.
+//
+// Default environment is jsdom (see vitest.config.ts) — needed because
+// AxFetcher relies on `window.setTimeout` / `requestAnimationFrame`.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { AxFetcher, AxStatus } from './ax-fetcher';
+import { AxSnapshot, AX_UNAVAILABLE_ERROR } from './ax-tree';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Test harness
+// ────────────────────────────────────────────────────────────────────────────
+
+// Minimal iOS tree the server might return; one root with one child, both
+// with usable frames. Used to verify normalizeIosTree wires through.
+const iosTreeJson = JSON.stringify([
+  {
+    frame: { x: 0, y: 0, width: 100, height: 200 },
+    type: 'Application',
+    children: [
+      {
+        frame: { x: 10, y: 10, width: 50, height: 50 },
+        type: 'Button',
+        AXLabel: 'A',
+        AXUniqueId: 'a',
+      },
+    ],
+  },
+]);
+
+const androidPayload = {
+  nodes: [
+    // screen root
+    { parsedBounds: { left: 0, top: 0, right: 1080, bottom: 2400, centerX: 540, centerY: 1200 } },
+    // a child
+    {
+      resourceId: 'foo',
+      className: 'android.widget.View',
+      parsedBounds: { left: 100, top: 100, right: 200, bottom: 200, centerX: 150, centerY: 150 },
+    },
+  ],
+};
+
+interface Harness {
+  fetcher: AxFetcher;
+  send: ReturnType<typeof vi.fn>;
+  onSnapshot: ReturnType<typeof vi.fn>;
+  onStatusChange: ReturnType<typeof vi.fn>;
+  // Pull the most recent request id we sent (for crafting responses).
+  lastRequestId: () => string | null;
+  // Helpers to feed a response.
+  respondIos: (id: string, opts?: { error?: string; json?: string }) => void;
+  respondAndroid: (id: string, opts?: { errorMessage?: string }) => void;
+}
+
+const makeIosHarness = (opts: { baseIntervalMs?: number; maxBackoffMs?: number } = {}): Harness => {
+  const send = vi.fn((payload: Record<string, unknown>) => {
+    // Accept all sends in tests; track by capturing the args.
+    return true;
+  });
+  const onSnapshot = vi.fn();
+  const onStatusChange = vi.fn();
+  const fetcher = new AxFetcher({
+    platform: 'ios',
+    send,
+    onSnapshot,
+    onStatusChange,
+    baseIntervalMs: opts.baseIntervalMs,
+    maxBackoffMs: opts.maxBackoffMs,
+  });
+  const lastRequestId = (): string | null => {
+    if (send.mock.calls.length === 0) return null;
+    const last = send.mock.calls[send.mock.calls.length - 1]![0] as { id?: string };
+    return last.id ?? null;
+  };
+  const respondIos: Harness['respondIos'] = (id, { error, json } = {}) => {
+    fetcher.handleMessage({
+      type: 'elementTreeResult',
+      id,
+      json: error ? undefined : json ?? iosTreeJson,
+      error,
+    });
+  };
+  const respondAndroid: Harness['respondAndroid'] = () => {
+    throw new Error('android responses not available on an iOS harness');
+  };
+  return { fetcher, send, onSnapshot, onStatusChange, lastRequestId, respondIos, respondAndroid };
+};
+
+const makeAndroidHarness = (): Harness => {
+  const send = vi.fn(() => true);
+  const onSnapshot = vi.fn();
+  const onStatusChange = vi.fn();
+  const fetcher = new AxFetcher({
+    platform: 'android',
+    send,
+    onSnapshot,
+    onStatusChange,
+  });
+  const lastRequestId = (): string | null => {
+    if (send.mock.calls.length === 0) return null;
+    const last = send.mock.calls[send.mock.calls.length - 1]![0] as { id?: string };
+    return last.id ?? null;
+  };
+  const respondIos: Harness['respondIos'] = () => {
+    throw new Error('iOS responses not available on an android harness');
+  };
+  const respondAndroid: Harness['respondAndroid'] = (id, { errorMessage } = {}) => {
+    fetcher.handleMessage({
+      type: 'getElementTreeResult',
+      id,
+      payload: errorMessage ? undefined : androidPayload,
+      error: errorMessage ? { message: errorMessage } : undefined,
+    });
+  };
+  return { fetcher, send, onSnapshot, onStatusChange, lastRequestId, respondIos, respondAndroid };
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('AxFetcher: basic lifecycle', () => {
+  test('start() emits starting → ready status and delivers first snapshot', async () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    expect(h.fetcher.getStatus()).toBe('starting');
+    expect(h.onStatusChange).toHaveBeenCalledWith('starting', undefined);
+
+    // start() schedules an immediate runOnce, which calls send synchronously.
+    expect(h.send).toHaveBeenCalledTimes(1);
+    const id = h.lastRequestId();
+    expect(id).toMatch(/^ax-rc-/);
+
+    h.respondIos(id!);
+    // Snapshot delivery happens after the promise chain resolves.
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(h.onSnapshot).toHaveBeenCalledTimes(1);
+    const snapshot = h.onSnapshot.mock.calls[0]![0] as AxSnapshot;
+    expect(snapshot.platform).toBe('ios');
+    expect(snapshot.elements).toHaveLength(1);
+    expect(h.fetcher.getStatus()).toBe('ready');
+    expect(h.onStatusChange).toHaveBeenLastCalledWith('ready', undefined);
+  });
+
+  test('stop() emits idle and a final null snapshot', async () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    h.respondIos(h.lastRequestId()!);
+    await vi.runOnlyPendingTimersAsync();
+
+    h.fetcher.stop();
+    expect(h.fetcher.getStatus()).toBe('idle');
+    expect(h.onStatusChange).toHaveBeenLastCalledWith('idle', undefined);
+    expect(h.onSnapshot).toHaveBeenLastCalledWith(null);
+  });
+
+  test('start() is idempotent (subsequent start() during running is a no-op)', async () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    h.fetcher.start();
+    h.fetcher.start();
+    // Only one fetch in flight.
+    expect(h.send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AxFetcher: single-flight', () => {
+  test('does not start a second fetch while the first is in flight', async () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    // Even if we advance time, no second send happens until the first resolves.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(h.send).toHaveBeenCalledTimes(1);
+
+    // Respond, advance one tick — single follow-up scheduled.
+    h.respondIos(h.lastRequestId()!);
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('AxFetcher: change-detect backoff', () => {
+  test('emits onSnapshot only when content changes', async () => {
+    const h = makeIosHarness({ baseIntervalMs: 100, maxBackoffMs: 1000 });
+    h.fetcher.start();
+    h.respondIos(h.lastRequestId()!);
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.onSnapshot).toHaveBeenCalledTimes(1);
+
+    // Same response on next poll — onSnapshot must NOT fire again.
+    await vi.advanceTimersByTimeAsync(100);
+    h.respondIos(h.lastRequestId()!);
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.onSnapshot).toHaveBeenCalledTimes(1);
+
+    // Different response — fires.
+    await vi.advanceTimersByTimeAsync(200);
+    h.respondIos(h.lastRequestId()!, {
+      json: JSON.stringify([
+        {
+          frame: { x: 0, y: 0, width: 100, height: 200 },
+          type: 'Application',
+          children: [
+            {
+              frame: { x: 10, y: 10, width: 50, height: 50 },
+              type: 'Button',
+              AXLabel: 'B', // changed
+              AXUniqueId: 'a',
+            },
+          ],
+        },
+      ]),
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.onSnapshot).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('AxFetcher: unavailable status', () => {
+  test('transitions to unavailable when the server reports AX is down', async () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    h.respondIos(h.lastRequestId()!, { error: AX_UNAVAILABLE_ERROR });
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.fetcher.getStatus()).toBe('unavailable');
+    expect(h.onStatusChange).toHaveBeenLastCalledWith('unavailable', AX_UNAVAILABLE_ERROR);
+  });
+
+  test('recovers to ready when a usable snapshot eventually arrives', async () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    h.respondIos(h.lastRequestId()!, { error: AX_UNAVAILABLE_ERROR });
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.fetcher.getStatus()).toBe('unavailable');
+
+    // Advance through the unavailable retry interval, then respond OK.
+    await vi.advanceTimersByTimeAsync(5000);
+    h.respondIos(h.lastRequestId()!);
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.fetcher.getStatus()).toBe('ready');
+  });
+});
+
+describe('AxFetcher: error path', () => {
+  test('transient parse error transitions to `error` then recovers', async () => {
+    const h = makeIosHarness({ baseIntervalMs: 100 });
+    h.fetcher.start();
+    // Send malformed JSON in the response.
+    h.respondIos(h.lastRequestId()!, { json: 'not-json{' });
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.fetcher.getStatus()).toBe('error');
+
+    // Recover with a valid response.
+    await vi.advanceTimersByTimeAsync(500);
+    h.respondIos(h.lastRequestId()!);
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.fetcher.getStatus()).toBe('ready');
+  });
+});
+
+describe('AxFetcher: bumpActivity / boost window', () => {
+  test('bumpActivity is a no-op when not running', () => {
+    const h = makeIosHarness();
+    h.fetcher.bumpActivity();
+    expect(h.send).toHaveBeenCalledTimes(0);
+  });
+
+  test('boosted cadence (~250 ms) is used while in the boost window', async () => {
+    const h = makeIosHarness({ baseIntervalMs: 500 });
+    h.fetcher.start();
+    expect(h.send).toHaveBeenCalledTimes(1);
+
+    // Bump while the initial fetch is still inflight. Bump can't trigger
+    // its own immediate send (inflight is true) but must extend the boost
+    // window so the NEXT scheduled fetch lands at ~250 ms rather than the
+    // base 500 ms.
+    h.fetcher.bumpActivity();
+    expect(h.send).toHaveBeenCalledTimes(1);
+
+    // Resolve the inflight — deliver+scheduleNext run on microtask. Flush
+    // microtasks without advancing the clock so scheduling happens but no
+    // timer has fired yet.
+    h.respondIos(h.lastRequestId()!);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // At t = 0+ε, no boosted timer has fired yet (it's scheduled at 250ms).
+    expect(h.send).toHaveBeenCalledTimes(1);
+
+    // At t = 240 ms, still under the boosted interval — no fire.
+    await vi.advanceTimersByTimeAsync(240);
+    expect(h.send).toHaveBeenCalledTimes(1);
+
+    // At t = 260 ms (past 250ms), the boosted timer fires.
+    await vi.advanceTimersByTimeAsync(30);
+    expect(h.send).toHaveBeenCalledTimes(2);
+  });
+
+  test('outside the boost window, cadence returns to base interval', async () => {
+    const h = makeIosHarness({ baseIntervalMs: 500 });
+    h.fetcher.start();
+    h.respondIos(h.lastRequestId()!);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // No bumpActivity was called, so we're not in boost. Wait 240 ms — no
+    // fire yet (base interval is 500ms).
+    await vi.advanceTimersByTimeAsync(240);
+    expect(h.send).toHaveBeenCalledTimes(1);
+
+    // Wait another 280ms to clear 500ms — base-interval fetch fires.
+    await vi.advanceTimersByTimeAsync(280);
+    expect(h.send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('AxFetcher: handleMessage routing', () => {
+  test('iOS handleMessage ignores wrong-platform message shapes', () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    const consumed = h.fetcher.handleMessage({
+      type: 'getElementTreeResult', // wrong for iOS
+      id: h.lastRequestId()!,
+      payload: { nodes: [] },
+    });
+    expect(consumed).toBe(false);
+    // Cleanup: respond properly so we don't leave a pending timer.
+    h.respondIos(h.lastRequestId()!);
+  });
+
+  test('Android handleMessage parses payload.nodes', async () => {
+    const h = makeAndroidHarness();
+    h.fetcher.start();
+    h.respondAndroid(h.lastRequestId()!);
+    await vi.runOnlyPendingTimersAsync();
+    expect(h.onSnapshot).toHaveBeenCalledTimes(1);
+    const snap = h.onSnapshot.mock.calls[0]![0] as AxSnapshot;
+    expect(snap.platform).toBe('android');
+  });
+
+  test('returns false for unknown request ids', () => {
+    const h = makeIosHarness();
+    h.fetcher.start();
+    expect(h.fetcher.handleMessage({ type: 'elementTreeResult', id: 'nope' })).toBe(false);
+  });
+});
+
+describe('AxFetcher: refresh()', () => {
+  test('triggers a one-shot fetch and dedupes via change-detect', async () => {
+    const h = makeIosHarness({ baseIntervalMs: 10_000 }); // long base, no spontaneous polls
+    h.fetcher.start();
+    h.respondIos(h.lastRequestId()!);
+    // Flush microtasks without advancing time so the next poll isn't tripped.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(h.onSnapshot).toHaveBeenCalledTimes(1);
+    const sendsBefore = h.send.mock.calls.length;
+
+    // Call refresh — initiates another fetch.
+    const p = h.fetcher.refresh();
+    expect(h.send.mock.calls.length).toBe(sendsBefore + 1);
+    h.respondIos(h.lastRequestId()!);
+    const snapshot = await p;
+    expect(snapshot.platform).toBe('ios');
+    // Identical content → no extra onSnapshot.
+    expect(h.onSnapshot).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AxFetcher: status callback safety', () => {
+  test('a throw in onStatusChange does not break the state machine', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const onStatusChange = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const send = vi.fn(() => true);
+      const onSnapshot = vi.fn();
+      const fetcher = new AxFetcher({
+        platform: 'ios',
+        send,
+        onSnapshot,
+        onStatusChange: onStatusChange as unknown as (s: AxStatus, e?: string) => void,
+      });
+      fetcher.start();
+      expect(fetcher.getStatus()).toBe('starting');
+      // Calling stop() would re-trigger the throwing callback — must not throw.
+      expect(() => fetcher.stop()).not.toThrow();
+
+      // The inflight request will time out asynchronously and call
+      // setStatus('error'), which also goes through the throwing callback.
+      // Drain that path while the spy is still in place to keep stderr
+      // clean for the rest of the suite.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(consoleSpy).toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/packages/ui/src/core/ax-fetcher.ts
+++ b/packages/ui/src/core/ax-fetcher.ts
@@ -1,0 +1,377 @@
+// Driver that fetches accessibility snapshots over an existing WebSocket and
+// emits change-detected updates to subscribers. Reuses the RemoteControl's
+// signaling WS (not a separate connection) and routes responses by request id.
+//
+// Cadence:
+// - Base interval (default 500ms) right after a fetch resolved.
+// - Doubles up to maxBackoff (default 2000ms) while consecutive snapshots
+//   are byte-identical.
+// - Jumps to UNAVAILABLE_RETRY_INTERVAL_MS when the server reports the AX
+//   subsystem isn't usable yet.
+// - On bumpActivity() (called by RemoteControl after any user input), the
+//   backoff is reset to base — UI almost certainly changed.
+
+import {
+  AX_UNAVAILABLE_ERROR,
+  AxPlatform,
+  AxSnapshot,
+  axSnapshotsEqual,
+  normalizeAndroidTree,
+  normalizeIosTree,
+} from './ax-tree';
+
+const DEFAULT_BASE_INTERVAL_MS = 500;
+const DEFAULT_MAX_BACKOFF_MS = 2000;
+const UNAVAILABLE_RETRY_INTERVAL_MS = 5000;
+const REQUEST_TIMEOUT_MS = 8000;
+// After a user-driven event (tap/scroll/openUrl/etc.) we enter a brief
+// "boost" window during which scheduled fetches happen on a shorter
+// interval. This catches mid- and post-animation UI states without
+// hammering the server during idle time.
+const ACTIVITY_BOOST_DURATION_MS = 1200;
+const ACTIVITY_BOOST_INTERVAL_MS = 250;
+
+// Coarse-grained status surfaced to customers so they can render readiness
+// indicators / error UI in their own panels.
+//
+// State machine:
+//   idle ───start()───▶ starting ──snapshot────▶ ready
+//                                ──AX_UNAVAILABLE_ERROR─▶ unavailable
+//                                ──other error──▶ error
+//   ready ──AX_UNAVAILABLE_ERROR─▶ unavailable
+//        ──other error──▶ error (transient; back to ready on next success)
+//   unavailable ──snapshot────▶ ready
+//   error       ──snapshot────▶ ready
+//   * stop() ────────▶ idle
+//
+// Note `error` is sticky-but-recoverable: the fetcher keeps polling, and as
+// soon as a fresh snapshot arrives we transition back to `ready`. Customers
+// don't need to manually retry.
+export type AxStatus = 'idle' | 'starting' | 'ready' | 'unavailable' | 'error';
+
+export type AxFetcherSendFn = (payload: Record<string, unknown>) => boolean;
+
+export interface AxFetcherOptions {
+  platform: AxPlatform;
+  send: AxFetcherSendFn;
+  onSnapshot: (snapshot: AxSnapshot | null) => void;
+  // Optional: notified on every status transition (deduplicated — no
+  // self-loops are emitted). `error` provides the error message when the
+  // status is `error` or `unavailable`.
+  onStatusChange?: (status: AxStatus, error?: string) => void;
+  baseIntervalMs?: number;
+  maxBackoffMs?: number;
+}
+
+type PendingResolver = {
+  resolve: (snapshot: AxSnapshot) => void;
+  reject: (err: Error) => void;
+  timer: number;
+};
+
+// Returns the request id used so the caller can route the matching response
+// back. We use ax-rc-{ts}-{rand} so it's easy to distinguish from screenshot
+// ids in debug output.
+const generateRequestId = (): string => `ax-rc-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+export class AxFetcher {
+  private readonly platform: AxPlatform;
+  private readonly send: AxFetcherSendFn;
+  private readonly onSnapshot: (snapshot: AxSnapshot | null) => void;
+  private readonly onStatusChange?: (status: AxStatus, error?: string) => void;
+  private readonly baseIntervalMs: number;
+  private readonly maxBackoffMs: number;
+  private readonly pending: Map<string, PendingResolver> = new Map();
+
+  private running = false;
+  private timer: number | undefined;
+  private currentInterval: number;
+  private lastSnapshot: AxSnapshot | null = null;
+  // Single-flight: only one outstanding request at a time. Avoids piling
+  // identical requests on a slow server.
+  private inflight = false;
+  // Rate-limit floor for bumpActivity so high-frequency input (drags,
+  // typing) doesn't trigger a request storm.
+  private lastBumpAtMs = 0;
+  // Wall-clock timestamp until which we're in "activity boost" mode and
+  // schedule fetches at ACTIVITY_BOOST_INTERVAL_MS instead of the normal
+  // backed-off interval. Set by bumpActivity().
+  private boostUntilMs = 0;
+  // Coarse-grained current status; deduplicated before emission so
+  // identical-to-current transitions are no-ops.
+  private status: AxStatus = 'idle';
+
+  constructor(opts: AxFetcherOptions) {
+    this.platform = opts.platform;
+    this.send = opts.send;
+    this.onSnapshot = opts.onSnapshot;
+    this.onStatusChange = opts.onStatusChange;
+    this.baseIntervalMs = opts.baseIntervalMs ?? DEFAULT_BASE_INTERVAL_MS;
+    this.maxBackoffMs = opts.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
+    this.currentInterval = this.baseIntervalMs;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.currentInterval = this.baseIntervalMs;
+    this.boostUntilMs = 0;
+    this.setStatus('starting');
+    // Kick a fetch immediately on enable so the overlay shows up fast.
+    void this.runOnce();
+  }
+
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+    if (this.timer !== undefined) {
+      window.clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    this.failAllPending('Inspector stopped');
+    this.lastSnapshot = null;
+    this.setStatus('idle');
+    this.onSnapshot(null);
+  }
+
+  getStatus(): AxStatus {
+    return this.status;
+  }
+
+  private setStatus(next: AxStatus, error?: string): void {
+    if (this.status === next) return;
+    this.status = next;
+    if (!this.onStatusChange) return;
+    try {
+      this.onStatusChange(next, error);
+    } catch (err) {
+      // Don't let customer status-handler errors break our state machine.
+      console.error('[AxFetcher] onStatusChange threw:', err);
+    }
+  }
+
+  // Called after any user-driven action that's likely to change the UI
+  // (taps, scrolls, key events, openUrl, app termination, orientation
+  // change, etc.). Has two effects:
+  //
+  //   1. Resets the polling interval to base and triggers an immediate
+  //      fetch (rate-limited so drags / rapid typing don't request-storm).
+  //   2. Enters a brief "boost" window during which scheduleNext() uses a
+  //      shorter interval (ACTIVITY_BOOST_INTERVAL_MS), so we capture the
+  //      mid- and post-animation tree without waiting for the next
+  //      back-off cycle.
+  bumpActivity(): void {
+    if (!this.running) return;
+    const now = Date.now();
+    // Extend the boost window on every bump so a rapid sequence of inputs
+    // (a swipe-then-tap, scrolling through a list) keeps polling fast
+    // throughout the action.
+    this.boostUntilMs = now + ACTIVITY_BOOST_DURATION_MS;
+    const floorMs = Math.max(150, Math.floor(this.baseIntervalMs / 2));
+    if (now - this.lastBumpAtMs < floorMs) {
+      // Still reset cadence so the next scheduled fetch lands at base
+      // interval, but don't cancel the current timer or trigger an extra
+      // immediate fetch.
+      this.currentInterval = this.baseIntervalMs;
+      return;
+    }
+    this.lastBumpAtMs = now;
+    this.currentInterval = this.baseIntervalMs;
+    if (this.timer !== undefined) {
+      window.clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    if (!this.inflight) {
+      void this.runOnce();
+    }
+  }
+
+  // Fire a one-shot fetch independent of the poll loop. Useful for the
+  // imperative refresh() ref method customers may call.
+  //
+  // Goes through the same change-detect path as the regular poll loop —
+  // identical-to-last-snapshot responses do NOT re-emit via onSnapshot, so
+  // a customer calling refresh() in a tight loop doesn't see a stream of
+  // duplicate snapshots. The returned promise still resolves with the
+  // (possibly identical) snapshot for the caller's own use.
+  async refresh(): Promise<AxSnapshot> {
+    const next = await this.requestOnce();
+    if (this.running) {
+      this.deliver(next);
+    }
+    return next;
+  }
+
+  // Returns the latest snapshot delivered to onSnapshot. May be stale.
+  getLatest(): AxSnapshot | null {
+    return this.lastSnapshot;
+  }
+
+  // Called by RemoteControl's ws.onmessage when it sees a message type we own.
+  // Returns true when the message was a response we were waiting for.
+  handleMessage(message: { type?: string; id?: string; [k: string]: unknown }): boolean {
+    if (!message || typeof message.id !== 'string') return false;
+    const id = message.id;
+    const resolver = this.pending.get(id);
+    if (!resolver) return false;
+
+    if (this.platform === 'ios') {
+      // iOS: {type:'elementTreeResult', id, json, error}
+      if (message.type !== 'elementTreeResult') return false;
+      const error = typeof message.error === 'string' ? message.error : null;
+      if (error) {
+        this.settleReject(id, new Error(error));
+        return true;
+      }
+      const json = typeof message.json === 'string' ? message.json : '';
+      try {
+        const parsed = JSON.parse(json);
+        const snapshot = normalizeIosTree(parsed);
+        this.settleResolve(id, snapshot);
+      } catch (e) {
+        this.settleReject(id, e instanceof Error ? e : new Error(String(e)));
+      }
+      return true;
+    }
+
+    // android: {type:'getElementTreeResult', id, payload:{xml,nodes}, error?}
+    if (message.type !== 'getElementTreeResult') return false;
+    const errObj = message.error as { message?: string; code?: string } | undefined;
+    if (errObj && typeof errObj === 'object') {
+      const msg = typeof errObj.message === 'string' ? errObj.message : 'getElementTree failed';
+      this.settleReject(id, new Error(msg));
+      return true;
+    }
+    const payload = message.payload as { nodes?: unknown[] } | undefined;
+    const nodes = Array.isArray(payload?.nodes) ? (payload!.nodes as Record<string, unknown>[]) : [];
+    try {
+      const snapshot = normalizeAndroidTree(nodes as Parameters<typeof normalizeAndroidTree>[0]);
+      this.settleResolve(id, snapshot);
+    } catch (e) {
+      this.settleReject(id, e instanceof Error ? e : new Error(String(e)));
+    }
+    return true;
+  }
+
+  private buildRequest(id: string): Record<string, unknown> {
+    if (this.platform === 'ios') {
+      return { type: 'elementTree', id };
+    }
+    return { type: 'getElementTree', id };
+  }
+
+  private async requestOnce(): Promise<AxSnapshot> {
+    const id = generateRequestId();
+    return new Promise<AxSnapshot>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error('elementTree request timed out'));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      const ok = this.send(this.buildRequest(id));
+      if (!ok) {
+        window.clearTimeout(timer);
+        this.pending.delete(id);
+        reject(new Error('elementTree send failed (WebSocket not open)'));
+      }
+    });
+  }
+
+  private async runOnce(): Promise<void> {
+    if (!this.running) return;
+    if (this.inflight) return;
+    this.inflight = true;
+    try {
+      const next = await this.requestOnce();
+      if (!this.running) return;
+      this.deliver(next);
+    } catch (err) {
+      // Don't surface transient errors to the customer's onSnapshot — just
+      // back off and try again. We DO surface them via status transitions
+      // so customers building their own UI can show a banner / spinner /
+      // etc. Persistent failures eventually settle on the longest backoff.
+      //
+      // If the fetcher was stopped while a request was in flight, the
+      // pending request is rejected by failAllPending() and we end up here
+      // with running=false. In that case skip the status transition — the
+      // current status is already 'idle' and we shouldn't churn it back to
+      // an error.
+      if (!this.running) return;
+      const message = err instanceof Error ? err.message : String(err);
+      const unavailable = /unavailable|not (yet )?running|failed|timeout/i.test(message);
+      this.currentInterval =
+        unavailable ? UNAVAILABLE_RETRY_INTERVAL_MS : Math.min(this.currentInterval * 2, this.maxBackoffMs);
+      this.setStatus(unavailable ? 'unavailable' : 'error', message);
+    } finally {
+      this.inflight = false;
+      this.scheduleNext();
+    }
+  }
+
+  private deliver(next: AxSnapshot): void {
+    const previous = this.lastSnapshot;
+    if (axSnapshotsEqual(previous, next)) {
+      // Same payload — back off so we don't churn.
+      this.currentInterval = Math.min(this.currentInterval * 2, this.maxBackoffMs);
+      // Still update capturedAt by replacing the cached snapshot.
+      this.lastSnapshot = next;
+      // A successful (even if unchanged) fetch is a sign that AX is
+      // working — emit `ready` if we were in a degraded status.
+      if (!next.errors?.includes(AX_UNAVAILABLE_ERROR)) {
+        this.setStatus('ready');
+      }
+      return;
+    }
+    this.lastSnapshot = next;
+    this.currentInterval = this.baseIntervalMs;
+    if (next.errors?.includes(AX_UNAVAILABLE_ERROR)) {
+      this.currentInterval = UNAVAILABLE_RETRY_INTERVAL_MS;
+      this.setStatus('unavailable', AX_UNAVAILABLE_ERROR);
+    } else {
+      this.setStatus('ready');
+    }
+    this.onSnapshot(next);
+  }
+
+  private scheduleNext(): void {
+    if (!this.running) return;
+    if (this.timer !== undefined) {
+      window.clearTimeout(this.timer);
+    }
+    // While in activity-boost mode, cap the wait so we keep capturing the
+    // UI through any animation that's mid-flight. Outside the boost
+    // window, use the normal (possibly backed-off) interval.
+    const interval =
+      Date.now() < this.boostUntilMs ?
+        Math.min(ACTIVITY_BOOST_INTERVAL_MS, this.currentInterval)
+      : this.currentInterval;
+    this.timer = window.setTimeout(() => {
+      this.timer = undefined;
+      void this.runOnce();
+    }, interval);
+  }
+
+  private settleResolve(id: string, snapshot: AxSnapshot): void {
+    const r = this.pending.get(id);
+    if (!r) return;
+    window.clearTimeout(r.timer);
+    this.pending.delete(id);
+    r.resolve(snapshot);
+  }
+
+  private settleReject(id: string, err: Error): void {
+    const r = this.pending.get(id);
+    if (!r) return;
+    window.clearTimeout(r.timer);
+    this.pending.delete(id);
+    r.reject(err);
+  }
+
+  private failAllPending(reason: string): void {
+    for (const [id, r] of this.pending.entries()) {
+      window.clearTimeout(r.timer);
+      r.reject(new Error(reason));
+      this.pending.delete(id);
+    }
+  }
+}

--- a/packages/ui/src/core/ax-tree.test.ts
+++ b/packages/ui/src/core/ax-tree.test.ts
@@ -1,0 +1,491 @@
+// @vitest-environment node
+//
+// Tests for `core/ax-tree.ts` — pure normalizers + helpers, no DOM required.
+//
+// These cover the contract customers depend on through `onAxSnapshotChange`
+// and the exported helpers, so regressions here surface as silent overlay
+// drift or selector copy-paste pain.
+
+import { describe, expect, test } from 'vitest';
+import {
+  AxElement,
+  AxSnapshot,
+  AX_UNAVAILABLE_ERROR,
+  axElementAtPoint,
+  axElementRoleLabel,
+  axElementSelectorExpression,
+  axElementSummary,
+  axElementsEqual,
+  axSnapshotsEqual,
+  clampAxFrameForScreen,
+  normalizeAndroidTree,
+  normalizeIosTree,
+} from './ax-tree';
+
+// ────────────────────────────────────────────────────────────────────────────
+// normalizeIosTree
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('normalizeIosTree', () => {
+  test('flattens nested children, skipping the screen-sized root', () => {
+    const tree = [
+      {
+        // root = whole screen, should be filtered
+        frame: { x: 0, y: 0, width: 393, height: 852 },
+        type: 'Application',
+        children: [
+          {
+            frame: { x: 16, y: 64, width: 200, height: 40 },
+            type: 'Button',
+            AXLabel: 'Sign in',
+            AXUniqueId: 'signin-button',
+            children: [
+              {
+                frame: { x: 24, y: 70, width: 80, height: 20 },
+                type: 'StaticText',
+                AXLabel: 'Sign in',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const snap = normalizeIosTree(tree);
+
+    expect(snap.platform).toBe('ios');
+    expect(snap.screen).toEqual({ width: 393, height: 852 });
+    // Application (root, screen-sized) skipped; button + nested text kept.
+    expect(snap.elements).toHaveLength(2);
+    expect(snap.elements[0].label).toBe('Sign in');
+    expect(snap.elements[0].id).toBe('signin-button');
+    expect(snap.elements[0].selectors.AXUniqueId).toBe('signin-button');
+    expect(snap.elements[1].path).toBe('0.0.0');
+  });
+
+  test('drops zero-area frames', () => {
+    const tree = [
+      {
+        frame: { x: 0, y: 0, width: 400, height: 800 },
+        type: 'Application',
+        children: [
+          { frame: { x: 0, y: 0, width: 0, height: 50 }, type: 'Invisible' },
+          { frame: { x: 0, y: 0, width: 50, height: 0 }, type: 'Invisible' },
+          { frame: { x: -10, y: 10, width: -5, height: 10 }, type: 'Invisible' },
+          { frame: { x: 10, y: 10, width: 50, height: 50 }, type: 'Visible' },
+        ],
+      },
+    ];
+    const snap = normalizeIosTree(tree);
+    expect(snap.elements).toHaveLength(1);
+    expect(snap.elements[0].type).toBe('Visible');
+  });
+
+  test('caps at MAX_ELEMENTS (500) even on huge trees', () => {
+    const children = Array.from({ length: 1000 }, (_, i) => ({
+      frame: { x: i, y: 0, width: 1, height: 1 },
+      type: 'T',
+    }));
+    const snap = normalizeIosTree([
+      {
+        frame: { x: 0, y: 0, width: 1000, height: 1 },
+        type: 'Root',
+        children,
+      },
+    ]);
+    expect(snap.elements.length).toBeLessThanOrEqual(500);
+  });
+
+  test('falls back to path id when AXUniqueId is missing', () => {
+    const snap = normalizeIosTree([
+      {
+        frame: { x: 0, y: 0, width: 400, height: 800 },
+        type: 'Application',
+        children: [
+          { frame: { x: 0, y: 0, width: 50, height: 50 }, type: 'A' },
+          { frame: { x: 0, y: 0, width: 50, height: 50 }, type: 'B', AXUniqueId: 'b-id' },
+        ],
+      },
+    ]);
+    expect(snap.elements[0].id).toBe('0.0');
+    expect(snap.elements[1].id).toBe('b-id');
+  });
+
+  test('accepts a single-object root (not an array)', () => {
+    const snap = normalizeIosTree({
+      frame: { x: 0, y: 0, width: 200, height: 400 },
+      type: 'Application',
+      children: [{ frame: { x: 10, y: 10, width: 30, height: 30 }, type: 'X' }],
+    });
+    expect(snap.elements).toHaveLength(1);
+    expect(snap.screen).toEqual({ width: 200, height: 400 });
+  });
+
+  test('returns a usable empty snapshot for an empty input', () => {
+    const snap = normalizeIosTree([]);
+    expect(snap.elements).toEqual([]);
+    expect(snap.platform).toBe('ios');
+    expect(snap.screen.width).toBeGreaterThan(0);
+  });
+
+  test('strips children from `raw` to avoid retaining the whole subtree', () => {
+    const snap = normalizeIosTree([
+      {
+        frame: { x: 0, y: 0, width: 400, height: 800 },
+        children: [
+          {
+            frame: { x: 0, y: 0, width: 50, height: 50 },
+            type: 'A',
+            AXLabel: 'A',
+            children: [{ frame: { x: 0, y: 0, width: 25, height: 25 }, type: 'A-Child' }],
+          },
+        ],
+      },
+    ]);
+    const a = snap.elements.find((e) => e.label === 'A')!;
+    expect(a.raw).not.toHaveProperty('children');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// normalizeAndroidTree
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('normalizeAndroidTree', () => {
+  const mkNode = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    resourceId: '',
+    text: '',
+    contentDesc: '',
+    className: 'android.widget.View',
+    parsedBounds: { left: 0, top: 0, right: 50, bottom: 50, centerX: 25, centerY: 25 },
+    enabled: true,
+    ...overrides,
+  });
+
+  test('uses the largest rect as the screen frame', () => {
+    const nodes = [
+      // not the largest — should not be picked
+      { parsedBounds: { left: 0, top: 0, right: 100, bottom: 100, centerX: 50, centerY: 50 } },
+      // largest — screen
+      {
+        parsedBounds: { left: 0, top: 0, right: 1080, bottom: 2400, centerX: 540, centerY: 1200 },
+      },
+    ];
+    const snap = normalizeAndroidTree(nodes);
+    expect(snap.screen).toEqual({ width: 1080, height: 2400 });
+  });
+
+  test('drops the screen-sized rect and keeps children', () => {
+    const nodes = [
+      // screen
+      {
+        className: 'android.widget.FrameLayout',
+        parsedBounds: { left: 0, top: 0, right: 1080, bottom: 2400, centerX: 540, centerY: 1200 },
+      },
+      mkNode({
+        resourceId: 'btn-home',
+        contentDesc: 'Home',
+        parsedBounds: {
+          left: 100,
+          top: 2300,
+          right: 200,
+          bottom: 2400,
+          centerX: 150,
+          centerY: 2350,
+        },
+      }),
+    ];
+    const snap = normalizeAndroidTree(nodes);
+    expect(snap.elements.map((e) => e.id)).toEqual(['btn-home']);
+    expect(snap.elements[0].label).toBe('Home');
+    expect(snap.elements[0].selectors.resourceId).toBe('btn-home');
+  });
+
+  test('synthesizes a `cd:` id when resourceId is missing but contentDesc is present', () => {
+    const nodes = [
+      {
+        parsedBounds: { left: 0, top: 0, right: 1080, bottom: 2400, centerX: 540, centerY: 1200 },
+      },
+      mkNode({
+        contentDesc: 'Settings',
+        parsedBounds: {
+          left: 10,
+          top: 10,
+          right: 60,
+          bottom: 60,
+          centerX: 35,
+          centerY: 35,
+        },
+      }),
+    ];
+    const snap = normalizeAndroidTree(nodes);
+    expect(snap.elements[0].id).toBe('cd:Settings');
+  });
+
+  test('skips nodes with no parsedBounds or zero area', () => {
+    const nodes = [
+      {
+        parsedBounds: { left: 0, top: 0, right: 1080, bottom: 2400, centerX: 540, centerY: 1200 },
+      },
+      mkNode({ parsedBounds: undefined }),
+      mkNode({
+        parsedBounds: { left: 10, top: 10, right: 10, bottom: 50, centerX: 10, centerY: 30 },
+      }),
+    ];
+    const snap = normalizeAndroidTree(nodes);
+    expect(snap.elements).toHaveLength(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('clampAxFrameForScreen', () => {
+  const screen = { width: 100, height: 100 };
+
+  test('returns the frame unchanged when fully inside', () => {
+    expect(clampAxFrameForScreen({ x: 10, y: 10, width: 50, height: 50 }, screen)).toEqual({
+      x: 10,
+      y: 10,
+      width: 50,
+      height: 50,
+    });
+  });
+
+  test('clips a frame that overhangs the right/bottom edges', () => {
+    expect(clampAxFrameForScreen({ x: 80, y: 80, width: 40, height: 40 }, screen)).toEqual({
+      x: 80,
+      y: 80,
+      width: 20,
+      height: 20,
+    });
+  });
+
+  test('clamps negative x/y to zero and reduces width/height accordingly', () => {
+    expect(clampAxFrameForScreen({ x: -10, y: -20, width: 30, height: 30 }, screen)).toEqual({
+      x: 0,
+      y: 0,
+      width: 20,
+      height: 10,
+    });
+  });
+
+  test('returns null when the visible area becomes empty', () => {
+    expect(clampAxFrameForScreen({ x: 200, y: 200, width: 10, height: 10 }, screen)).toBeNull();
+    expect(clampAxFrameForScreen({ x: 0, y: 0, width: 0, height: 100 }, screen)).toBeNull();
+  });
+});
+
+describe('axElementAtPoint', () => {
+  const mkEl = (id: string, x: number, y: number, w: number, h: number): AxElement => ({
+    id,
+    path: id,
+    label: id,
+    value: '',
+    role: '',
+    type: '',
+    enabled: true,
+    focused: false,
+    frame: { x, y, width: w, height: h },
+    selectors: {},
+    raw: {},
+  });
+
+  const snap: AxSnapshot = {
+    platform: 'ios',
+    screen: { width: 1000, height: 1000 },
+    elements: [
+      mkEl('outer', 0, 0, 1000, 1000),
+      mkEl('mid', 100, 100, 800, 800),
+      mkEl('inner', 400, 400, 200, 200),
+    ],
+    capturedAt: 0,
+  };
+
+  test('picks the smallest element under the point', () => {
+    expect(axElementAtPoint(snap, 500, 500)?.id).toBe('inner');
+  });
+
+  test('falls back to a larger element when the smaller one does not contain the point', () => {
+    expect(axElementAtPoint(snap, 200, 200)?.id).toBe('mid');
+  });
+
+  test('returns null for points outside all rects', () => {
+    expect(axElementAtPoint(snap, -10, -10)).toBeNull();
+    expect(axElementAtPoint(snap, 2000, 2000)).toBeNull();
+  });
+
+  test('boundary point on the right/bottom edge is considered inside', () => {
+    // 600, 600 = exactly the right/bottom edge of `inner` (400+200, 400+200)
+    expect(axElementAtPoint(snap, 600, 600)?.id).toBe('inner');
+  });
+});
+
+describe('axElementsEqual & axSnapshotsEqual', () => {
+  const mkEl = (id: string, frame: { x: number; y: number; width: number; height: number }): AxElement => ({
+    id,
+    path: id,
+    label: 'L',
+    value: '',
+    role: 'r',
+    type: 't',
+    enabled: true,
+    focused: false,
+    frame,
+    selectors: {},
+    raw: {},
+  });
+
+  test('axElementsEqual returns true for content-identical elements', () => {
+    expect(
+      axElementsEqual(
+        mkEl('a', { x: 0, y: 0, width: 1, height: 1 }),
+        mkEl('a', { x: 0, y: 0, width: 1, height: 1 }),
+      ),
+    ).toBe(true);
+  });
+
+  test('axElementsEqual returns false on any field difference', () => {
+    const a = mkEl('a', { x: 0, y: 0, width: 1, height: 1 });
+    expect(axElementsEqual(a, { ...a, frame: { ...a.frame, x: 1 } })).toBe(false);
+    expect(axElementsEqual(a, { ...a, label: 'X' })).toBe(false);
+  });
+
+  test('axSnapshotsEqual compares element lists in order', () => {
+    const e1 = mkEl('a', { x: 0, y: 0, width: 1, height: 1 });
+    const e2 = mkEl('b', { x: 1, y: 1, width: 1, height: 1 });
+    const s1: AxSnapshot = {
+      platform: 'ios',
+      screen: { width: 10, height: 10 },
+      elements: [e1, e2],
+      capturedAt: 100,
+    };
+    const s2: AxSnapshot = { ...s1, capturedAt: 200 };
+    // capturedAt is metadata, not content — equal.
+    expect(axSnapshotsEqual(s1, s2)).toBe(true);
+
+    const s3: AxSnapshot = { ...s1, elements: [e2, e1] };
+    expect(axSnapshotsEqual(s1, s3)).toBe(false);
+
+    expect(axSnapshotsEqual(null, null)).toBe(true);
+    expect(axSnapshotsEqual(null, s1)).toBe(false);
+  });
+});
+
+describe('axElementRoleLabel', () => {
+  const mk = (role: string, type = ''): AxElement => ({
+    id: '0',
+    path: '0',
+    label: '',
+    value: '',
+    role,
+    type,
+    enabled: true,
+    focused: false,
+    frame: { x: 0, y: 0, width: 1, height: 1 },
+    selectors: {},
+    raw: {},
+  });
+
+  test('strips AX prefix and splits CamelCase', () => {
+    expect(axElementRoleLabel(mk('AXTextField'))).toBe('Text Field');
+    expect(axElementRoleLabel(mk('AXButton'))).toBe('Button');
+  });
+
+  test('rewrites GenericElement to "Element"', () => {
+    expect(axElementRoleLabel(mk('AXGenericElement'))).toBe('Element');
+  });
+
+  test('reduces fully-qualified Android class names to the last segment and humanizes', () => {
+    expect(axElementRoleLabel(mk('android.widget.TextView'))).toBe('Text View');
+    expect(axElementRoleLabel(mk('android.widget.FrameLayout'))).toBe('Frame Layout');
+  });
+
+  test('falls back to "element" for empty role/type', () => {
+    expect(axElementRoleLabel(mk('', ''))).toBe('element');
+  });
+});
+
+describe('axElementSummary', () => {
+  const mk = (label: string, role = 'Button'): AxElement => ({
+    id: '0',
+    path: '0',
+    label,
+    value: '',
+    role,
+    type: '',
+    enabled: true,
+    focused: false,
+    frame: { x: 0, y: 0, width: 1, height: 1 },
+    selectors: {},
+    raw: {},
+  });
+
+  test('concatenates role and label', () => {
+    expect(axElementSummary(mk('Sign in'))).toBe('Button · Sign in');
+  });
+
+  test('truncates long labels with ellipsis', () => {
+    const long = 'a'.repeat(120);
+    const summary = axElementSummary(mk(long));
+    expect(summary.length).toBeLessThan(120);
+    expect(summary).toMatch(/…$/);
+  });
+
+  test('drops label when empty', () => {
+    expect(axElementSummary(mk(''))).toBe('Button');
+  });
+});
+
+describe('axElementSelectorExpression', () => {
+  const mkIos = (sel: Partial<AxElement['selectors']>): AxElement => ({
+    id: '0',
+    path: '0',
+    label: '',
+    value: '',
+    role: '',
+    type: '',
+    enabled: true,
+    focused: false,
+    frame: { x: 0, y: 0, width: 1, height: 1 },
+    selectors: sel,
+    raw: {},
+  });
+
+  test('iOS: prefers AXUniqueId', () => {
+    expect(axElementSelectorExpression(mkIos({ AXUniqueId: 'signin' }), 'ios')).toBe(
+      'client.tapElement({ AXUniqueId: "signin" })',
+    );
+  });
+
+  test('iOS: falls back to AXLabel + type hint', () => {
+    expect(axElementSelectorExpression(mkIos({ AXLabel: 'OK', className: 'Button' }), 'ios')).toBe(
+      'client.tapElement({ AXLabel: "OK", type: "Button" })',
+    );
+  });
+
+  test('iOS: returns null when no selectors are usable', () => {
+    expect(axElementSelectorExpression(mkIos({}), 'ios')).toBeNull();
+    expect(axElementSelectorExpression(mkIos({ className: 'OnlyClass' }), 'ios')).toBeNull();
+  });
+
+  test('Android: prefers resourceId, then contentDesc, then text', () => {
+    expect(axElementSelectorExpression(mkIos({ resourceId: 'r1' }), 'android')).toMatch(/resourceId/);
+    expect(axElementSelectorExpression(mkIos({ contentDesc: 'cd' }), 'android')).toMatch(/contentDesc/);
+    expect(axElementSelectorExpression(mkIos({ text: 't' }), 'android')).toMatch(/text/);
+  });
+
+  test('escapes quotes in selector values via JSON.stringify', () => {
+    expect(axElementSelectorExpression(mkIos({ AXLabel: 'has "quotes"' }), 'ios')).toContain(
+      'AXLabel: "has \\"quotes\\""',
+    );
+  });
+});
+
+describe('AX_UNAVAILABLE_ERROR', () => {
+  test('is a non-empty string customers can compare against', () => {
+    expect(typeof AX_UNAVAILABLE_ERROR).toBe('string');
+    expect(AX_UNAVAILABLE_ERROR.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/core/ax-tree.ts
+++ b/packages/ui/src/core/ax-tree.ts
@@ -1,0 +1,416 @@
+// Accessibility tree types, normalizers, and helpers shared by the inspect
+// overlay and exported for customers building their own panels.
+//
+// We unify two server response shapes into a single AxSnapshot:
+//
+//   iOS (limulator):    {type:'elementTreeResult', id, json: '<nested-tree-json>'}
+//   Android (scrcpy):   {type:'getElementTreeResult', id, payload:{nodes:[flat]}}
+//                       (also emits legacy {type:'elementTreeResult', id, json:'<xml>'})
+//
+// Both are flattened into a single list of AxElement; positions are expressed
+// in a normalized screen coordinate space derived from the root rect so
+// rendering can use plain percentages.
+
+export interface AxRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface AxSelectors {
+  AXUniqueId?: string;
+  AXLabel?: string;
+  resourceId?: string;
+  contentDesc?: string;
+  text?: string;
+  className?: string;
+}
+
+export interface AxElement {
+  // Stable identity for React keys / selection persistence across snapshots.
+  // Prefers AXUniqueId / resourceId, falls back to a hierarchical path.
+  id: string;
+  // Hierarchical path within the source tree (e.g. "0.1.2"). Useful as a
+  // fallback identity and for debugging.
+  path: string;
+  // Human label (AXLabel on iOS, content-desc/text on Android).
+  label: string;
+  // Value (AXValue on iOS, text on Android inputs).
+  value: string;
+  // Semantic role (role_description on iOS, className on Android).
+  role: string;
+  // Element type / class name.
+  type: string;
+  // Whether the element is interactive.
+  enabled: boolean;
+  // Whether the element currently has focus.
+  focused: boolean;
+  // Bounds in the screen coordinate space of AxSnapshot.screen.
+  frame: AxRect;
+  // Selectors that map back to SDK tapElement / tap calls.
+  selectors: AxSelectors;
+  // Raw platform-specific node (without children/parsedBounds extras).
+  // Exposed so advanced customers can read fields we didn't surface.
+  raw: Record<string, unknown>;
+}
+
+export type AxPlatform = 'ios' | 'android';
+
+export interface AxSnapshot {
+  platform: AxPlatform;
+  screen: { width: number; height: number };
+  elements: AxElement[];
+  // Unix epoch ms when the response was decoded on the client.
+  capturedAt: number;
+  errors?: string[];
+}
+
+export const AX_UNAVAILABLE_ERROR = 'Accessibility unavailable on this device.';
+
+// Hard cap to keep React render time bounded on enormous trees.
+const MAX_ELEMENTS = 500;
+
+const rectsApproxEqual = (a: AxRect, b: AxRect): boolean =>
+  Math.abs(a.x - b.x) < 0.5 &&
+  Math.abs(a.y - b.y) < 0.5 &&
+  Math.abs(a.width - b.width) < 0.5 &&
+  Math.abs(a.height - b.height) < 0.5;
+
+const rectArea = (r: AxRect): number => Math.max(0, r.width) * Math.max(0, r.height);
+
+// ────────────────────────────────────────────────────────────────────────────
+// iOS normalization
+// ────────────────────────────────────────────────────────────────────────────
+
+interface RawIosNode {
+  AXLabel?: string | null;
+  AXValue?: string | null;
+  AXUniqueId?: string | null;
+  // `frame` is the canonical bounds; the legacy `AXFrame` string field is
+  // not consumed.
+  frame?: { x: number; y: number; width: number; height: number };
+  role?: string;
+  role_description?: string;
+  type?: string;
+  subrole?: string | null;
+  title?: string | null;
+  enabled?: boolean;
+  focused?: boolean;
+  pid?: number;
+  traits?: string[];
+  children?: RawIosNode[];
+  // Some serializations carry extras we'll preserve in `raw`.
+  [key: string]: unknown;
+}
+
+// Picks the "screen rectangle" used as the denominator when expressing
+// element positions as percentages.
+//
+// Apple's `accessibilityElementForFrontmostApplication()` returns the
+// foreground Application element as the (only) root; its `frame` is the
+// device's logical screen — `{x: 0, y: 0, width, height}` in points. The
+// element frames inside the tree are in this same coordinate space, so a
+// child at `(16, 64)` is 16pt from the device's left edge and 64pt from
+// the top edge.
+//
+// We accept any root whose frame has positive dimensions to be robust
+// against the edge case where the foreground app reports a non-zero
+// origin (e.g. status bar excluded). In practice that never happens; if
+// it does, percentages will be slightly off but the overlay will still
+// roughly line up. The defensive console.warn helps us catch this in
+// production telemetry without breaking the feature.
+const iosScreenFrame = (roots: RawIosNode[]): AxRect => {
+  const root = roots.find((n) => n.frame && n.frame.width > 0 && n.frame.height > 0);
+  if (root?.frame) {
+    if (Math.abs(root.frame.x) > 0.5 || Math.abs(root.frame.y) > 0.5) {
+      console.warn(
+        `[ax-tree] iOS root frame is not anchored at (0,0): ` +
+          `(${root.frame.x},${root.frame.y}). Element positions may be ` +
+          `slightly off from the rendered video.`,
+      );
+    }
+    return { x: 0, y: 0, width: root.frame.width, height: root.frame.height };
+  }
+  return { x: 0, y: 0, width: 1, height: 1 };
+};
+
+const buildIosSelectors = (node: RawIosNode): AxSelectors => {
+  const sel: AxSelectors = {};
+  if (typeof node.AXUniqueId === 'string' && node.AXUniqueId.length > 0) sel.AXUniqueId = node.AXUniqueId;
+  if (typeof node.AXLabel === 'string' && node.AXLabel.length > 0) sel.AXLabel = node.AXLabel;
+  if (typeof node.type === 'string' && node.type.length > 0) sel.className = node.type;
+  return sel;
+};
+
+const stripIosChildren = (node: RawIosNode): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(node)) {
+    if (k === 'children') continue;
+    out[k] = v;
+  }
+  return out;
+};
+
+export function normalizeIosTree(roots: RawIosNode[] | RawIosNode): AxSnapshot {
+  const rootArray = Array.isArray(roots) ? roots : [roots];
+  const screen = iosScreenFrame(rootArray);
+  const elements: AxElement[] = [];
+
+  const visit = (node: RawIosNode, path: string) => {
+    if (elements.length >= MAX_ELEMENTS) return;
+    const frame = node.frame;
+    if (frame && frame.width > 0 && frame.height > 0 && !rectsApproxEqual(frame, screen)) {
+      const role = (node.role_description as string | undefined) || (node.role as string | undefined) || '';
+      const label =
+        (typeof node.AXLabel === 'string' ? node.AXLabel : '') ||
+        (typeof node.title === 'string' ? (node.title as string) : '') ||
+        '';
+      elements.push({
+        id: typeof node.AXUniqueId === 'string' && node.AXUniqueId.length > 0 ? node.AXUniqueId : path,
+        path,
+        label,
+        value: typeof node.AXValue === 'string' ? node.AXValue : '',
+        role,
+        type: typeof node.type === 'string' ? node.type : '',
+        enabled: node.enabled !== false,
+        focused: node.focused === true,
+        frame: { x: frame.x, y: frame.y, width: frame.width, height: frame.height },
+        selectors: buildIosSelectors(node),
+        raw: stripIosChildren(node),
+      });
+    }
+    const children = Array.isArray(node.children) ? node.children : [];
+    for (let i = 0; i < children.length && elements.length < MAX_ELEMENTS; i++) {
+      visit(children[i]!, `${path}.${i}`);
+    }
+  };
+
+  for (let i = 0; i < rootArray.length && elements.length < MAX_ELEMENTS; i++) {
+    visit(rootArray[i]!, String(i));
+  }
+
+  return {
+    platform: 'ios',
+    screen: { width: screen.width, height: screen.height },
+    elements,
+    capturedAt: Date.now(),
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Android normalization
+// ────────────────────────────────────────────────────────────────────────────
+
+interface RawAndroidParsedBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  centerX: number;
+  centerY: number;
+}
+
+interface RawAndroidNode {
+  index?: string;
+  text?: string;
+  resourceId?: string;
+  className?: string;
+  packageName?: string;
+  contentDesc?: string;
+  clickable?: boolean;
+  enabled?: boolean;
+  focusable?: boolean;
+  focused?: boolean;
+  scrollable?: boolean;
+  selected?: boolean;
+  bounds?: string;
+  parsedBounds?: RawAndroidParsedBounds;
+  [key: string]: unknown;
+}
+
+const androidScreenFrame = (nodes: RawAndroidNode[]): AxRect => {
+  // Take the largest rect — uiautomator's first node is typically the
+  // screen-spanning FrameLayout, but tolerate weirdness by scanning.
+  let best: AxRect = { x: 0, y: 0, width: 1, height: 1 };
+  let bestArea = 0;
+  for (const n of nodes) {
+    const pb = n.parsedBounds;
+    if (!pb) continue;
+    const w = pb.right - pb.left;
+    const h = pb.bottom - pb.top;
+    const area = Math.max(0, w) * Math.max(0, h);
+    if (area > bestArea) {
+      bestArea = area;
+      best = { x: 0, y: 0, width: w, height: h };
+    }
+  }
+  return best;
+};
+
+const buildAndroidSelectors = (node: RawAndroidNode): AxSelectors => {
+  const sel: AxSelectors = {};
+  if (typeof node.resourceId === 'string' && node.resourceId.length > 0) sel.resourceId = node.resourceId;
+  if (typeof node.contentDesc === 'string' && node.contentDesc.length > 0) sel.contentDesc = node.contentDesc;
+  if (typeof node.text === 'string' && node.text.length > 0) sel.text = node.text;
+  if (typeof node.className === 'string' && node.className.length > 0) sel.className = node.className;
+  return sel;
+};
+
+export function normalizeAndroidTree(nodes: RawAndroidNode[]): AxSnapshot {
+  const screen = androidScreenFrame(nodes);
+  const elements: AxElement[] = [];
+
+  for (let i = 0; i < nodes.length && elements.length < MAX_ELEMENTS; i++) {
+    const node = nodes[i]!;
+    const pb = node.parsedBounds;
+    if (!pb) continue;
+    const width = Math.max(0, pb.right - pb.left);
+    const height = Math.max(0, pb.bottom - pb.top);
+    if (width <= 0 || height <= 0) continue;
+    const frame: AxRect = { x: pb.left, y: pb.top, width, height };
+    if (rectsApproxEqual(frame, { x: 0, y: 0, width: screen.width, height: screen.height })) continue;
+
+    const label = node.contentDesc || node.text || '';
+    const role = node.className || '';
+    elements.push({
+      id:
+        node.resourceId && node.resourceId.length > 0 ? node.resourceId
+        : node.contentDesc && node.contentDesc.length > 0 ? `cd:${node.contentDesc}`
+        : String(i),
+      path: String(i),
+      label,
+      value: typeof node.text === 'string' ? node.text : '',
+      role,
+      type: role,
+      enabled: node.enabled !== false,
+      focused: node.focused === true,
+      frame,
+      selectors: buildAndroidSelectors(node),
+      raw: { ...node },
+    });
+  }
+
+  return {
+    platform: 'android',
+    screen: { width: screen.width, height: screen.height },
+    elements,
+    capturedAt: Date.now(),
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Generic helpers (exported for customers building their own panels)
+// ────────────────────────────────────────────────────────────────────────────
+
+export function clampAxFrameForScreen(
+  frame: AxRect,
+  screen: { width: number; height: number },
+): AxRect | null {
+  const x = Math.max(0, frame.x);
+  const y = Math.max(0, frame.y);
+  const right = Math.min(screen.width, frame.x + frame.width);
+  const bottom = Math.min(screen.height, frame.y + frame.height);
+  const width = Math.max(0, right - x);
+  const height = Math.max(0, bottom - y);
+  return width > 0 && height > 0 ? { x, y, width, height } : null;
+}
+
+export function axElementsEqual(a: AxElement, b: AxElement): boolean {
+  if (a === b) return true;
+  if (a.id !== b.id || a.path !== b.path) return false;
+  if (a.label !== b.label || a.value !== b.value) return false;
+  if (a.role !== b.role || a.type !== b.type) return false;
+  if (a.enabled !== b.enabled || a.focused !== b.focused) return false;
+  const fa = a.frame;
+  const fb = b.frame;
+  return fa.x === fb.x && fa.y === fb.y && fa.width === fb.width && fa.height === fb.height;
+}
+
+export function axSnapshotsEqual(a: AxSnapshot | null, b: AxSnapshot | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.platform !== b.platform) return false;
+  if (a.screen.width !== b.screen.width || a.screen.height !== b.screen.height) return false;
+  if (a.elements.length !== b.elements.length) return false;
+  for (let i = 0; i < a.elements.length; i++) {
+    if (!axElementsEqual(a.elements[i]!, b.elements[i]!)) return false;
+  }
+  return true;
+}
+
+// Returns the smallest matching element under the given point (in screen
+// coordinate space). Used by the overlay for hit-testing when boxes overlap.
+export function axElementAtPoint(snapshot: AxSnapshot, x: number, y: number): AxElement | null {
+  let best: AxElement | null = null;
+  let bestArea = Infinity;
+  for (const el of snapshot.elements) {
+    const f = el.frame;
+    if (x < f.x || y < f.y || x > f.x + f.width || y > f.y + f.height) continue;
+    const area = rectArea(f);
+    if (area < bestArea) {
+      bestArea = area;
+      best = el;
+    }
+  }
+  return best;
+}
+
+// Produces a one-line SDK selector expression that customers can paste into
+// code. Returns null when no usable selector exists.
+export function axElementSelectorExpression(el: AxElement, platform: AxPlatform): string | null {
+  if (platform === 'ios') {
+    if (el.selectors.AXUniqueId) {
+      return `client.tapElement({ AXUniqueId: ${JSON.stringify(el.selectors.AXUniqueId)} })`;
+    }
+    if (el.selectors.AXLabel) {
+      const typeHint = el.selectors.className ? `, type: ${JSON.stringify(el.selectors.className)}` : '';
+      return `client.tapElement({ AXLabel: ${JSON.stringify(el.selectors.AXLabel)}${typeHint} })`;
+    }
+    return null;
+  }
+  // android
+  if (el.selectors.resourceId) {
+    return `client.tap({ selector: { resourceId: ${JSON.stringify(el.selectors.resourceId)} } })`;
+  }
+  if (el.selectors.contentDesc) {
+    return `client.tap({ selector: { contentDesc: ${JSON.stringify(el.selectors.contentDesc)} } })`;
+  }
+  if (el.selectors.text) {
+    return `client.tap({ selector: { text: ${JSON.stringify(el.selectors.text)} } })`;
+  }
+  return null;
+}
+
+// Cleans up internal-looking role tokens. iOS's `role_description` can be
+// raw strings like "AXGenericElement" or empty when AppKit doesn't have a
+// description for the role. Android sets role to the className which is
+// often fully-qualified (`android.widget.TextView`); strip the package.
+export function axElementRoleLabel(el: AxElement): string {
+  const raw = el.role || el.type || '';
+  if (!raw) return 'element';
+  // Drop "AX" prefix and split CamelCase into spaced words ("AXTextField" → "Text Field").
+  let cleaned = raw.replace(/^AX/, '');
+  // For Android fully-qualified names, keep just the last segment.
+  if (cleaned.includes('.')) {
+    cleaned = cleaned.split('.').pop()!;
+  }
+  // Reject the generic catch-all bucket; callers can decide to hide it.
+  if (cleaned === 'GenericElement') return 'Element';
+  // Lightly humanize CamelCase.
+  cleaned = cleaned.replace(/([a-z])([A-Z])/g, '$1 $2');
+  return cleaned;
+}
+
+// A short human-readable summary used in tooltips and the info card title.
+// Truncated to avoid blowing up tooltips on elements with paragraph-length
+// AXLabels.
+const SUMMARY_MAX_LABEL_LEN = 80;
+export function axElementSummary(el: AxElement): string {
+  const role = axElementRoleLabel(el);
+  const text = el.label || el.value || '';
+  if (!text) return role;
+  const trimmed =
+    text.length > SUMMARY_MAX_LABEL_LEN ? text.slice(0, SUMMARY_MAX_LABEL_LEN).trimEnd() + '…' : text;
+  return `${role} · ${trimmed}`;
+}

--- a/packages/ui/src/demo.tsx
+++ b/packages/ui/src/demo.tsx
@@ -1,16 +1,38 @@
 import { useState, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RemoteControl, RemoteControlHandle } from './components/remote-control';
+import { AxSnapshot } from './core/ax-tree';
+
+type InspectChoice = 'off' | 'hover-only' | 'select';
+
+// Pre-fill from query string so the developer testing the demo can deeplink
+// `?url=...&token=...&inspect=select&autoconnect=1`. Nothing is persisted.
+const initialParams = new URLSearchParams(window.location.search);
+const initialUrl = initialParams.get('url') || 'ws://localhost:8833/signaling';
+const initialToken = initialParams.get('token') || 'token';
+const initialPlatformParam = initialParams.get('platform');
+const initialPlatform: 'ios' | 'android' = initialPlatformParam === 'android' ? 'android' : 'ios';
+const initialInspect = (initialParams.get('inspect') as InspectChoice | null) ?? 'off';
+const initialAutoconnect =
+  initialParams.get('autoconnect') === '1' && initialParams.has('url') && initialParams.has('token');
 
 function Demo() {
-  const [url, setUrl] = useState('ws://localhost:8833/signaling');
-  const [token, setToken] = useState('token');
-  const [platform, setPlatform] = useState<'ios' | 'android'>('ios');
-  const [isConnected, setIsConnected] = useState(false);
+  const [url, setUrl] = useState(initialUrl);
+  const [token, setToken] = useState(initialToken);
+  const [platform, setPlatform] = useState<'ios' | 'android'>(initialPlatform);
+  const [isConnected, setIsConnected] = useState(initialAutoconnect);
   const [key, setKey] = useState(0);
   const [showDebugInfo, setShowDebugInfo] = useState(false);
+  const [inspectChoice, setInspectChoice] = useState<InspectChoice>(initialInspect);
+  const [latestSnapshot, setLatestSnapshot] = useState<AxSnapshot | null>(null);
+  const [latestSelection, setLatestSelection] = useState<string | null>(null);
 
   const remoteControlRef = useRef<RemoteControlHandle>(null);
+
+  const inspectModeProp: boolean | 'hover-only' | undefined =
+    inspectChoice === 'off' ? undefined
+    : inspectChoice === 'hover-only' ? 'hover-only'
+    : true;
 
   const handleConnect = () => {
     if (url) {
@@ -112,6 +134,19 @@ function Demo() {
             </label>
           </div>
 
+          <div className="control-group">
+            <label htmlFor="inspect-mode">Inspect Mode</label>
+            <select
+              id="inspect-mode"
+              value={inspectChoice}
+              onChange={(e) => setInspectChoice(e.target.value as InspectChoice)}
+            >
+              <option value="off">Off</option>
+              <option value="hover-only">Hover-only (input still works)</option>
+              <option value="select">Select (click to pin, ESC to clear)</option>
+            </select>
+          </div>
+
           <div className="button-group">
             {!isConnected ?
               <button className="primary" onClick={handleConnect} disabled={!url}>
@@ -153,14 +188,62 @@ function Demo() {
         )}
 
         {isConnected ?
-          <div className="device-preview">
-            <div className="preview-item">
-              <h3>{platform === 'ios' ? '📱 iOS with Frame' : '🤖 Android (No Frame)'}</h3>
-              <div className="device-wrapper">
-                <RemoteControl key={key} ref={remoteControlRef} url={url} token={token} />
+          <>
+            <div className="device-preview">
+              <div className="preview-item">
+                <h3>{platform === 'ios' ? '📱 iOS with Frame' : '🤖 Android (No Frame)'}</h3>
+                <div className="device-wrapper">
+                  <RemoteControl
+                    key={key}
+                    ref={remoteControlRef}
+                    url={url}
+                    token={token}
+                    inspectMode={inspectModeProp}
+                    onAxSnapshotChange={setLatestSnapshot}
+                    onInspectSelectionChange={(sel) =>
+                      setLatestSelection(
+                        sel ?
+                          `${sel.element.role || sel.element.type} · ${sel.element.label || '(no label)'}`
+                        : null,
+                      )
+                    }
+                  />
+                </div>
               </div>
             </div>
-          </div>
+
+            {inspectChoice !== 'off' && (
+              <div
+                style={{
+                  marginTop: '20px',
+                  background: '#0f172a',
+                  color: '#e2e8f0',
+                  border: '1px solid #1e293b',
+                  borderRadius: '8px',
+                  padding: '12px 14px',
+                  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                  fontSize: '12px',
+                }}
+              >
+                <div
+                  style={{
+                    fontWeight: 600,
+                    marginBottom: '6px',
+                    display: 'flex',
+                    gap: '12px',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <span>Inspect debug (demo-only)</span>
+                  <span style={{ color: '#94a3b8', fontWeight: 400 }}>
+                    elements: {latestSnapshot?.elements.length ?? 0} · screen:{' '}
+                    {latestSnapshot ? `${latestSnapshot.screen.width}×${latestSnapshot.screen.height}` : '—'}{' '}
+                    · platform: {latestSnapshot?.platform ?? '—'} · selection: {latestSelection ?? '(none)'}
+                  </span>
+                </div>
+              </div>
+            )}
+          </>
         : <div
             style={{
               textAlign: 'center',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,19 @@
 export { RemoteControl } from './components/remote-control';
 export type { RemoteControlHandle } from './components/remote-control';
+
+// Accessibility / inspect-mode types and helpers. Exported so customers can
+// build their own side panels, search UIs, or agent-driven inspectors on top
+// of the snapshots delivered via `onAxSnapshotChange`.
+export type { AxSnapshot, AxElement, AxRect, AxSelectors, AxPlatform } from './core/ax-tree';
+export type { AxStatus } from './core/ax-fetcher';
+export {
+  axElementAtPoint,
+  axElementSelectorExpression,
+  axElementSummary,
+  axElementsEqual,
+  axSnapshotsEqual,
+  clampAxFrameForScreen,
+  normalizeAndroidTree,
+  normalizeIosTree,
+  AX_UNAVAILABLE_ERROR,
+} from './core/ax-tree';

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+// Vitest config for @limrun/ui unit tests.
+//
+// We use jsdom as the default environment because the runtime code uses
+// browser globals (window.setTimeout, window.requestAnimationFrame, etc.).
+// Pure modules can opt back into the node env per-file via:
+//
+//   // @vitest-environment node
+//
+// at the top of the test file.
+//
+// The actual <RemoteControl> component is intentionally NOT under unit
+// test here — its WebRTC plumbing is integration-tested via the demo +
+// staging instance. These tests cover the smaller, pure-logic modules:
+// `core/ax-tree.ts` and `core/ax-fetcher.ts`.
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    globals: false,
+  },
+});

--- a/packages/ui/yarn.lock
+++ b/packages/ui/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@asamuzakjp/css-color@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
+  integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.3"
+    "@csstools/css-color-parser" "^3.0.9"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@ast-grep/napi-darwin-arm64@0.36.3":
   version "0.36.3"
   resolved "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.36.3.tgz#21300034de594055beb56d5e5e26589380934918"
@@ -87,85 +98,198 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
+"@csstools/color-helpers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
+  integrity sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==
+
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.4.tgz#8473f63e2fcd6e459838dd412401d5948f224c65"
+  integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
+
+"@csstools/css-color-parser@^3.0.9":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz#4e386af3a99dd36c46fef013cfe4c1c341eed6f0"
+  integrity sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==
+  dependencies:
+    "@csstools/color-helpers" "^5.1.0"
+    "@csstools/css-calc" "^2.1.4"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz#5755370a9a29abaec5515b43c8b3f2cf9c2e3076"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
+
+"@esbuild/aix-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
+  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
+
 "@esbuild/aix-ppc64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz#bef96351f16520055c947aba28802eede3c9e9a9"
   integrity sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==
+
+"@esbuild/android-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
+  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
 
 "@esbuild/android-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz#d2e70be7d51a529425422091e0dcb90374c1546c"
   integrity sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==
 
+"@esbuild/android-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
+  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
+
 "@esbuild/android-arm@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz#d2a753fe2a4c73b79437d0ba1480e2d760097419"
   integrity sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==
+
+"@esbuild/android-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
+  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
 
 "@esbuild/android-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz#5278836e3c7ae75761626962f902a0d55352e683"
   integrity sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==
 
+"@esbuild/darwin-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
 "@esbuild/darwin-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz#f1513eaf9ec8fa15dcaf4c341b0f005d3e8b47ae"
   integrity sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==
+
+"@esbuild/darwin-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
+  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
 
 "@esbuild/darwin-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz#e27dbc3b507b3a1cea3b9280a04b8b6b725f82be"
   integrity sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==
 
+"@esbuild/freebsd-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
+  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
+
 "@esbuild/freebsd-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz#364e3e5b7a1fd45d92be08c6cc5d890ca75908ca"
   integrity sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==
+
+"@esbuild/freebsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
+  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
 
 "@esbuild/freebsd-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz#7c869b45faeb3df668e19ace07335a0711ec56ab"
   integrity sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==
 
+"@esbuild/linux-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
+  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+
 "@esbuild/linux-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz#48d42861758c940b61abea43ba9a29b186d6cb8b"
   integrity sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==
+
+"@esbuild/linux-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
+  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
 
 "@esbuild/linux-arm@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz#6ce4b9cabf148274101701d112b89dc67cc52f37"
   integrity sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==
 
+"@esbuild/linux-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
+  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
+
 "@esbuild/linux-ia32@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz#207e54899b79cac9c26c323fc1caa32e3143f1c4"
   integrity sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==
+
+"@esbuild/linux-loong64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
+  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
 
 "@esbuild/linux-loong64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz#0ba48a127159a8f6abb5827f21198b999ffd1fc0"
   integrity sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==
 
+"@esbuild/linux-mips64el@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
+  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
+
 "@esbuild/linux-mips64el@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz#a4d4cc693d185f66a6afde94f772b38ce5d64eb5"
   integrity sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==
+
+"@esbuild/linux-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
+  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
 
 "@esbuild/linux-ppc64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz#0f5805c1c6d6435a1dafdc043cb07a19050357db"
   integrity sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==
 
+"@esbuild/linux-riscv64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
+  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
+
 "@esbuild/linux-riscv64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz#6776edece0f8fca79f3386398b5183ff2a827547"
   integrity sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==
 
+"@esbuild/linux-s390x@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
+  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
+
 "@esbuild/linux-s390x@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz#3f6f29ef036938447c2218d309dc875225861830"
   integrity sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==
+
+"@esbuild/linux-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
+  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
 "@esbuild/linux-x64@0.25.9":
   version "0.25.9"
@@ -177,6 +301,11 @@
   resolved "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz#06f99d7eebe035fbbe43de01c9d7e98d2a0aa548"
   integrity sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==
 
+"@esbuild/netbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
+  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
+
 "@esbuild/netbsd-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz#db99858e6bed6e73911f92a88e4edd3a8c429a52"
@@ -186,6 +315,11 @@
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz#afb886c867e36f9d86bb21e878e1185f5d5a0935"
   integrity sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==
+
+"@esbuild/openbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
+  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
 
 "@esbuild/openbsd-x64@0.25.9":
   version "0.25.9"
@@ -197,20 +331,40 @@
   resolved "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz#2f2144af31e67adc2a8e3705c20c2bd97bd88314"
   integrity sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==
 
+"@esbuild/sunos-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
+  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
+
 "@esbuild/sunos-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz#69b99a9b5bd226c9eb9c6a73f990fddd497d732e"
   integrity sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==
+
+"@esbuild/win32-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
+  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
 
 "@esbuild/win32-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz#d789330a712af916c88325f4ffe465f885719c6b"
   integrity sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==
 
+"@esbuild/win32-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
+  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
+
 "@esbuild/win32-ia32@0.25.9":
   version "0.25.9"
   resolved "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz#52fc735406bd49688253e74e4e837ac2ba0789e3"
   integrity sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==
+
+"@esbuild/win32-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@esbuild/win32-x64@0.25.9":
   version "0.25.9"
@@ -296,50 +450,110 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.1.tgz#7d41dc45adcfcb272504ebcea9c8a5b2c659e963"
   integrity sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag==
 
+"@rollup/rollup-android-arm-eabi@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz#3a04f01e9f01392bbef5920b94aa3b88794be7ab"
+  integrity sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==
+
 "@rollup/rollup-android-arm64@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.1.tgz#6c708fae2c9755e994c42d56c34a94cb77020650"
   integrity sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw==
+
+"@rollup/rollup-android-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz#e371b653ceabc900790ae73f5548a0fd7cd63a70"
+  integrity sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==
 
 "@rollup/rollup-darwin-arm64@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.1.tgz#85ccf92ab114e434c83037a175923a525635cbb4"
   integrity sha512-xc6i2AuWh++oGi4ylOFPmzJOEeAa2lJeGUGb4MudOtgfyyjr4UPNK+eEWTPLvmPJIY/pgw6ssFIox23SyrkkJw==
 
+"@rollup/rollup-darwin-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz#2a5aa70432e39816d666d79287a7324cfc3b4e72"
+  integrity sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==
+
 "@rollup/rollup-darwin-x64@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.1.tgz#0af089f3d658d05573208dabb3a392b44d7f4630"
   integrity sha512-2ofU89lEpDYhdLAbRdeyz/kX3Y2lpYc6ShRnDjY35bZhd2ipuDMDi6ZTQ9NIag94K28nFMofdnKeHR7BT0CATw==
+
+"@rollup/rollup-darwin-x64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz#c3b5b49629379cd9cdc5d841bf00ed44ebf393dd"
+  integrity sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==
 
 "@rollup/rollup-freebsd-arm64@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.1.tgz#46c22a16d18180e99686647543335567221caa9c"
   integrity sha512-wOsE6H2u6PxsHY/BeFHA4VGQN3KUJFZp7QJBmDYI983fgxq5Th8FDkVuERb2l9vDMs1D5XhOrhBrnqcEY6l8ZA==
 
+"@rollup/rollup-freebsd-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz#f929d8e0462fae6602fc960beeabd7287d859283"
+  integrity sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==
+
 "@rollup/rollup-freebsd-x64@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.1.tgz#819ffef2f81891c266456952962a13110c8e28b5"
   integrity sha512-A/xeqaHTlKbQggxCqispFAcNjycpUEHP52mwMQZUNqDUJFFYtPHCXS1VAG29uMlDzIVr+i00tSFWFLivMcoIBQ==
+
+"@rollup/rollup-freebsd-x64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz#c01cb58031226f95d0900b1ec847f4fb32c6e809"
+  integrity sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==
 
 "@rollup/rollup-linux-arm-gnueabihf@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.1.tgz#7fe283c14793e607e653a3214b09f8973f08262a"
   integrity sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==
 
+"@rollup/rollup-linux-arm-gnueabihf@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz#f29d890c4858c8e0d3be01677eef4f6a359eed9d"
+  integrity sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==
+
 "@rollup/rollup-linux-arm-musleabihf@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.1.tgz#066e92eb22ea30560414ec800a6d119ba0b435ac"
   integrity sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==
+
+"@rollup/rollup-linux-arm-musleabihf@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz#1ebfc8eb9f66136ed2faae5f44995add5ca3c964"
+  integrity sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==
 
 "@rollup/rollup-linux-arm64-gnu@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.1.tgz#480d518ea99a8d97b2a174c46cd55164f138cc37"
   integrity sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==
 
+"@rollup/rollup-linux-arm64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz#c1fa823c2c4ce46ba7f61de1a4c3fdadd4fb4e7b"
+  integrity sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==
+
 "@rollup/rollup-linux-arm64-musl@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.1.tgz#ed7db3b8999b60dd20009ddf71c95f3af49423c8"
   integrity sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==
+
+"@rollup/rollup-linux-arm64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz#a7f18854d0471b78bda8ea38f0891a4e059b571d"
+  integrity sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==
+
+"@rollup/rollup-linux-loong64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz#83658a9a4576bcce8cef85b2c78b9b649d2200c4"
+  integrity sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==
+
+"@rollup/rollup-linux-loong64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz#fd2af677ae3417bb58d57ae37dd0d84686e40244"
+  integrity sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==
 
 "@rollup/rollup-linux-loongarch64-gnu@4.50.1":
   version "4.50.1"
@@ -351,50 +565,115 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.1.tgz#a006700469be0041846c45b494c35754e6a04eea"
   integrity sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==
 
+"@rollup/rollup-linux-ppc64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz#6481647181c4cf8f1ddbd99f62c84cfc56c1a94a"
+  integrity sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==
+
+"@rollup/rollup-linux-ppc64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz#18610a1a1550e28a5042ca916f898419540f17f4"
+  integrity sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==
+
 "@rollup/rollup-linux-riscv64-gnu@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.1.tgz#0fcc45b2ec8a0e54218ca48849ea6d596f53649c"
   integrity sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==
+
+"@rollup/rollup-linux-riscv64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz#597bb80465a2621dbe0de0a41c66394a8a7e9a6e"
+  integrity sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==
 
 "@rollup/rollup-linux-riscv64-musl@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.1.tgz#d6e617eec9fe6f5859ee13fad435a16c42b469f2"
   integrity sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==
 
+"@rollup/rollup-linux-riscv64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz#a2a919a9f927ef7f24a60af77e3cb55f1ad59e4d"
+  integrity sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==
+
 "@rollup/rollup-linux-s390x-gnu@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.1.tgz#b147760d63c6f35b4b18e6a25a2a760dd3ea0c05"
   integrity sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==
+
+"@rollup/rollup-linux-s390x-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz#3166f6ceae7df9bbfddf9f36be1937231e13e3c6"
+  integrity sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==
 
 "@rollup/rollup-linux-x64-gnu@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.1.tgz#fc0be1da374f85e7e85dccaf1ff12d7cfc9fbe3d"
   integrity sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==
 
+"@rollup/rollup-linux-x64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz#23c9bf79771d804fb87415eb0767569f273261e5"
+  integrity sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==
+
 "@rollup/rollup-linux-x64-musl@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.1.tgz#54c79932e0f9a3c992b034c82325be3bcde0d067"
   integrity sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==
+
+"@rollup/rollup-linux-x64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz#97941c6b94d67fe25cde0f027c10a19f2d1fdd39"
+  integrity sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==
+
+"@rollup/rollup-openbsd-x64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz#7aeb7d92e2cd1d399f56daf75c39040b777b6c77"
+  integrity sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==
 
 "@rollup/rollup-openharmony-arm64@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.1.tgz#fc48e74d413623ac02c1d521bec3e5e784488fdc"
   integrity sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==
 
+"@rollup/rollup-openharmony-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz#925de61ae83bf99aa636e8acea87432e8c0ffaab"
+  integrity sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==
+
 "@rollup/rollup-win32-arm64-msvc@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.1.tgz#8ce3d1181644406362cf1e62c90e88ab083e02bb"
   integrity sha512-hpZB/TImk2FlAFAIsoElM3tLzq57uxnGYwplg6WDyAxbYczSi8O2eQ+H2Lx74504rwKtZ3N2g4bCUkiamzS6TQ==
+
+"@rollup/rollup-win32-arm64-msvc@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz#888ab83842721491044c46a7407e1f38f3235bb4"
+  integrity sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==
 
 "@rollup/rollup-win32-ia32-msvc@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.1.tgz#dd2dfc896eac4b2689d55f01c6d51c249263f805"
   integrity sha512-SXjv8JlbzKM0fTJidX4eVsH+Wmnp0/WcD8gJxIZyR6Gay5Qcsmdbi9zVtnbkGPG8v2vMR1AD06lGWy5FLMcG7A==
 
+"@rollup/rollup-win32-ia32-msvc@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz#fa30ac24e3f0232139d2a47500560a28695764d4"
+  integrity sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==
+
+"@rollup/rollup-win32-x64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz#223e2bc93f86e0707568e1fadb5b537e50c976c7"
+  integrity sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==
+
 "@rollup/rollup-win32-x64-msvc@4.50.1":
   version "4.50.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.1.tgz#13f758c97b9fbbac56b6928547a3ff384e7cfb3e"
   integrity sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==
+
+"@rollup/rollup-win32-x64-msvc@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz#da4f1676d87e2bdf744291b504b0ab79550c3e61"
+  integrity sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==
 
 "@rushstack/node-core-library@5.14.0":
   version "5.14.0"
@@ -547,6 +826,65 @@
     "@rolldown/pluginutils" "1.0.0-beta.32"
     "@swc/core" "^1.13.2"
 
+"@vitest/expect@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.9.tgz#b566ea20d58ea6578d8dc37040d6c1a47ebe5ff8"
+  integrity sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    tinyrainbow "^1.2.0"
+
+"@vitest/mocker@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.9.tgz#36243b27351ca8f4d0bbc4ef91594ffd2dc25ef5"
+  integrity sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+
+"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.9.tgz#434ff2f7611689f9ce70cd7d567eceb883653fdf"
+  integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
+  dependencies:
+    tinyrainbow "^1.2.0"
+
+"@vitest/runner@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.1.9.tgz#cc18148d2d797fd1fd5908d1f1851d01459be2f6"
+  integrity sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==
+  dependencies:
+    "@vitest/utils" "2.1.9"
+    pathe "^1.1.2"
+
+"@vitest/snapshot@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.1.9.tgz#24260b93f798afb102e2dcbd7e61c6dfa118df91"
+  integrity sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+
+"@vitest/spy@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.9.tgz#cb28538c5039d09818b8bfa8edb4043c94727c60"
+  integrity sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.9.tgz#4f2486de8a54acf7ecbf2c5c24ad7994a680a6c1"
+  integrity sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    loupe "^3.1.2"
+    tinyrainbow "^1.2.0"
+
 "@volar/language-core@2.4.23", "@volar/language-core@~2.4.11":
   version "2.4.23"
   resolved "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz#deb6dbc5fdbafa9bb7ba691fc59cb196cdb856d3"
@@ -619,6 +957,11 @@ acorn@^8.15.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
 ajv-draft-04@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz#3b64761b268ba0b9e668f0b41ba53fce0ad77fc8"
@@ -673,6 +1016,11 @@ argparse@~1.0.9:
   dependencies:
     sprintf-js "~1.0.2"
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -684,6 +1032,27 @@ brace-expansion@^2.0.1:
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
+
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
+chai@^5.1.2:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 clsx@^2.1.1:
   version "2.1.1"
@@ -705,15 +1074,38 @@ confbox@^0.2.2:
   resolved "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz#8652f53961c74d9e081784beed78555974a9c110"
   integrity sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==
 
+cssstyle@^4.2.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.6.0.tgz#ea18007024e3167f4f105315f3ec2d982bf48ed9"
+  integrity sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==
+  dependencies:
+    "@asamuzakjp/css-color" "^3.2.0"
+    rrweb-cssom "^0.8.0"
+
 csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
+
+debug@4, debug@^4.3.4, debug@^4.3.7:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@^4.4.0:
   version "4.4.1"
@@ -722,10 +1114,59 @@ debug@^4.4.0:
   dependencies:
     ms "^2.1.3"
 
+decimal.js@^10.5.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+
 entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
+es-module-lexer@^1.5.4:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
+esbuild@^0.21.3:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
+  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.21.5"
+    "@esbuild/android-arm" "0.21.5"
+    "@esbuild/android-arm64" "0.21.5"
+    "@esbuild/android-x64" "0.21.5"
+    "@esbuild/darwin-arm64" "0.21.5"
+    "@esbuild/darwin-x64" "0.21.5"
+    "@esbuild/freebsd-arm64" "0.21.5"
+    "@esbuild/freebsd-x64" "0.21.5"
+    "@esbuild/linux-arm" "0.21.5"
+    "@esbuild/linux-arm64" "0.21.5"
+    "@esbuild/linux-ia32" "0.21.5"
+    "@esbuild/linux-loong64" "0.21.5"
+    "@esbuild/linux-mips64el" "0.21.5"
+    "@esbuild/linux-ppc64" "0.21.5"
+    "@esbuild/linux-riscv64" "0.21.5"
+    "@esbuild/linux-s390x" "0.21.5"
+    "@esbuild/linux-x64" "0.21.5"
+    "@esbuild/netbsd-x64" "0.21.5"
+    "@esbuild/openbsd-x64" "0.21.5"
+    "@esbuild/sunos-x64" "0.21.5"
+    "@esbuild/win32-arm64" "0.21.5"
+    "@esbuild/win32-ia32" "0.21.5"
+    "@esbuild/win32-x64" "0.21.5"
 
 esbuild@^0.25.0:
   version "0.25.9"
@@ -763,6 +1204,18 @@ estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
+expect-type@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 exsolve@^1.0.7:
   version "1.0.7"
@@ -825,6 +1278,36 @@ he@^1.2.0:
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 import-lazy@~4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
@@ -842,10 +1325,41 @@ is-core-module@^2.16.0:
   dependencies:
     hasown "^2.0.2"
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 jju@~1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
+jsdom@^26.0.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.1.0.tgz#ab5f1c1cafc04bd878725490974ea5e8bf0c72b3"
+  integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
+  dependencies:
+    cssstyle "^4.2.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.5.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.6"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.16"
+    parse5 "^7.2.1"
+    rrweb-cssom "^0.8.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.1.1"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.1.1"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
 
 json-schema-traverse@^1.0.0:
   version "1.0.0"
@@ -880,12 +1394,29 @@ lodash@~4.17.15:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loupe@^3.1.0, loupe@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
+lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+magic-string@^0.30.12:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 magic-string@^0.30.17:
   version "0.30.19"
@@ -933,6 +1464,23 @@ nanoid@^3.3.11:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
+nanoid@^3.3.12:
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+
+nwsapi@^2.2.16:
+  version "2.2.23"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.23.tgz#59712c3a88e6de2bb0b6ccc1070397267019cf6c"
+  integrity sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==
+
+parse5@^7.2.1:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 path-browserify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
@@ -951,10 +1499,20 @@ path@^0.12.7:
     process "^0.11.1"
     util "^0.10.3"
 
+pathe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
 pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -984,6 +1542,15 @@ pkg-types@^2.3.0:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
+postcss@^8.4.43:
+  version "8.5.15"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
+  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
+  dependencies:
+    nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 postcss@^8.5.6:
   version "8.5.6"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
@@ -998,7 +1565,7 @@ process@^0.11.1:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -1034,6 +1601,40 @@ resolve@~1.22.1, resolve@~1.22.2:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+rollup@^4.20.0:
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.4.tgz#ca3814f5900da3ac3981d2e0c61944b7e6e0cb09"
+  integrity sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.60.4"
+    "@rollup/rollup-android-arm64" "4.60.4"
+    "@rollup/rollup-darwin-arm64" "4.60.4"
+    "@rollup/rollup-darwin-x64" "4.60.4"
+    "@rollup/rollup-freebsd-arm64" "4.60.4"
+    "@rollup/rollup-freebsd-x64" "4.60.4"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.60.4"
+    "@rollup/rollup-linux-arm-musleabihf" "4.60.4"
+    "@rollup/rollup-linux-arm64-gnu" "4.60.4"
+    "@rollup/rollup-linux-arm64-musl" "4.60.4"
+    "@rollup/rollup-linux-loong64-gnu" "4.60.4"
+    "@rollup/rollup-linux-loong64-musl" "4.60.4"
+    "@rollup/rollup-linux-ppc64-gnu" "4.60.4"
+    "@rollup/rollup-linux-ppc64-musl" "4.60.4"
+    "@rollup/rollup-linux-riscv64-gnu" "4.60.4"
+    "@rollup/rollup-linux-riscv64-musl" "4.60.4"
+    "@rollup/rollup-linux-s390x-gnu" "4.60.4"
+    "@rollup/rollup-linux-x64-gnu" "4.60.4"
+    "@rollup/rollup-linux-x64-musl" "4.60.4"
+    "@rollup/rollup-openbsd-x64" "4.60.4"
+    "@rollup/rollup-openharmony-arm64" "4.60.4"
+    "@rollup/rollup-win32-arm64-msvc" "4.60.4"
+    "@rollup/rollup-win32-ia32-msvc" "4.60.4"
+    "@rollup/rollup-win32-x64-gnu" "4.60.4"
+    "@rollup/rollup-win32-x64-msvc" "4.60.4"
+    fsevents "~2.3.2"
+
 rollup@^4.43.0:
   version "4.50.1"
   resolved "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz#6f0717c34aacc65cc727eeaaaccc2afc4e4485fd"
@@ -1064,6 +1665,23 @@ rollup@^4.43.0:
     "@rollup/rollup-win32-x64-msvc" "4.50.1"
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
+
 scheduler@^0.26.0:
   version "0.26.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz#4ce8a8c2a2095f13ea11bf9a445be50c555d6337"
@@ -1075,6 +1693,11 @@ semver@~7.5.4:
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
 source-map-js@^1.2.1:
   version "1.2.1"
@@ -1090,6 +1713,16 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.8.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 string-argv@~0.3.1:
   version "0.3.2"
@@ -1113,6 +1746,21 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
 tinyglobby@^0.2.15:
   version "0.2.15"
   resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
@@ -1120,6 +1768,47 @@ tinyglobby@^0.2.15:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.3"
+
+tinypool@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
+  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
+
+tldts-core@^6.1.86:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.86.tgz#a93e6ed9d505cb54c542ce43feb14c73913265d8"
+  integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
+
+tldts@^6.1.32:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.86.tgz#087e0555b31b9725ee48ca7e77edc56115cd82f7"
+  integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
+  dependencies:
+    tldts-core "^6.1.86"
+
+tough-cookie@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
+  dependencies:
+    tldts "^6.1.32"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
 
 typescript@5.8.2:
   version "5.8.2"
@@ -1150,6 +1839,17 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
+vite-node@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.1.9.tgz#549710f76a643f1c39ef34bdb5493a944e4f895f"
+  integrity sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.7"
+    es-module-lexer "^1.5.4"
+    pathe "^1.1.2"
+    vite "^5.0.0"
+
 vite-plugin-dts@^4.5.4:
   version "4.5.4"
   resolved "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz#51b60aaaa760d9cf5c2bb3676c69d81910d6b08c"
@@ -1174,6 +1874,17 @@ vite-plugin-lib-inject-css@^2.2.2:
     magic-string "^0.30.17"
     picocolors "^1.1.1"
 
+vite@^5.0.0:
+  version "5.4.21"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vite@^7.1.4:
   version "7.1.5"
   resolved "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz#4dbcb48c6313116689be540466fc80faa377be38"
@@ -1188,10 +1899,91 @@ vite@^7.1.4:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vitest@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.9.tgz#7d01ffd07a553a51c87170b5e80fea3da7fb41e7"
+  integrity sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+  dependencies:
+    "@vitest/expect" "2.1.9"
+    "@vitest/mocker" "2.1.9"
+    "@vitest/pretty-format" "^2.1.9"
+    "@vitest/runner" "2.1.9"
+    "@vitest/snapshot" "2.1.9"
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    debug "^4.3.7"
+    expect-type "^1.1.0"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.1"
+    tinypool "^1.0.1"
+    tinyrainbow "^1.2.0"
+    vite "^5.0.0"
+    vite-node "2.1.9"
+    why-is-node-running "^2.3.0"
+
 vscode-uri@^3.0.8:
   version "3.1.0"
   resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
+
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0, whatwg-url@^14.1.1:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
+
+ws@^8.18.0:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new inspect-mode polling/state machine and UI overlay on top of `RemoteControl`, introducing new async WebSocket traffic, input-blocking behavior, and exported APIs that could affect runtime performance and interaction handling.
> 
> **Overview**
> Adds an **AX-tree “inspect mode”** to `RemoteControl` that polls accessibility snapshots over the existing signaling WebSocket and renders an overlay of element bounds on top of the video stream (hover-only preview or click-to-select mode with ESC-to-clear).
> 
> Introduces `core/ax-tree` (snapshot/element normalization for iOS+Android plus hit-testing and selector helpers) and `core/ax-fetcher` (single-flight polling with change-detect backoff, activity-based boost, status transitions), exports these helpers publicly, and adds Vitest coverage.
> 
> Updates the demo to toggle inspect mode and show snapshot/selection debug info, adjusts the fullstack example to consume `@limrun/ui` via a local `file:` install with Vite `react`/`react-dom` deduping, and bumps `@limrun/ui` to `0.8.1` with new test tooling dependencies/config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e5eb0643d6762e0dc9761ce480051711e3951f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->