### PR TITLE
Remember sandbox Xcode targets

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -5,6 +5,7 @@ import { parseLabels } from '../../lib/formatting';
 import { registerCreatedInstance } from '../../lib/config';
 import { xcodeSandboxIdFromUrl } from '../../lib/xcode-sandbox';
 import { formatSimulatorAttachResult, simulatorAttachJson } from '../../lib/simulator-attach';
+import { formatDurationMs } from '../../lib/duration';
 import { type SimulatorAttachResult } from '@limrun/api';
 import { type IosInstanceCreateParams } from '@limrun/api/resources/ios-instances';
 
@@ -133,8 +134,9 @@ export default class IosCreate extends BaseCommand {
         if (labels) params.metadata.labels = labels;
       }
 
-      const start = Date.now();
+      const createStart = Date.now();
       const instance = await this.client.iosInstances.create(params);
+      const createDurationMs = Date.now() - createStart;
       const consoleUrl = this.consoleStreamUrl(instance.metadata.id);
       const signedStreamUrl = this.signedStreamUrl(instance.status);
       const xcodeSandboxUrl = instance.status.sandbox?.xcode?.url;
@@ -149,9 +151,12 @@ export default class IosCreate extends BaseCommand {
         }
       };
       let attachResult: SimulatorAttachResult | undefined;
+      let attachDurationMs: number | undefined;
       if (attachClient) {
         try {
+          const attachStart = Date.now();
           attachResult = await attachClient.attachSimulator(instance);
+          attachDurationMs = Date.now() - attachStart;
         } catch (err) {
           this.info(`Created iOS instance ${instance.metadata.id}, but attach failed.`);
           if (flags.rm) {
@@ -160,7 +165,11 @@ export default class IosCreate extends BaseCommand {
           throw err;
         }
       }
-      this.info(`Created a new iOS instance in ${((Date.now() - start) / 1000).toFixed(1)}s`);
+      const createdMessage =
+        flags.xcode ?
+          `Created a new iOS instance with Xcode sandbox in ${formatDurationMs(createDurationMs)}.`
+        : `Created a new iOS instance in ${formatDurationMs(createDurationMs)}.`;
+      this.info(createdMessage);
       this.info('iOS Instance:');
       this.info(`  ID: ${instance.metadata.id}`);
       this.info(`  Console URL: ${consoleUrl}`);
@@ -177,6 +186,9 @@ export default class IosCreate extends BaseCommand {
         this.info(`  URL: ${xcodeSandboxUrl}`);
       }
       if (attachResult && attachTarget) {
+        if (attachDurationMs !== undefined) {
+          this.info(`Attach/install completed in ${formatDurationMs(attachDurationMs)}.`);
+        }
         this.info(formatSimulatorAttachResult(instance.metadata.id, attachTarget.id, attachResult));
       }
 

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -252,9 +252,7 @@ function buildLastInstanceRecord(
   };
 }
 
-function buildLastXcodeSlotRecord(
-  instanceOrId: InstanceInput,
-): LastIosInstance | LastXcodeInstance | null {
+function buildLastXcodeSlotRecord(instanceOrId: InstanceInput): LastIosInstance | LastXcodeInstance | null {
   const record = buildLastInstanceRecord(instanceOrId);
   if (record.type === 'xcode') {
     return record;
@@ -345,14 +343,26 @@ export function loadLastXcodeInstance(): LastIosInstance | LastXcodeInstance | n
   return data.xcode ?? null;
 }
 
+function sandboxXcodeIdFromLastIosInstance(instance: LastIosInstance | undefined): string | undefined {
+  const sandboxXcodeUrl = instance?.sandboxXcodeUrl ?? instance?.status?.sandbox?.xcode?.url;
+  return sandboxXcodeUrl ? xcodeSandboxIdFromUrl(sandboxXcodeUrl) : undefined;
+}
+
 export function clearLastInstanceId(instanceId: string): void {
   const data = readLastInstances();
+  const iosRecord = data.ios;
   let changed = false;
   for (const key of Object.keys(data) as (keyof LastInstances)[]) {
     if (data[key]?.id === instanceId) {
       delete data[key];
       changed = true;
     }
+  }
+  const sandboxXcodeId =
+    iosRecord?.id === instanceId ? sandboxXcodeIdFromLastIosInstance(iosRecord) : undefined;
+  if (sandboxXcodeId && data.xcode?.type === 'xcode' && data.xcode.id === sandboxXcodeId) {
+    delete data.xcode;
+    changed = true;
   }
   if (changed) {
     ensureConfigDir();

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 import { type AndroidInstance } from '@limrun/api/resources/android-instances';
 import { type IosInstance } from '@limrun/api/resources/ios-instances';
 import { type XcodeInstance } from '@limrun/api/resources/xcode-instances';
+import { xcodeSandboxIdFromUrl } from './xcode-sandbox';
 
 const CONFIG_DIR = path.join(os.homedir(), '.lim');
 const CONFIG_FILE = path.join(CONFIG_DIR, 'config.yaml');
@@ -251,13 +252,63 @@ function buildLastInstanceRecord(
   };
 }
 
+function buildLastXcodeSlotRecord(
+  instanceOrId: InstanceInput,
+): LastIosInstance | LastXcodeInstance | null {
+  const record = buildLastInstanceRecord(instanceOrId);
+  if (record.type === 'xcode') {
+    return record;
+  }
+  if (record.type !== 'ios' || !isIosInstance(instanceOrId)) {
+    return null;
+  }
+
+  const sandboxXcodeUrl = instanceOrId.status.sandbox?.xcode?.url;
+  const sandboxXcodeId = sandboxXcodeUrl ? xcodeSandboxIdFromUrl(sandboxXcodeUrl) : undefined;
+  if (!sandboxXcodeUrl || !sandboxXcodeId) {
+    return record;
+  }
+
+  const metadata: XcodeInstance.Metadata = {
+    id: sandboxXcodeId,
+    createdAt: instanceOrId.metadata.createdAt,
+    organizationId: instanceOrId.metadata.organizationId,
+  };
+  if (instanceOrId.metadata.displayName) {
+    metadata.displayName = instanceOrId.metadata.displayName;
+  }
+
+  const spec: XcodeInstance.Spec = {
+    region: instanceOrId.spec.region,
+    inactivityTimeout: instanceOrId.spec.inactivityTimeout,
+  };
+  if (instanceOrId.spec.hardTimeout) {
+    spec.hardTimeout = instanceOrId.spec.hardTimeout;
+  }
+
+  return {
+    id: sandboxXcodeId,
+    type: 'xcode',
+    metadata,
+    spec,
+    status: {
+      state: instanceOrId.status.state,
+      apiUrl: sandboxXcodeUrl,
+      token: instanceOrId.status.token,
+    },
+    apiUrl: sandboxXcodeUrl,
+    token: instanceOrId.status.token,
+  };
+}
+
 function saveLastInstance(instanceOrId: InstanceInput, slot?: 'xcode'): void {
   ensureConfigDir();
   const record = buildLastInstanceRecord(instanceOrId);
   const data = readLastInstances();
   if (slot === 'xcode') {
-    if (record.type === 'ios' || record.type === 'xcode') {
-      data.xcode = record;
+    const xcodeRecord = buildLastXcodeSlotRecord(instanceOrId);
+    if (xcodeRecord) {
+      data.xcode = xcodeRecord;
     }
   } else if (record.type === 'android') {
     data.android = record;

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -4,7 +4,9 @@ import path from 'path';
 
 import { type IosInstance } from '@limrun/api/resources/ios-instances';
 
-async function withConfigModule<T>(fn: (config: typeof import('../packages/cli/src/lib/config')) => T): Promise<T> {
+async function withConfigModule<T>(
+  fn: (config: typeof import('../packages/cli/src/lib/config')) => T,
+): Promise<T> {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-cli-config-test-'));
   const homedir = () => homeDir;
   jest.resetModules();
@@ -80,6 +82,20 @@ describe('CLI last instance config', () => {
     });
   });
 
+  test('clears the derived sandbox Xcode target when the owning iOS instance is cleared', async () => {
+    await withConfigModule((config) => {
+      config.registerCreatedInstance(
+        iosInstanceWithXcodeUrl('https://instances.example.test/sandbox_01xcode/api'),
+        ['xcode'],
+      );
+
+      config.clearLastInstanceId('ios_euna_01test');
+
+      expect(config.loadLastIosInstance()).toBeNull();
+      expect(config.loadLastXcodeInstance()).toBeNull();
+    });
+  });
+
   test('keeps legacy iOS xcode slot behavior when no sandbox URL is available', async () => {
     await withConfigModule((config) => {
       config.registerCreatedInstance(iosInstanceWithXcodeUrl(), ['xcode']);
@@ -93,9 +109,10 @@ describe('CLI last instance config', () => {
 
   test('keeps legacy iOS xcode slot behavior when sandbox URL cannot be parsed', async () => {
     await withConfigModule((config) => {
-      config.registerCreatedInstance(iosInstanceWithXcodeUrl('https://instances.example.test/no-sandbox-id'), [
-        'xcode',
-      ]);
+      config.registerCreatedInstance(
+        iosInstanceWithXcodeUrl('https://instances.example.test/no-sandbox-id'),
+        ['xcode'],
+      );
 
       expect(config.loadLastXcodeInstance()).toMatchObject({
         id: 'ios_euna_01test',

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { type IosInstance } from '@limrun/api/resources/ios-instances';
+
+async function withConfigModule<T>(fn: (config: typeof import('../packages/cli/src/lib/config')) => T): Promise<T> {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-cli-config-test-'));
+  const homedir = () => homeDir;
+  jest.resetModules();
+  jest.doMock('os', () => {
+    const actual = jest.requireActual<typeof import('os')>('os');
+    return { ...actual, homedir, default: { ...actual, homedir } };
+  });
+
+  try {
+    const config = await import('../packages/cli/src/lib/config');
+    return fn(config);
+  } finally {
+    jest.dontMock('os');
+    jest.resetModules();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+function iosInstanceWithXcodeUrl(url?: string): IosInstance {
+  return {
+    metadata: {
+      id: 'ios_euna_01test',
+      createdAt: '2026-05-29T00:00:00Z',
+      organizationId: 'org_123',
+      displayName: 'Sample app session',
+    },
+    spec: {
+      region: 'eu-north-1',
+      inactivityTimeout: '3m',
+      hardTimeout: '30m',
+    },
+    status: {
+      state: 'ready',
+      apiUrl: 'https://ios.example.test',
+      token: 'lim_ios_token',
+      ...(url ? { sandbox: { xcode: { url } } } : {}),
+    },
+  };
+}
+
+describe('CLI last instance config', () => {
+  test('registers the real sandbox Xcode target for iOS-owned Xcode sandboxes', async () => {
+    await withConfigModule((config) => {
+      const xcodeUrl = 'https://instances.example.test/sandbox_01xcode/api';
+      config.registerCreatedInstance(iosInstanceWithXcodeUrl(xcodeUrl), ['xcode']);
+
+      expect(config.loadLastIosInstance()).toMatchObject({
+        id: 'ios_euna_01test',
+        type: 'ios',
+      });
+      expect(config.loadLastXcodeInstance()).toMatchObject({
+        id: 'sandbox_01xcode',
+        type: 'xcode',
+        apiUrl: xcodeUrl,
+        token: 'lim_ios_token',
+        metadata: {
+          id: 'sandbox_01xcode',
+          createdAt: '2026-05-29T00:00:00Z',
+          organizationId: 'org_123',
+          displayName: 'Sample app session',
+        },
+        spec: {
+          region: 'eu-north-1',
+          inactivityTimeout: '3m',
+          hardTimeout: '30m',
+        },
+        status: {
+          state: 'ready',
+          apiUrl: xcodeUrl,
+          token: 'lim_ios_token',
+        },
+      });
+    });
+  });
+
+  test('keeps legacy iOS xcode slot behavior when no sandbox URL is available', async () => {
+    await withConfigModule((config) => {
+      config.registerCreatedInstance(iosInstanceWithXcodeUrl(), ['xcode']);
+
+      expect(config.loadLastXcodeInstance()).toMatchObject({
+        id: 'ios_euna_01test',
+        type: 'ios',
+      });
+    });
+  });
+
+  test('keeps legacy iOS xcode slot behavior when sandbox URL cannot be parsed', async () => {
+    await withConfigModule((config) => {
+      config.registerCreatedInstance(iosInstanceWithXcodeUrl('https://instances.example.test/no-sandbox-id'), [
+        'xcode',
+      ]);
+
+      expect(config.loadLastXcodeInstance()).toMatchObject({
+        id: 'ios_euna_01test',
+        type: 'ios',
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Local CLI config and user-facing messages only; behavior is covered by new unit tests with legacy fallbacks.
> 
> **Overview**
> The CLI now **remembers the real Xcode sandbox** when you create an iOS instance with `--xcode`, instead of storing the iOS instance ID in the Xcode “last used” slot. The derived sandbox record uses the parsed sandbox ID and API URL (with iOS metadata/spec copied where relevant). **Clearing** the owning iOS instance also removes that derived Xcode entry. If there is no sandbox URL or the URL cannot be parsed, behavior stays the same as before (the iOS record remains in the Xcode slot).
> 
> `lim ios create` reports **create** and optional **attach/install** durations via `formatDurationMs`, with a distinct message when an Xcode sandbox was enabled. Package version is bumped to **0.11.7**. New tests cover registration, cleanup, and legacy fallbacks for `last-instances.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d1cf7518c12260042732647632676dfc6b4a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->