### PR TITLE
Fix native iOS project detection

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"

--- a/packages/cli/src/commands/go.ts
+++ b/packages/cli/src/commands/go.ts
@@ -3,6 +3,7 @@ import { BaseCommand } from '../base-command';
 import { readConfig, registerCreatedInstance } from '../lib/config';
 import { detectProject, type ProjectDetection } from '../lib/project-detection';
 import {
+  applyProjectEnvApiKey,
   ensureLoggedIn,
   ensureProjectEnvApiKey,
   ensureSampleRepo,
@@ -29,6 +30,10 @@ export default class Go extends BaseCommand {
     const { flags } = await this.parse(Go);
     this.setParsedFlags(flags);
 
+    const detection = detectProject(process.cwd());
+    const envRoot = detection.kind === 'sample' ? process.cwd() : detection.projectDir;
+    const projectEnvApiKey = flags['api-key'] ? undefined : applyProjectEnvApiKey(envRoot).apiKey;
+
     await ensureLoggedIn({
       version: VERSION,
       apiKey: flags['api-key'],
@@ -36,8 +41,7 @@ export default class Go extends BaseCommand {
     });
 
     const apiKey = flags['api-key'] || readConfig().apiKey;
-    const allowAuthRetry = !flags['api-key'];
-    const detection = detectProject(process.cwd());
+    const allowAuthRetry = !flags['api-key'] && !projectEnvApiKey && !process.env['LIM_API_KEY'];
     if (detection.kind === 'native-ios') {
       await this.setupExistingProject(detection, [IOS_SKILL], apiKey, allowAuthRetry);
       return;

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
+import { parse as parseDotenv } from 'dotenv';
 
 import { readConfig } from './config';
 import {
@@ -24,6 +25,7 @@ const SAMPLE_CLONE_TIMEOUT_MS = 300_000;
 type OnboardingAgent = Extract<AgentId, 'claude' | 'cursor'>;
 type SkillStatus = 'installed' | 'unchanged' | 'skipped';
 const ONBOARDING_AGENTS: OnboardingAgent[] = ['cursor', 'claude'];
+const PROJECT_ENV_FILES = ['.env', '.env.local'];
 
 export interface SkillInstallResult {
   skill: string;
@@ -55,6 +57,11 @@ export interface EnvApiKeyResult {
   warnings: string[];
 }
 
+export interface ProjectEnvApiKeyResult {
+  apiKey?: string;
+  path?: string;
+}
+
 const ENV_API_KEY_RE = /^\s*(?:export\s+)?LIM_API_KEY\s*=/;
 
 class OnboardingError extends Error {
@@ -76,6 +83,20 @@ export async function ensureLoggedIn({ version, apiKey, log }: EnsureLoggedInOpt
   const { login } = await import('./auth');
   await login(config.consoleEndpoint, version);
   log?.('Logged in to Limrun.');
+}
+
+export function applyProjectEnvApiKey(projectRoot: string): ProjectEnvApiKeyResult {
+  const result = readProjectEnvApiKey(projectRoot);
+  if (!result.apiKey) {
+    return result;
+  }
+
+  const dotEnvApiKey = readEnvFileApiKey(path.join(projectRoot, '.env'));
+  const current = process.env['LIM_API_KEY'];
+  if (!current || current === dotEnvApiKey) {
+    process.env['LIM_API_KEY'] = result.apiKey;
+  }
+  return result;
 }
 
 export function ensureProjectEnvApiKey(projectRoot: string, apiKey: string): EnvApiKeyResult {
@@ -131,6 +152,27 @@ export function ensureProjectEnvApiKey(projectRoot: string, apiKey: string): Env
     fs.chmodSync(envPath, 0o600);
   }
   return { warnings };
+}
+
+function readProjectEnvApiKey(projectRoot: string): ProjectEnvApiKeyResult {
+  let result: ProjectEnvApiKeyResult = {};
+  for (const fileName of PROJECT_ENV_FILES) {
+    const envPath = path.join(projectRoot, fileName);
+    const apiKey = readEnvFileApiKey(envPath);
+    if (apiKey) {
+      result = { apiKey, path: envPath };
+    }
+  }
+  return result;
+}
+
+function readEnvFileApiKey(envPath: string): string | undefined {
+  const stat = lstatIfExists(envPath);
+  if (!stat || stat.isSymbolicLink() || !stat.isFile()) {
+    return undefined;
+  }
+  const parsed = parseDotenv(fs.readFileSync(envPath));
+  return parsed['LIM_API_KEY'];
 }
 
 function lstatIfExists(filePath: string): fs.Stats | undefined {

--- a/packages/cli/src/lib/project-detection.ts
+++ b/packages/cli/src/lib/project-detection.ts
@@ -34,6 +34,10 @@ const WALK_EXCLUDES = new Set([
   'Carthage',
 ]);
 
+function isXcodeBundle(name: string): boolean {
+  return name.endsWith('.xcodeproj') || name.endsWith('.xcworkspace');
+}
+
 function safeReadDir(dir: string): fs.Dirent[] {
   try {
     return fs.readdirSync(dir, { withFileTypes: true });
@@ -53,6 +57,7 @@ function walkDirs(root: string, maxDepth = DEFAULT_MAX_DEPTH): string[] {
     for (const entry of safeReadDir(dir)) {
       if (!entry.isDirectory()) continue;
       if (WALK_EXCLUDES.has(entry.name)) continue;
+      if (isXcodeBundle(entry.name)) continue;
       visit(path.join(dir, entry.name), depth + 1);
     }
   }
@@ -108,6 +113,7 @@ function isSameOrInside(parent: string, child: string): boolean {
 }
 
 export function detectProject(root = process.cwd()): ProjectDetection {
+  const rootPath = path.resolve(root);
   const dirs = walkDirs(root);
   const iosCandidates = dirs
     .map((dir) => ({ dir, ...iosProjectFiles(dir) }))
@@ -119,6 +125,13 @@ export function detectProject(root = process.cwd()): ProjectDetection {
     if (iosCandidates.every((candidate) => isSameOrInside(expoDir, candidate.dir))) {
       return { kind: 'expo', projectDir: expoDir };
     }
+  }
+  const rootIosCandidates = iosCandidates.filter((candidate) => path.resolve(candidate.dir) === rootPath);
+  if (rootIosCandidates.length === 1 && expoCandidates.length === 0) {
+    return {
+      kind: 'native-ios',
+      projectDir: rootIosCandidates[0]!.dir,
+    };
   }
   if (iosCandidates.length === 1 && expoCandidates.length === 0) {
     const candidate = iosCandidates[0]!;

--- a/tests/cli-onboarding.test.ts
+++ b/tests/cli-onboarding.test.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'child_process';
 
 import { detectProject } from '../packages/cli/src/lib/project-detection';
 import {
+  applyProjectEnvApiKey,
   ensureSampleRepo,
   ensureProjectEnvApiKey,
   installProjectSkills,
@@ -142,6 +143,61 @@ describe('lim go skill installation', () => {
 });
 
 describe('lim go project env setup', () => {
+  const originalApiKey = process.env['LIM_API_KEY'];
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env['LIM_API_KEY'];
+    } else {
+      process.env['LIM_API_KEY'] = originalApiKey;
+    }
+  });
+
+  test('loads LIM_API_KEY from project .env.local before login', () => {
+    const projectRoot = makeTempDir();
+    try {
+      delete process.env['LIM_API_KEY'];
+      writeFile(path.join(projectRoot, '.env'), 'LIM_API_KEY=lim_env_key\n');
+      writeFile(path.join(projectRoot, '.env.local'), 'LIM_API_KEY=lim_local_key\n');
+
+      expect(applyProjectEnvApiKey(projectRoot)).toEqual({
+        apiKey: 'lim_local_key',
+        path: path.join(projectRoot, '.env.local'),
+      });
+      expect(process.env['LIM_API_KEY']).toBe('lim_local_key');
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('does not override an explicit process LIM_API_KEY with project env files', () => {
+    const projectRoot = makeTempDir();
+    try {
+      process.env['LIM_API_KEY'] = 'lim_shell_key';
+      writeFile(path.join(projectRoot, '.env.local'), 'LIM_API_KEY=lim_local_key\n');
+
+      expect(applyProjectEnvApiKey(projectRoot).apiKey).toBe('lim_local_key');
+      expect(process.env['LIM_API_KEY']).toBe('lim_shell_key');
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('lets .env.local override a .env value loaded by dotenv/config', () => {
+    const projectRoot = makeTempDir();
+    try {
+      process.env['LIM_API_KEY'] = 'lim_env_key';
+      writeFile(path.join(projectRoot, '.env'), 'LIM_API_KEY=lim_env_key\n');
+      writeFile(path.join(projectRoot, '.env.local'), 'LIM_API_KEY=lim_local_key\n');
+
+      applyProjectEnvApiKey(projectRoot);
+
+      expect(process.env['LIM_API_KEY']).toBe('lim_local_key');
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test('creates missing .env with LIM_API_KEY using private file mode', () => {
     const projectRoot = makeTempDir();
     try {

--- a/tests/cli-onboarding.test.ts
+++ b/tests/cli-onboarding.test.ts
@@ -49,11 +49,43 @@ function fakeRemoteSkills(root: string, names: string[]): LoadedRemoteSkills {
 }
 
 describe('lim go project detection', () => {
-  test('detects one native iOS app directory with project and workspace files', () => {
+  test('detects a default Xcode native iOS app without counting bundle internals', () => {
     const root = makeTempDir();
     try {
-      fs.mkdirSync(path.join(root, 'App.xcodeproj'), { recursive: true });
-      fs.mkdirSync(path.join(root, 'App.xcworkspace'), { recursive: true });
+      writeFile(path.join(root, 'App.xcodeproj', 'project.pbxproj'), '');
+      writeFile(path.join(root, 'App.xcodeproj', 'project.xcworkspace', 'contents.xcworkspacedata'), '');
+      writeFile(path.join(root, 'App', 'ContentView.swift'), '');
+
+      expect(detectProject(root)).toMatchObject({
+        kind: 'native-ios',
+        projectDir: root,
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('detects native iOS apps in a conventional ios directory', () => {
+    const root = makeTempDir();
+    try {
+      writeFile(path.join(root, 'ios', 'App.xcodeproj', 'project.pbxproj'), '');
+      writeFile(path.join(root, 'ios', 'App', 'ContentView.swift'), '');
+
+      expect(detectProject(root)).toMatchObject({
+        kind: 'native-ios',
+        projectDir: path.join(root, 'ios'),
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('prefers a root iOS app when nested stale sample projects also exist', () => {
+    const root = makeTempDir();
+    try {
+      writeFile(path.join(root, 'App.xcodeproj', 'project.pbxproj'), '');
+      writeFile(path.join(root, 'App', 'ContentView.swift'), '');
+      writeFile(path.join(root, 'sample-native-app', 'sample-native-app.xcodeproj', 'project.pbxproj'), '');
 
       expect(detectProject(root)).toMatchObject({
         kind: 'native-ios',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Onboarding and detection logic only; API key reads use existing symlink guards and do not broaden secret exposure beyond prior .env handling.
> 
> **Overview**
> **`lim go`** now picks up **`LIM_API_KEY`** from project **`.env`** / **`.env.local`** (with **`.env.local`** winning) before prompting for browser login, and skips interactive auth retry when that key (or an explicit shell **`LIM_API_KEY`**) is already available.
> 
> **Native iOS detection** is tightened: directory walks no longer descend into **`.xcodeproj`** / **`.xcworkspace`** bundles (avoiding false “multiple projects”), and when the repo root is a single iOS app, that root is preferred over nested stale projects (e.g. **`sample-native-app`**). CLI version bumps to **0.10.1** with expanded onboarding tests for these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa91444ffa316e69bbbebb792a80ae5ae23ecbd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->