### PR TITLE
cli: fix login callback wait

### DIFF
--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -1,26 +1,86 @@
 import http from 'http';
-import open from 'open';
+import type { Socket } from 'net';
 import { writeConfig, CONFIG_KEYS } from './config';
 
 const CALLBACK_PORT = 32412;
+const CALLBACK_HOST = 'localhost';
 const CALLBACK_PATH = '/authn/callback';
+const LOGIN_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+interface LoginOptions {
+  consoleEndpoint: string;
+  version: string;
+  callbackHost?: string;
+  callbackPort?: number;
+  configWriter?: typeof writeConfig;
+  opener?: (url: string) => Promise<unknown> | unknown;
+  timeoutMs?: number;
+}
+
+async function openLoginUrl(url: string): Promise<void> {
+  const importEsm = new Function('specifier', 'return import(specifier)') as (
+    specifier: string,
+  ) => Promise<typeof import('open')>;
+  const { default: open } = await importEsm('open');
+  await open(url);
+}
 
 export async function login(consoleEndpoint: string, version: string): Promise<void> {
+  return loginWithOptions({ consoleEndpoint, version });
+}
+
+export async function loginWithOptions(options: LoginOptions): Promise<void> {
   return new Promise((resolve, reject) => {
+    const { consoleEndpoint, version } = options;
+    const callbackHost = options.callbackHost ?? CALLBACK_HOST;
+    const callbackPort = options.callbackPort ?? CALLBACK_PORT;
+    const configWriter = options.configWriter ?? writeConfig;
+    const sockets = new Set<Socket>();
+    let settled = false;
+    let callbackTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const closeServer = () => {
+      if (server.listening) {
+        server.close();
+      }
+      server.closeIdleConnections?.();
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+    };
+
+    const settle = (err?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (callbackTimeout) {
+        clearTimeout(callbackTimeout);
+      }
+      closeServer();
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    };
+
     const server = http.createServer((req, res) => {
       // CORS preflight
       if (req.method === 'OPTIONS') {
         res.writeHead(200, {
           'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+          'Access-Control-Allow-Methods': 'GET, OPTIONS',
           'Access-Control-Allow-Headers': '*',
           'Access-Control-Max-Age': '86400',
+          'Access-Control-Allow-Private-Network': 'true',
+          Connection: 'close',
         });
         res.end();
         return;
       }
 
-      const url = new URL(req.url || '/', `http://localhost:${CALLBACK_PORT}`);
+      const url = new URL(req.url || '/', `http://${callbackHost}:${callbackPort}`);
       if (url.pathname !== CALLBACK_PATH) {
         res.writeHead(404);
         res.end('Not found');
@@ -31,32 +91,49 @@ export async function login(consoleEndpoint: string, version: string): Promise<v
 
       const apiKey = url.searchParams.get(CONFIG_KEYS.apiKey);
       if (!apiKey) {
-        res.writeHead(400);
-        res.end('missing api-key');
-        server.close();
-        reject(new Error('Login callback received without api-key'));
+        res.writeHead(400, { Connection: 'close' });
+        res.end('missing api-key', () => {
+          settle(new Error('Login callback received without api-key'));
+        });
         return;
       }
 
-      writeConfig({ [CONFIG_KEYS.apiKey]: apiKey });
-      res.writeHead(200);
-      res.end('OK');
-
-      server.close(() => {
-        resolve();
+      try {
+        configWriter({ [CONFIG_KEYS.apiKey]: apiKey });
+      } catch (err) {
+        res.writeHead(500, { Connection: 'close' });
+        res.end('failed to save api-key', () => {
+          settle(err instanceof Error ? err : new Error(String(err)));
+        });
+        return;
+      }
+      res.writeHead(200, { Connection: 'close' });
+      res.end('OK', () => {
+        settle();
       });
     });
 
-    server.listen(CALLBACK_PORT, () => {
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.on('close', () => {
+        sockets.delete(socket);
+      });
+    });
+
+    server.listen(callbackPort, callbackHost, () => {
       const loginUrl = new URL('/authn/login', consoleEndpoint);
       loginUrl.searchParams.set('user-agent', `lim/${version}`);
-      open(loginUrl.toString()).catch(() => {
+      Promise.resolve((options.opener ?? openLoginUrl)(loginUrl.toString())).catch(() => {
         console.log(`Open this URL in your browser to log in:\n${loginUrl.toString()}`);
       });
     });
 
+    callbackTimeout = setTimeout(() => {
+      settle(new Error('Login timed out waiting for browser authorization. Run `lim login` again to retry.'));
+    }, options.timeoutMs ?? LOGIN_CALLBACK_TIMEOUT_MS);
+
     server.on('error', (err) => {
-      reject(new Error(`Failed to start login server on port ${CALLBACK_PORT}: ${err.message}`));
+      settle(new Error(`Failed to start login server on ${callbackHost}:${callbackPort}: ${err.message}`));
     });
   });
 }

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -55,7 +55,6 @@ function request(
   });
 }
 
-
 describe('lim login callback server', () => {
   test('writes the api key and resolves promptly after a keep-alive callback', async () => {
     const port = await getAvailablePort();

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -1,0 +1,163 @@
+import http from 'http';
+import net from 'net';
+
+const CONSOLE_ENDPOINT = 'https://console.example.test';
+
+function getAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, 'localhost', () => {
+      const address = server.address();
+      if (typeof address !== 'object' || !address) {
+        server.close();
+        reject(new Error('Failed to allocate test port'));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+function request(
+  port: number,
+  options: {
+    agent?: http.Agent;
+    headers?: http.OutgoingHttpHeaders;
+    method?: string;
+    path: string;
+  },
+): Promise<{ body: string; headers: http.IncomingHttpHeaders; statusCode: number | undefined }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        agent: options.agent,
+        headers: options.headers,
+        host: 'localhost',
+        method: options.method ?? 'GET',
+        path: options.path,
+        port,
+      },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          resolve({ body, headers: res.headers, statusCode: res.statusCode });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+
+describe('lim login callback server', () => {
+  test('writes the api key and resolves promptly after a keep-alive callback', async () => {
+    const port = await getAvailablePort();
+    const agent = new http.Agent({ keepAlive: true });
+    const configWrites: Array<Partial<Record<string, string>>> = [];
+    let hangingSocket: net.Socket | undefined;
+    let hangingSocketClosed: Promise<void> = Promise.resolve();
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+
+    try {
+      const loginPromise = loginWithOptions({
+        consoleEndpoint: CONSOLE_ENDPOINT,
+        version: 'test',
+        callbackPort: port,
+        configWriter: (partial) => {
+          configWrites.push(partial);
+        },
+        opener: () => {
+          hangingSocket = net.createConnection({ host: 'localhost', port });
+          hangingSocketClosed = new Promise((resolve) => {
+            hangingSocket?.on('close', () => resolve());
+          });
+          void request(port, { agent, path: '/authn/callback?api-key=lim_test_key' }).catch(() => {});
+        },
+        timeoutMs: 1_000,
+      });
+
+      const timeout = new Promise((resolve) => setTimeout(() => resolve('timeout'), 500));
+      await expect(Promise.race([loginPromise.then(() => 'resolved'), timeout])).resolves.toBe('resolved');
+      await expect(Promise.race([hangingSocketClosed.then(() => 'closed'), timeout])).resolves.toBe('closed');
+      expect(configWrites).toEqual([{ 'api-key': 'lim_test_key' }]);
+    } finally {
+      agent.destroy();
+      hangingSocket?.destroy();
+    }
+  });
+
+  test('allows browser private-network preflight before callback delivery', async () => {
+    const port = await getAvailablePort();
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+    let preflightHeaders: http.IncomingHttpHeaders | undefined;
+
+    await loginWithOptions({
+      consoleEndpoint: CONSOLE_ENDPOINT,
+      version: 'test',
+      callbackPort: port,
+      configWriter: () => {},
+      opener: () => {
+        void (async () => {
+          const preflight = await request(port, {
+            headers: {
+              Origin: 'https://console.limrun.com',
+              'Access-Control-Request-Method': 'GET',
+              'Access-Control-Request-Private-Network': 'true',
+            },
+            method: 'OPTIONS',
+            path: '/authn/callback?api-key=lim_test_key',
+          });
+          preflightHeaders = preflight.headers;
+          await request(port, { path: '/authn/callback?api-key=lim_test_key' });
+        })().catch(() => {});
+      },
+      timeoutMs: 1_000,
+    });
+
+    expect(preflightHeaders?.['access-control-allow-private-network']).toBe('true');
+    expect(preflightHeaders?.connection).toBe('close');
+  });
+
+  test('rejects when the browser never calls back', async () => {
+    const port = await getAvailablePort();
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+
+    await expect(
+      loginWithOptions({
+        consoleEndpoint: CONSOLE_ENDPOINT,
+        version: 'test',
+        callbackPort: port,
+        configWriter: () => {},
+        opener: () => undefined,
+        timeoutMs: 10,
+      }),
+    ).rejects.toThrow('Login timed out waiting for browser authorization');
+  });
+
+  test('rejects cleanly when saving the api key fails', async () => {
+    const port = await getAvailablePort();
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+
+    await expect(
+      loginWithOptions({
+        consoleEndpoint: CONSOLE_ENDPOINT,
+        version: 'test',
+        callbackPort: port,
+        configWriter: () => {
+          throw new Error('disk full');
+        },
+        opener: () => {
+          void request(port, { path: '/authn/callback?api-key=lim_test_key' }).catch(() => {});
+        },
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow('disk full');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches CLI authentication and API key persistence; behavior changes could affect all `lim login` flows, though scope is localized and covered by new tests.
> 
> **Overview**
> Fixes **`lim login`** hanging after the browser returns the API key by only finishing the login promise after the callback response is fully sent, then tearing down tracked connections (including keep-alive sockets).
> 
> The local callback server now supports **private-network CORS preflight** (`Access-Control-Allow-Private-Network`), uses **`Connection: close`**, and fails fast on missing keys or config write errors. A **5-minute timeout** covers callbacks that never arrive. **`loginWithOptions`** injects host/port, config writer, opener, and timeout for tests; **`open`** is loaded via dynamic import. New **`cli-auth`** tests cover keep-alive resolution, preflight, timeout, and save failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70fc9705c8d1b32f156243dd69a1d048c1f368da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->