### PR TITLE
xcode: document dev server launch URLs

### DIFF
--- a/packages/cli/skills/limrun-ios/SKILL.md
+++ b/packages/cli/skills/limrun-ios/SKILL.md
@@ -66,7 +66,7 @@ Use `--configuration Debug` or `--configuration Release` when the app needs a sp
 lim xcode build . --configuration Debug
 ```
 
-If omitted, Limrun uses limbuild's project-type default: `Debug` for native Xcode builds and `Release` for React Native / Expo builds. `--dev-server-url` is only supported with `--configuration Debug`.
+If omitted, Limrun uses limbuild's project-type default: `Debug` for native Xcode builds and `Release` for React Native / Expo builds. `--dev-server-url` is only supported with `--configuration Debug` for React Native / Expo builds. It is a post-install launch URL: limbuild validates that it is a parseable absolute URL, then opens it unchanged after installing on the attached simulator.
 
 For Expo dev-client builds, do not use plain `exp://`; Expo Go may intercept it. Use the app scheme: `expo.scheme` from `app.json` when present, otherwise Expo dev-client's generated default `exp+{expo.slug}`.
 
@@ -83,7 +83,7 @@ lim xcode build . --configuration Debug \
   --dev-server-url 'myapp://expo-development-client/?url=http%3A%2F%2F<reverse-host>%3A57090'
 ```
 
-`--dev-server-url` may not auto-open the bundle after install. If the app launches without connecting to Metro, open the same URL explicitly:
+If the app launches without connecting to Metro, open the same URL explicitly to separate build/install issues from dev-client URL issues:
 
 ```bash
 lim ios open-url --id <ios-instance-id> \

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -21,7 +21,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build --scheme MyApp --workspace MyApp.xcworkspace',
     '<%= config.bin %> xcode build --configuration Debug',
     '<%= config.bin %> xcode build ./ExpoApp --configuration Debug --dev-server-url https://abc123.exp.direct',
-    '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url exp://abc123.exp.direct',
+    '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
@@ -59,7 +59,7 @@ export default class XcodeBuild extends BaseCommand {
     }),
     'dev-server-url': Flags.string({
       description:
-        'Expo development server URL for Debug builds. If the build is installed on an attached iOS simulator, the app opens this URL after build; otherwise this option has no launch effect. Accepts https://, http://, exp://, and exp+... links. For plain http:// URLs, your app must be configured to allow that connection on iOS. HTTPS Expo tunnel URLs do not require this.',
+        'Launch URL for Debug React Native / Expo builds. If the build is installed on an attached iOS simulator, the app opens this URL unchanged after build; otherwise this option has no launch effect. For Expo dev-client builds, pass the exact dev-client URL or development server URL you want opened.',
     }),
     'expo-app-dir': Flags.string({
       description:

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -72,15 +72,13 @@ export type ReactNativeBuildConfig = {
    */
   expoAppDir?: string;
   /**
-   * Expo development server URL for Debug builds, such as the
-   * https://...exp.direct URL printed by `expo start --tunnel`.
+   * Launch URL for Debug React Native / Expo builds.
    *
    * If the build is installed on an attached iOS simulator, the app opens this
-   * URL after build. Otherwise, this option has no launch effect.
+   * URL unchanged after build. Otherwise, this option has no launch effect.
    *
-   * Accepted forms are https://..., http://..., exp://..., and exp+... links.
-   * For plain http:// URLs, your app must be configured to allow that
-   * connection on iOS. HTTPS Expo tunnel URLs do not require this.
+   * For Expo dev-client builds, pass the exact dev-client URL or development
+   * server URL you want opened.
    */
   devServerURL?: string;
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates around `--dev-server-url` semantics and recommended Expo dev-client URLs; no runtime logic changes.
> 
> **Overview**
> Clarifies `lim xcode build --dev-server-url` as a *post-install launch URL* for **Debug React Native / Expo builds**, stating it is validated as an absolute URL and then opened unchanged on the attached simulator.
> 
> Updates CLI help text and examples to steer Expo dev-client users toward passing the exact dev-client deep link (rather than `exp://`), and expands the Limrun iOS skill guide with tunnel/Metro URL guidance and troubleshooting steps (e.g., using `lim ios open-url`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47fdf5831dce384c588aa087fea5d558a88476fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->