### PR TITLE
feat: add appConfig to xcode build

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -410,6 +410,9 @@ lim xcode build ./MyProject --scheme MyApp --workspace MyApp.xcworkspace
 # Build and upload artifact
 lim xcode build ./MyProject --scheme MyApp --upload my-app-build
 
+# Build with app config values available as Xcode build settings
+lim xcode build ./MyProject --scheme MyApp --app-config PREVIEW_BUILD=true --app-config DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"
+
 # Signed device build
 lim xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa
 
@@ -649,6 +652,8 @@ lim asset pull my-app-build -o ./build-output
 #### Build Behavior
 
 `lim xcode build [PATH]` automatically performs a one-shot code sync for the given project path before invoking `xcodebuild`. The sync step automatically ignores build artifacts (`build/`, `DerivedData/`, `.build/`), dependency folders (`Pods/`, `Carthage/Build/`, `.swiftpm/`), and user-specific files (`xcuserdata/`, `.dSYM/`).
+
+Pass `--app-config KEY=VALUE` to provide app config baked into the build. Use a bare key (`^[A-Z0-9_]+$`); the `APP_CONFIG_` prefix is added automatically when the value is passed to xcodebuild. So `--app-config DEV_LOGIN_SECRET=...` is referenced in `Info.plist` as `<string>$(APP_CONFIG_DEV_LOGIN_SECRET)</string>` and read at runtime with `Bundle.main`.
 
 Provide `--certificate-p12`, `--certificate-password`, and `--provisioning-profile` together to sign a real-device build. When signing assets are provided without `--sdk`, the CLI builds with `iphoneos`; pass `--sdk watchos` for signed watchOS device builds.
 

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -5,7 +5,7 @@ import { compileIgnorePatterns } from '../../lib/ignore-patterns';
 import { formatDurationMs } from '../../lib/duration';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
-import { type XcodeClient } from '@limrun/api';
+import { parseAppConfigEntries, type XcodeBuildOptions, type XcodeClient } from '@limrun/api';
 
 const DEVICE_SDKS = new Set(['iphoneos', 'watchos']);
 const SIMULATOR_SDKS = new Set(['iphonesimulator', 'watchsimulator']);
@@ -34,6 +34,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
+    '<%= config.bin %> xcode build ./MyProject --app-config PREVIEW_BUILD=true --app-config DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"',
     '<%= config.bin %> xcode build ./MyProject --basis-cache-dir ./.limsync-cache --max-patch-bytes 2097152',
     '<%= config.bin %> xcode build ./MyProject --ignore "\\\\.xcuserdata/"',
     '<%= config.bin %> xcode build ./MyProject --additional-file ~/.netrc=~/.netrc',
@@ -81,6 +82,11 @@ export default class XcodeBuild extends BaseCommand {
     upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
     'signed-upload-url': Flags.string({
       description: 'Presigned URL to upload the resulting build artifact to.',
+    }),
+    'app-config': Flags.string({
+      description:
+        'App config value baked into the build, as KEY=VALUE with a bare key (the APP_CONFIG_ prefix is added automatically). Repeat for multiple.',
+      multiple: true,
     }),
     'certificate-p12': Flags.string({
       description:
@@ -143,12 +149,16 @@ export default class XcodeBuild extends BaseCommand {
       if (flags.ios && !flags.sdk) settings.sdk = 'iphonesimulator';
       if (flags.configuration) settings.configuration = flags.configuration;
 
-      const options: Record<string, unknown> = {};
+      const options: XcodeBuildOptions = {};
       if (flags['dev-server-url'] || flags['expo-app-dir']) {
         options.reactNative = {
           ...(flags['expo-app-dir'] && { expoAppDir: flags['expo-app-dir'] }),
           ...(flags['dev-server-url'] && { devServerURL: flags['dev-server-url'] }),
         };
+      }
+      const appConfig = parseAppConfigEntries(flags['app-config'] ?? []);
+      if (appConfig) {
+        options.appConfig = appConfig;
       }
       const signing = await this.buildSigningOptions(flags);
       if (signing) {

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -1,0 +1,65 @@
+export const appConfigKeyPattern = /^[A-Z0-9_]+$/;
+
+const maxAppConfigCount = 32;
+const maxAppConfigValueBytes = 4096;
+const maxAppConfigTotalBytes = 65536;
+
+function validateAppConfigKey(key: string): void {
+  if (key.startsWith('APP_CONFIG_')) {
+    throw new Error(
+      `invalid app config key "${key}": must not include the APP_CONFIG_ prefix, it is added automatically`,
+    );
+  }
+  if (!appConfigKeyPattern.test(key)) {
+    throw new Error(`invalid app config key "${key}": keys must match ^[A-Z0-9_]+$`);
+  }
+}
+
+export function validateAppConfig(config: Record<string, string>): void {
+  const entries = Object.entries(config);
+  if (entries.length > maxAppConfigCount) {
+    throw new Error(`too many app config entries: got ${entries.length}, max ${maxAppConfigCount}`);
+  }
+
+  let totalBytes = 0;
+  for (const [key, value] of entries) {
+    validateAppConfigKey(key);
+    if (typeof value !== 'string') {
+      throw new Error(`invalid app config value for "${key}": value must be a string`);
+    }
+    const valueBytes = Buffer.byteLength(value, 'utf8');
+    if (valueBytes > maxAppConfigValueBytes) {
+      throw new Error(
+        `app config value for "${key}" is too large: got ${valueBytes} bytes, max ${maxAppConfigValueBytes} bytes`,
+      );
+    }
+    totalBytes += Buffer.byteLength(key, 'utf8') + valueBytes;
+    if (totalBytes > maxAppConfigTotalBytes) {
+      throw new Error(`app config payload is too large: max ${maxAppConfigTotalBytes} bytes`);
+    }
+  }
+}
+
+export function parseAppConfigEntries(entries: readonly string[]): Record<string, string> | undefined {
+  const config: Record<string, string> = {};
+  for (const entry of entries) {
+    const separator = entry.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(`invalid app config entry "${entry}": expected KEY=VALUE`);
+    }
+    const key = entry.slice(0, separator).trim();
+    const value = entry.slice(separator + 1);
+    if (!key) {
+      throw new Error(`invalid app config entry "${entry}": key is required`);
+    }
+    if (Object.prototype.hasOwnProperty.call(config, key)) {
+      throw new Error(`duplicate app config key "${key}"`);
+    }
+    config[key] = value;
+  }
+  if (Object.keys(config).length === 0) {
+    return undefined;
+  }
+  validateAppConfig(config);
+  return config;
+}

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -30,6 +30,7 @@ export type ExecRequest = {
     certificatePassword?: string;
     provisioningProfileBase64?: string;
   };
+  appConfig?: Record<string, string>;
   signedUploadUrl?: string;
   additionalMetadata?: {
     signedDownloadUrl?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { PagePromise } from './core/pagination';
 export * from './instance-client';
 export * as Ios from './ios-client';
 export { startHttpProxy, type HttpProxy, type StartHttpProxyOptions } from './http-proxy';
+export { appConfigKeyPattern, parseAppConfigEntries, validateAppConfig } from './app-config';
 export {
   exec,
   type ExecRequest,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -13,6 +13,7 @@ import {
 import { createIgnoreFn } from '../folder-sync-ignore';
 import { nodeProxyTransport } from '../internal/proxy-transport';
 import { directInstanceHttpError } from '../internal/direct-instance-errors';
+import { validateAppConfig } from '../app-config';
 
 export type LogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug';
 
@@ -88,6 +89,7 @@ export type XcodeBuildOptions = {
   upload?: { assetName: string } | { signedUploadUrl: string };
   signing?: XcodeSigningConfig;
   reactNative?: ReactNativeBuildConfig;
+  appConfig?: Record<string, string>;
 };
 
 export type SimulatorInstallState =
@@ -326,11 +328,15 @@ export class XcodeInstances extends GeneratedXcodeInstances {
         if (options?.reactNative?.devServerURL && settings?.configuration === 'Release') {
           throw new Error('reactNative.devServerURL is only supported for Debug builds');
         }
+        if (options?.appConfig) {
+          validateAppConfig(options.appConfig);
+        }
         const request: ExecRequest = {
           command: 'xcodebuild',
           ...(settings && { xcodebuild: settings }),
           ...(options?.reactNative && { reactNative: options.reactNative }),
           ...(options?.signing && { signing: options.signing }),
+          ...(options?.appConfig && { appConfig: options.appConfig }),
         };
 
         if (options?.upload && 'assetName' in options.upload) {

--- a/tests/app-config.test.ts
+++ b/tests/app-config.test.ts
@@ -1,0 +1,53 @@
+import { parseAppConfigEntries, validateAppConfig } from '@limrun/api';
+
+describe('app config helpers', () => {
+  test('parses repeated entries and preserves values containing equals', () => {
+    expect(parseAppConfigEntries(['PREVIEW_BUILD=true', 'DEV_LOGIN_SECRET=abc=def'])).toEqual({
+      PREVIEW_BUILD: 'true',
+      DEV_LOGIN_SECRET: 'abc=def',
+    });
+  });
+
+  test('rejects keys carrying the APP_CONFIG_ prefix', () => {
+    expect(() => parseAppConfigEntries(['APP_CONFIG_DEV_LOGIN_SECRET=1337'])).toThrow(
+      'must not include the APP_CONFIG_ prefix',
+    );
+  });
+
+  test('rejects keys with invalid characters', () => {
+    expect(() => parseAppConfigEntries(['dev-secret=1337'])).toThrow('keys must match ^[A-Z0-9_]+$');
+  });
+
+  test('rejects malformed entries', () => {
+    expect(() => parseAppConfigEntries(['SECRET'])).toThrow('expected KEY=VALUE');
+  });
+
+  test('validates config maps', () => {
+    expect(() => validateAppConfig({ PREVIEW_BUILD: 'true' })).not.toThrow();
+    expect(() => validateAppConfig({ APP_CONFIG_PREVIEW_BUILD: 'true' })).toThrow(
+      'must not include the APP_CONFIG_ prefix',
+    );
+  });
+
+  test('rejects too many entries', () => {
+    const config: Record<string, string> = {};
+    for (let i = 0; i < 33; i++) {
+      config[`K${i}`] = 'v';
+    }
+    expect(() => validateAppConfig(config)).toThrow('too many app config entries');
+  });
+
+  test('rejects an oversized value', () => {
+    expect(() => validateAppConfig({ SECRET: 'x'.repeat(4097) })).toThrow('is too large');
+  });
+
+  test('rejects an oversized payload', () => {
+    // Each entry stays under the per-value cap; the total exceeds the payload cap.
+    const config: Record<string, string> = {};
+    const value = 'x'.repeat(4000);
+    for (let i = 0; i < 20; i++) {
+      config[`K${i}`] = value;
+    }
+    expect(() => validateAppConfig(config)).toThrow('payload is too large');
+  });
+});

--- a/tests/xcode-client-app-config.test.ts
+++ b/tests/xcode-client-app-config.test.ts
@@ -1,10 +1,8 @@
 jest.mock('eventsource-client', () => ({
-  createEventSource: jest.fn(
-    (options: { onMessage: (message: { event: string; data: string }) => void }) => {
-      setTimeout(() => options.onMessage({ event: 'exitCode', data: '0' }), 0);
-      return { close: jest.fn() };
-    },
-  ),
+  createEventSource: jest.fn((options: { onMessage: (message: { event: string; data: string }) => void }) => {
+    setTimeout(() => options.onMessage({ event: 'exitCode', data: '0' }), 0);
+    return { close: jest.fn() };
+  }),
 }));
 
 import Limrun from '@limrun/api';

--- a/tests/xcode-client-app-config.test.ts
+++ b/tests/xcode-client-app-config.test.ts
@@ -1,0 +1,65 @@
+jest.mock('eventsource-client', () => ({
+  createEventSource: jest.fn(
+    (options: { onMessage: (message: { event: string; data: string }) => void }) => {
+      setTimeout(() => options.onMessage({ event: 'exitCode', data: '0' }), 0);
+      return { close: jest.fn() };
+    },
+  ),
+}));
+
+import Limrun from '@limrun/api';
+import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
+import type { RequestInfo } from '../src/internal/builtin-types';
+
+const originalFetch = nodeProxyTransport.fetch;
+
+describe('xcode client app config', () => {
+  afterEach(() => {
+    nodeProxyTransport.fetch = originalFetch;
+  });
+
+  test('serializes appConfig in limbuild exec request', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://xcode.example.test/exec') {
+        return jsonResponse({ execId: 'build-1' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const xcode = await client.xcodeInstances.createClient({
+      apiUrl: 'https://xcode.example.test',
+      token: 'xcode-token',
+    });
+
+    const result = await xcode.xcodebuild(
+      { scheme: 'Scripty' },
+      {
+        appConfig: {
+          PREVIEW_BUILD: 'true',
+          DEV_LOGIN_SECRET: 'abc=def',
+        },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls[0]?.init?.method).toBe('POST');
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'xcodebuild',
+      xcodebuild: { scheme: 'Scripty' },
+      appConfig: {
+        PREVIEW_BUILD: 'true',
+        DEV_LOGIN_SECRET: 'abc=def',
+      },
+    });
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build-time values (including secrets via flags) are validated and forwarded to remote exec; misuse or oversized payloads is bounded but misconfiguration can still leak values into compiled artifacts.
> 
> **Overview**
> Adds **baked-in build configuration** for remote Xcode builds: callers can pass `KEY=VALUE` pairs that become Xcode build settings (with an automatic `APP_CONFIG_` prefix for `Info.plist` / `Bundle.main`).
> 
> The **CLI** gains repeatable `--app-config` on `lim xcode build`; the **API** exposes `parseAppConfigEntries`, `validateAppConfig`, and `appConfig` on `XcodeBuildOptions` / limbuild `ExecRequest`. Shared validation enforces bare `^[A-Z0-9_]+$` keys (no duplicate `APP_CONFIG_` prefix), entry limits, and per-value/total payload caps before the config is sent to `xcodebuild`.
> 
> README documents usage (e.g. preview flags and secrets); unit tests cover parsing, validation errors, and JSON serialization on exec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4efbace78dd39c30bbd6e2c66083b90bbc86926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->