### PR TITLE
cli: release 0.13.0

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lim",
-  "version": "0.11.6",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.11.6",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "^0.28.10",
+        "@limrun/api": "^0.30.0",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.28.10",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.28.10.tgz",
-      "integrity": "sha512-sOu2wwT0HaG3vWWtYTEOm27vI4h8WmX7c2Qodd8FZffThHaNKguBffz0t6b0x82gZZw5YMoYv8KCAdNb2t/fzg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.30.0.tgz",
+      "integrity": "sha512-tpkMZPlyPzJjPXpvmPJZSfw4/Ad6jn2OBl6gXPSckjpyPbLmMq5Gc7RbyEGtZT0cczKqzT8ujbHfGhDddm4QiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "eventsource-client": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -24,7 +24,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.29.0",
+    "@limrun/api": "^0.30.0",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/android/set-wifi-bandwidth.ts
+++ b/packages/cli/src/commands/android/set-wifi-bandwidth.ts
@@ -21,8 +21,7 @@ export default class AndroidSetWifiBandwidth extends BaseCommand {
   static flags = {
     ...BaseCommand.baseFlags,
     id: Flags.string({
-      description:
-        'Android instance ID to target. Defaults to the last created Android instance.',
+      description: 'Android instance ID to target. Defaults to the last created Android instance.',
     }),
     'down-kbps': Flags.integer({
       description: 'Download bandwidth limit in Kbps. Use 0 to clear the download limit.',

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -412,7 +412,8 @@ export function startDaemonServer(): void {
           break;
 
         case 'set-wifi-bandwidth':
-          if (type !== 'android') throw new Error('set-wifi-bandwidth is only supported on Android instances');
+          if (type !== 'android')
+            throw new Error('set-wifi-bandwidth is only supported on Android instances');
           await (client as any).setWifiBandwidth(args[0]);
           result = { updated: true, bandwidth: args[0] };
           break;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and dependency pin updates plus cosmetic formatting; no logic changes to commands or daemon dispatch.
> 
> **Overview**
> **Releases `lim` CLI 0.13.0** and bumps **`@limrun/api`** to **`^0.30.0`** in `package.json` and `package-lock.json` so the published CLI tracks the newer SDK.
> 
> The only source edits are **formatting**: a single-line `--id` flag description in `set-wifi-bandwidth.ts` and a wrapped `throw` in the session daemon’s `set-wifi-bandwidth` handler—**no behavior changes** to Wi‑Fi bandwidth or session routing in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc8eddb475e131228f977dc3d3fdf80db5caf4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->