### PR TITLE
cli: add spinners for lim run and make detection choice optional

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -24,7 +24,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.28.7",
+    "@limrun/api": "0.28.8",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -427,19 +427,20 @@ function formatDurationMs(ms: number): string {
   return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
 }
 
-function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
-    return value;
-  }
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 function bold(value: string): string {
   return `\x1b[1m${value}\x1b[22m`;
 }
 
 function environmentUserName(): string {
-  return process.env['USER'] || process.env['USERNAME'] || os.userInfo().username || 'Limrun';
+  return process.env['USER'] || process.env['USERNAME'] || safeOsUserName() || 'Limrun';
+}
+
+function safeOsUserName(): string | undefined {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return undefined;
+  }
 }
 
 function progressLine(line: string): string {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,4 +1,7 @@
+import os from 'os';
 import path from 'path';
+import { ux } from '@oclif/core';
+import prompts from 'prompts';
 import { BaseCommand } from '../base-command';
 import { readConfig, registerCreatedInstance } from '../lib/config';
 import { detectProject, type ProjectDetection } from '../lib/project-detection';
@@ -10,12 +13,26 @@ import {
   installProjectSkills,
   type SkillInstallResult,
 } from '../lib/onboarding';
-import { xcodeSandboxIdFromUrl } from '../lib/xcode-sandbox';
 
 const VERSION = require('../../package.json').version;
 
 const IOS_SKILL = 'limrun-xcode-and-ios-simulator';
 const EXPO_SKILL = 'limrun-expo-development';
+const SPINNER_FRAMES =
+  process.platform === 'win32' ? ['-', '\\', '|', '/'] : ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const SUCCESS_ICON = process.platform === 'win32' ? '√' : '✔';
+const FAILURE_ICON = process.platform === 'win32' ? '×' : '✖';
+const BUILD_LOG_TAIL_LINES = 10;
+type DetectedProject = Extract<ProjectDetection, { kind: 'native-ios' | 'expo' }>;
+type BuildAndLaunchOptions = {
+  projectRoot: string;
+  displayName: string;
+  labels: Record<string, string>;
+  progressLabel: string;
+  failureLabel: string;
+  recoveryPath: string;
+  recoveryFromDir: string;
+};
 
 export default class Run extends BaseCommand {
   static baseFlags = {
@@ -26,13 +43,16 @@ export default class Run extends BaseCommand {
   static summary = 'Get started with Limrun';
   static description = 'Prepare your app for Limrun, or launch a working sample in a cloud simulator.';
   static examples = ['<%= config.bin %> run'];
+  private progress?: ProgressState;
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Run);
     this.setParsedFlags(flags);
 
     const detection = detectProject(process.cwd());
-    const envRoot = detection.kind === 'sample' ? process.cwd() : detection.projectDir;
+    const useDetectedProject =
+      detection.kind !== 'sample' ? await this.shouldUseDetectedProject(detection) : false;
+    const envRoot = detection.kind !== 'sample' && useDetectedProject ? detection.projectDir : process.cwd();
     const projectEnvApiKey = flags['api-key'] ? undefined : applyProjectEnvApiKey(envRoot).apiKey;
 
     await ensureLoggedIn({
@@ -43,11 +63,11 @@ export default class Run extends BaseCommand {
 
     const apiKey = flags['api-key'] || readConfig().apiKey;
     const allowAuthRetry = !flags['api-key'] && !projectEnvApiKey && !process.env['LIM_API_KEY'];
-    if (detection.kind === 'native-ios') {
+    if (detection.kind === 'native-ios' && useDetectedProject) {
       await this.setupExistingProject(detection, [IOS_SKILL], apiKey, allowAuthRetry);
       return;
     }
-    if (detection.kind === 'expo') {
+    if (detection.kind === 'expo' && useDetectedProject) {
       await this.setupExistingProject(detection, [IOS_SKILL, EXPO_SKILL], apiKey, allowAuthRetry);
       return;
     }
@@ -63,26 +83,57 @@ export default class Run extends BaseCommand {
   ): Promise<void> {
     const projectRoot = detection.projectDir;
     const projectPath = humanPath(projectRoot);
-    await this.validateAuth(allowAuthRetry);
-    this.info('Detected an iOS/Expo project.');
-    this.info('Installing Limrun agent skills...');
-    const results = await installProjectSkills({ projectRoot, skillNames });
+    await this.withProgress('Checking Limrun access', () => this.validateAuth(allowAuthRetry));
+    this.success(`Detected an iOS/Expo project at ${projectPath}`);
+    const results = await this.withProgress('Installing Limrun agent skills', () =>
+      installProjectSkills({ projectRoot, skillNames }),
+    );
     this.printSkillSummary(results);
     this.printEnvWarnings(ensureProjectEnvApiKey(projectRoot, apiKey).warnings);
-    this.info('Configured .env for Limrun.');
+    this.success('Configured .env for Limrun');
+
+    const streamUrl = await this.buildAndLaunchProject({
+      projectRoot,
+      displayName: 'lim-run-project',
+      labels: {
+        name: 'lim-run-project',
+        projectKind: detection.kind,
+      },
+      progressLabel: buildProgressLabel(detection.kind),
+      failureLabel: 'Build failed',
+      recoveryPath: projectRoot,
+      recoveryFromDir: process.cwd(),
+    });
 
     this.output('');
-    if (projectPath !== '.') {
-      this.output(`Project: ${projectPath}`);
-      this.output(`Run your coding agent from: cd ${shellQuote(projectPath)}`);
-      this.output('');
+    this.output('✨ Click here to see your app:');
+    this.output(streamUrl);
+    this.outputNextSteps(projectPath, 'Make a change and rebuild with Limrun skills.');
+  }
+
+  private async shouldUseDetectedProject(detection: DetectedProject): Promise<boolean> {
+    if (this.shouldSuppressInfo() || !process.stdin.isTTY || !process.stderr.isTTY) {
+      return true;
     }
-    this.output('Next steps: open your coding agent in this project and ask:');
-    if (detection.kind === 'expo') {
-      this.output('"Build and run this Expo app with Limrun. Share the simulator URL when it is ready."');
-    } else {
-      this.output('"Build and run this iOS app with Limrun. Share the simulator URL when it is ready."');
-    }
+    const projectPath = interactivePathLabel(humanPath(detection.projectDir));
+    const response = await prompts(
+      {
+        type: 'select',
+        name: 'choice',
+        message: `Found an iOS/Expo project at ${projectPath}. What do you want to use?`,
+        choices: [
+          { title: `Use ${projectPath}`, value: 'project' },
+          { title: 'Clone and run the sample app', value: 'sample' },
+        ],
+        initial: 0,
+      },
+      {
+        onCancel: () => {
+          this.error('Cancelled.');
+        },
+      },
+    );
+    return response.choice !== 'sample';
   }
 
   private printSkillSummary(results: SkillInstallResult[]): void {
@@ -90,9 +141,11 @@ export default class Run extends BaseCommand {
     const unchanged = results.filter((result) => result.status === 'unchanged').length;
     const skipped = results.filter((result) => result.status === 'skipped');
     if (installed > 0) {
-      this.info('Limrun skills installed for Claude Code and Cursor/OpenCode-compatible agents.');
+      this.success('Limrun skills installed for Claude Code and Cursor/OpenCode-compatible agents');
     } else if (unchanged > 0 && skipped.length === 0) {
-      this.info('Limrun skills are already installed for Claude Code and Cursor/OpenCode-compatible agents.');
+      this.success(
+        'Limrun skills are already installed for Claude Code and Cursor/OpenCode-compatible agents',
+      );
     }
     if (skipped.length > 0) {
       this.info('Skipped skill directories with local changes:');
@@ -109,6 +162,13 @@ export default class Run extends BaseCommand {
     }
   }
 
+  private success(message: string): void {
+    if (this.shouldSuppressInfo()) {
+      return;
+    }
+    process.stderr.write(`${ux.colorize('green', SUCCESS_ICON)} ${message}\n`);
+  }
+
   private async validateAuth(allowRetry: boolean): Promise<void> {
     const check = async () => {
       await this.client.iosInstances.list({ state: 'ready' } as any);
@@ -122,35 +182,62 @@ export default class Run extends BaseCommand {
 
   private async runSampleFlow(apiKey: string, allowAuthRetry: boolean): Promise<void> {
     const cwd = process.cwd();
-    this.info('No iOS or Expo project detected. Setting up the sample app.');
-    await this.validateAuth(allowAuthRetry);
-    const sample = await ensureSampleRepo({ cwd });
-    this.info(`${sample.reused ? 'Using existing' : 'Cloned'} ${humanPath(sample.path)}.`);
+    await this.withProgress('Checking Limrun access', () => this.validateAuth(allowAuthRetry));
+    const sample = await this.withProgress('Setting up sample app', () => ensureSampleRepo({ cwd }));
+    const samplePathFromStart = humanPath(sample.path, cwd);
+    this.success(`${sample.reused ? 'Using existing' : 'Cloned'} ${samplePathFromStart}`);
+    process.chdir(sample.path);
     this.printEnvWarnings(ensureProjectEnvApiKey(sample.path, apiKey).warnings);
-    this.info('Configured .env for Limrun.');
+    this.success('Configured .env for Limrun');
 
+    const streamUrl = await this.buildAndLaunchProject({
+      projectRoot: process.cwd(),
+      displayName: 'lim-run-sample',
+      labels: {
+        name: 'lim-go-sample',
+        repo: 'sample-native-app',
+      },
+      progressLabel: buildProgressLabel('native-ios'),
+      failureLabel: 'Sample build failed',
+      recoveryPath: sample.path,
+      recoveryFromDir: cwd,
+    });
+
+    this.output('');
+    this.output('✨ Click here to see your app:');
+    this.output(streamUrl);
+    this.outputNextSteps(humanPath(sample.path, cwd), samplePrompt());
+  }
+
+  private async buildAndLaunchProject({
+    projectRoot,
+    displayName,
+    labels,
+    progressLabel,
+    failureLabel,
+    recoveryPath,
+    recoveryFromDir,
+  }: BuildAndLaunchOptions): Promise<string> {
     let recoveryPrinted = false;
     try {
-      await this.withAuth(async () => {
-        this.info('Preparing a Limrun iOS simulator with Xcode...');
-        const instance = await this.client.iosInstances.create({
-          wait: true,
-          reuseIfExists: true,
-          metadata: {
-            displayName: 'lim-run-sample',
-            labels: {
-              name: 'lim-go-sample',
-              repo: 'sample-native-app',
+      return await this.withAuth(async () => {
+        const instance = await this.withProgress('Preparing a Limrun iOS simulator with Xcode', () =>
+          this.client.iosInstances.create({
+            wait: true,
+            reuseIfExists: true,
+            metadata: {
+              displayName,
+              labels,
             },
-          },
-          spec: {
-            sandbox: {
-              xcode: {
-                enabled: true,
+            spec: {
+              sandbox: {
+                xcode: {
+                  enabled: true,
+                },
               },
             },
-          },
-        });
+          }),
+        );
         registerCreatedInstance(instance, ['xcode']);
 
         const xcodeUrl = instance.status.sandbox?.xcode?.url;
@@ -163,64 +250,181 @@ export default class Run extends BaseCommand {
           token: instance.status.token,
         });
 
-        this.info('Syncing sample app...');
-        await xcode.sync(sample.path, { watch: false });
+        await xcode.sync(projectRoot, { watch: false });
 
-        this.info('Building and launching sample app...');
-        const xcodeSandboxId = xcodeSandboxIdFromUrl(xcodeUrl);
-        if (xcodeSandboxId) {
-          this.outputBuildInProgress(xcodeSandboxId);
-        }
         const build = xcode.xcodebuild();
-        const result = await build;
-        if (result.exitCode !== 0) {
-          this.outputSampleRecovery(sample.path);
-          recoveryPrinted = true;
-          this.error(`Sample build failed with exit code ${result.exitCode}`, { exit: result.exitCode });
+        this.startProgress(progressLabel);
+        build.stdout.on('data', (line: string) => this.appendProgressLog(line));
+        build.stderr.on('data', (line: string) => this.appendProgressLog(line));
+        const buildStart = Date.now();
+        let result: Awaited<typeof build>;
+        try {
+          result = await build;
+        } catch (err) {
+          this.stopProgress('failure');
+          throw err;
         }
+        if (result.exitCode !== 0) {
+          this.stopProgress('failure');
+          this.outputProjectRecovery(recoveryPath, recoveryFromDir);
+          recoveryPrinted = true;
+          this.error(`${failureLabel} with exit code ${result.exitCode}`, { exit: result.exitCode });
+        }
+        this.stopProgress('success', `Built and launched in ${formatDurationMs(Date.now() - buildStart)}`);
 
-        this.output('Build completed successfully!');
-        this.output('');
-        this.output('App deployed and running in a Limrun cloud simulator:');
-        this.output(this.consoleStreamUrl(instance.metadata.id));
-        this.outputSampleNextStep(sample.path);
+        return this.consoleStreamUrl(instance.metadata.id);
       });
     } catch (err) {
       if (!recoveryPrinted) {
-        this.outputSampleRecovery(sample.path);
+        this.outputProjectRecovery(recoveryPath, recoveryFromDir);
       }
       throw err;
     }
   }
 
-  private outputBuildInProgress(sandboxId: string): void {
-    this.output('Build is in progress. You can follow the logs from:');
-    this.output(this.consoleBuildUrl(sandboxId));
-  }
-
-  private outputSampleRecovery(samplePath: string): void {
+  private outputProjectRecovery(projectPath: string, fromDir = process.cwd()): void {
     this.output('');
-    this.output(`Sample app is available at ${humanPath(samplePath)}.`);
+    this.output(`Project is available at ${humanPath(projectPath, fromDir)}.`);
     this.output('Open it with your coding agent to continue.');
   }
 
-  private outputSampleNextStep(samplePath: string): void {
+  private outputNextSteps(projectPath: string, prompt: string): void {
     this.output('');
     this.output('Next steps:');
-    this.output(`  cd ${shellQuote(humanPath(samplePath))}`);
-    this.output('  Open your favorite coding agent and ask:');
-    this.output(
-      '  "Change `Hello, world!` to `Hello, Limrun!`, rebuild with Limrun, and show me the updated simulator."',
-    );
-    this.output('  Start building your app.');
+    this.output('');
+    this.output(`- Open ${bold(interactivePathLabel(projectPath))} in your coding agent`);
+    this.output('');
+    this.output(`- Prompt it: "${prompt}"`);
+  }
+
+  private async withProgress<T>(message: string, run: () => Promise<T>): Promise<T> {
+    this.startProgress(message);
+    try {
+      const result = await run();
+      this.stopProgress('success');
+      return result;
+    } catch (err) {
+      this.stopProgress('failure');
+      throw err;
+    }
+  }
+
+  private startProgress(message: string): void {
+    if (this.shouldSuppressInfo()) {
+      return;
+    }
+    this.progress = { frame: 0, logLines: [], message, renderedRows: 0 };
+    if (process.stderr.isTTY) {
+      this.progress.timer = setInterval(
+        () => this.renderProgress(),
+        process.platform === 'win32' ? 500 : 100,
+      );
+      this.progress.timer.unref();
+      this.renderProgress();
+    }
+  }
+
+  private stopProgress(result: 'success' | 'failure' = 'success', message?: string): void {
+    if (this.shouldSuppressInfo() || !this.progress) {
+      return;
+    }
+    const progress = this.progress;
+    if (progress.timer) {
+      clearInterval(progress.timer);
+    }
+    this.progress = undefined;
+    this.clearProgressBlock(progress);
+    const icon = result === 'success' ? ux.colorize('green', SUCCESS_ICON) : ux.colorize('red', FAILURE_ICON);
+    process.stderr.write(`${icon} ${message ?? progress.message}\n`);
+  }
+
+  private appendProgressLog(chunk: string): void {
+    if (this.shouldSuppressInfo() || !this.progress) {
+      return;
+    }
+    const lines = String(chunk)
+      .replace(/\r/g, '\n')
+      .split('\n')
+      .map((line) => line.trimEnd())
+      .filter((line) => line.length > 0);
+    if (lines.length === 0) {
+      return;
+    }
+    this.progress.logLines.push(...lines);
+    this.progress.logLines = this.progress.logLines.slice(-BUILD_LOG_TAIL_LINES);
+    this.renderProgress();
+  }
+
+  private renderProgress(): void {
+    if (!this.progress || !process.stderr.isTTY) {
+      return;
+    }
+    const frame = SPINNER_FRAMES[this.progress.frame % SPINNER_FRAMES.length]!;
+    this.progress.frame += 1;
+    const lines = [
+      progressLine(`${ux.colorize('magenta', frame)} ${this.progress.message}`),
+      ...this.progress.logLines.map((line) => ux.colorize('dim', `  ${truncateTerminalLine(line, 2)}`)),
+    ];
+    this.clearProgressBlock(this.progress);
+    this.progress.renderedRows = lines.length;
+    process.stderr.write(lines.join('\n'));
+  }
+
+  private clearProgressBlock(progress: ProgressState): void {
+    if (!process.stderr.isTTY) {
+      return;
+    }
+    process.stderr.clearLine(0);
+    process.stderr.cursorTo(0);
+    for (let i = 1; i < progress.renderedRows; i += 1) {
+      process.stderr.moveCursor(0, -1);
+      process.stderr.clearLine(0);
+      process.stderr.cursorTo(0);
+    }
   }
 }
 
-function humanPath(absolutePath: string): string {
-  const relative = path.relative(process.cwd(), absolutePath);
+type ProgressState = {
+  frame: number;
+  logLines: string[];
+  message: string;
+  renderedRows: number;
+  timer?: NodeJS.Timeout;
+};
+
+function humanPath(absolutePath: string, fromDir = process.cwd()): string {
+  const relative = path.relative(fromDir, absolutePath);
   if (!relative) return '.';
   if (relative.startsWith('..') || path.isAbsolute(relative)) return absolutePath;
   return relative;
+}
+
+function interactivePathLabel(value: string): string {
+  return value === '.' ? 'current directory' : value;
+}
+
+function buildProgressLabel(kind: DetectedProject['kind']): string {
+  if (kind === 'expo') {
+    return 'Building and launching app (est. 5-10m)';
+  }
+  return 'Building and launching app (est. 30s-5m)';
+}
+
+function samplePrompt(): string {
+  return `Change \`Hello, world!\` to \`Hello, ${environmentUserName()}!\``;
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
 }
 
 function shellQuote(value: string): string {
@@ -228,4 +432,29 @@ function shellQuote(value: string): string {
     return value;
   }
   return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function bold(value: string): string {
+  return `\x1b[1m${value}\x1b[22m`;
+}
+
+function environmentUserName(): string {
+  return process.env['USER'] || process.env['USERNAME'] || os.userInfo().username || 'Limrun';
+}
+
+function progressLine(line: string): string {
+  const width = process.stderr.columns;
+  if (!width || line.length < width - 1) {
+    return line;
+  }
+  return `${line.slice(0, Math.max(0, width - 4))}...`;
+}
+
+function truncateTerminalLine(line: string, indent = 0): string {
+  const width = process.stderr.columns;
+  const max = width ? width - indent - 1 : undefined;
+  if (!max || line.length < max) {
+    return line;
+  }
+  return `${line.slice(0, Math.max(0, max - 3))}...`;
 }

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@limrun/api@0.28.7":
-  version "0.28.7"
-  resolved "https://registry.npmjs.org/@limrun/api/-/api-0.28.7.tgz"
-  integrity sha512-YqbLNlAfik2RmP/dvNt+DxykBDzXGPuXMZL91UO+0Tg7348Sf2doPqkk8WiR60g5OWN+pOS3wIrF2q0uQLZQ5w==
+"@limrun/api@0.28.8":
+  version "0.28.8"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.28.8.tgz#9e2fec14112c6ae0a7a4a9bc0adc948417903aa2"
+  integrity sha512-8LFcMAPb4p8gDlbRxon4G3W1gl0g8SvpgSUHi7rIzTdV5g/elbbkg34jr34Ra2lk0l4FofLZA9f/zvnIOS1lHA==
   dependencies:
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"
@@ -20,7 +20,7 @@
     ws "^8.18.3"
     xdelta3-wasm "^1.0.0"
 
-"@oclif/core@^4", "@oclif/core@>= 3.0.0":
+"@oclif/core@^4":
   version "4.10.5"
   resolved "https://registry.npmjs.org/@oclif/core/-/core-4.10.5.tgz"
   integrity sha512-qcdCF7NrdWPfme6Kr34wwljRCXbCVpL1WVxiNy0Ep6vbWKjxAjFQwuhqkoyL0yjI+KdwtLcOCGn5z2yzdijc8w==
@@ -189,7 +189,7 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-debug@^4.4.3, debug@4:
+debug@4, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -384,7 +384,7 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.4:
+picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core onboarding/cloud build orchestration and default behavior when a project is detected; mis-detection or TTY edge cases could send users down the wrong path, though auth and API usage patterns are unchanged.
> 
> **Overview**
> **`lim run`** is reworked for clearer terminal UX and a broader default path: detected native iOS/Expo projects can be chosen interactively (or auto-used when not a TTY/`--quiet`), then skills, `.env`, cloud simulator prep, sync, **build, and launch** run end-to-end with a simulator stream URL—not only the sample repo flow.
> 
> Long-running steps use **TTY spinners** on stderr (platform-specific frames/icons), **`withProgress`** wrappers for auth/skills/instance setup, and a **live build** view that tails the last lines of `xcodebuild` stdout/stderr with duration on success. Success lines use green checkmarks; failures show recovery paths with paths relative to the starting cwd.
> 
> Messaging is tightened: prominent “click here” stream links, simplified next steps (open project + sample prompt personalized via `os.userInfo()`), and removal of the separate in-progress **console build log** link from this command. Release bumps **`lim` to 0.11.1** and **`@limrun/api` to 0.28.8** (lockfile updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20eb2c2eec3fd619749b0c06444cf75f301e9165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->