### PR TITLE
fix(cli): drop stray --xcode flag from ios create install example

### DIFF
--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -18,7 +18,7 @@ export default class IosCreate extends BaseCommand {
     '<%= config.bin %> ios create',
     '<%= config.bin %> ios create --rm --model ipad',
     '<%= config.bin %> ios create --region us-west --install-asset my-app.ipa',
-    '<%= config.bin %> ios create --install ./MyApp.ipa --xcode',
+    '<%= config.bin %> ios create --install ./MyApp.ipa',
     '<%= config.bin %> ios create --attach <xcode-instance-ID>',
   ];
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a static CLI example string with no runtime or API impact.
> 
> **Overview**
> Corrects the **`ios create`** static help example for local app install so it no longer appends **`--xcode`**.
> 
> The example now reads `<%= config.bin %> ios create --install ./MyApp.ipa`, matching an install-only workflow. **`--xcode`** remains a separate flag on the command for enabling the Xcode sandbox; it was only removed from this misleading combined example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c2e53b40a27dc066889f2b9796c79e61998b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->