### PR TITLE
auth: fix email sign-in/sign-up flow

### DIFF
--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -48,7 +48,10 @@ export async function login(consoleEndpoint: string, version: string): Promise<v
     });
 
     server.listen(CALLBACK_PORT, () => {
-      const loginUrl = new URL('/authn/login', consoleEndpoint);
+      // Navigate to /authn/cli directly so the console stores it as `returnTo`
+      // and returns here after sign-in to mint an API key and POST it back.
+      // Routing via /authn/login drops the query string on email magiclink.
+      const loginUrl = new URL('/authn/cli', consoleEndpoint);
       loginUrl.searchParams.set('user-agent', `lim/${version}`);
       open(loginUrl.toString()).catch(() => {
         console.log(`Open this URL in your browser to log in:\n${loginUrl.toString()}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the CLI authentication entrypoint URL; a wrong route or returnTo handling could break login across platforms, but the change is small and localized.
> 
> **Overview**
> Updates the CLI login flow to open the console’s dedicated `'/authn/cli'` route (instead of `'/authn/login'`) so the console reliably stores `returnTo` and preserves the callback query string for email magic-link sign-in/sign-up, ensuring the API key is minted and posted back to the local callback server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190690098a3b0df31f13d338d5dd3cec72e30ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->