### PR TITLE
lim xcode rbe: print an inferred build target, not a placeholder

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lim",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "^0.30.0",
+        "@limrun/api": "^0.31.0",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.30.0.tgz",
-      "integrity": "sha512-tpkMZPlyPzJjPXpvmPJZSfw4/Ad6jn2OBl6gXPSckjpyPbLmMq5Gc7RbyEGtZT0cczKqzT8ujbHfGhDddm4QiQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.31.0.tgz",
+      "integrity": "sha512-xhH94oKtg2c81JMoQxCjESyEBy/d+3VPYm8tbqENP5kOZB/z6zGDDRGdODassiMuQ6clZYtANh3TAZ0sDABY6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "eventsource-client": "^1.2.0",

--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -9,6 +9,7 @@ import { clearLastInstanceId } from '../../lib/config';
 import { ProgressReporter } from '../../lib/progress';
 import {
   findBazelWorkspaceRoot,
+  inferBuildTarget,
   writeRbeWorkspaceFiles,
   LIMRUN_DIR,
   type RbeWorkspaceFiles,
@@ -193,7 +194,10 @@ export default class XcodeRbe extends BaseCommand {
       // is already the default — so always emit it. It is a startup flag (can't
       // live in --config=limrun, and would change the digest for ALL the user's
       // builds if put in .bazelrc), hence it precedes `build` in the command.
-      const buildCmd = 'bazelisk --digest_function=sha256 build --config=limrun //your:target';
+      // Infer a real app target so the printed command is runnable as-is; fall
+      // back to a placeholder when there's no single obvious target.
+      const target = inferBuildTarget(workspaceRoot) ?? '//your:target';
+      const buildCmd = `bazelisk --digest_function=sha256 build --config=limrun ${target}`;
 
       if (flags.daemon) {
         await this.spawnBackgroundTunnel({

--- a/packages/cli/src/lib/rbe-workspace.ts
+++ b/packages/cli/src/lib/rbe-workspace.ts
@@ -38,6 +38,73 @@ export function findBazelWorkspaceRoot(startDir: string): string | null {
   }
 }
 
+const APP_RULE_RE = /\b(?:ios|macos|tvos|watchos)_application\s*\(/;
+const TARGET_NAME_RE = /^\s*name\s*=\s*"([^"]+)"/;
+const TARGET_SCAN_SKIP_DIRS = new Set(['.git', 'node_modules', '.limrun']);
+
+/**
+ * Best-effort guess of a single buildable app target to show in the printed
+ * build command, so it reads `//App` instead of a `//your:target` placeholder.
+ * Scans the workspace's BUILD files (buildifier-formatted) for apple
+ * `*_application` rules — no bazel invocation — and returns the label in short
+ * form (`//pkg` when the target name matches the package's last segment).
+ * Returns null when there are zero or multiple candidates (ambiguous → caller
+ * keeps the placeholder).
+ */
+export function inferBuildTarget(workspaceRoot: string): string | null {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    if (found.length > 1) return; // already ambiguous; stop early
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (TARGET_SCAN_SKIP_DIRS.has(entry.name) || entry.name.startsWith('bazel-')) continue;
+        walk(path.join(dir, entry.name));
+      } else if (entry.name === 'BUILD' || entry.name === 'BUILD.bazel') {
+        collectAppTargets(path.join(dir, entry.name), workspaceRoot, found);
+      }
+    }
+  };
+  walk(workspaceRoot);
+  return found.length === 1 ? found[0]! : null;
+}
+
+/** Appends `//pkg[:name]` labels of apple application rules in one BUILD file. */
+function collectAppTargets(buildFile: string, workspaceRoot: string, out: string[]): void {
+  let content: string;
+  try {
+    content = fs.readFileSync(buildFile, 'utf8');
+  } catch {
+    return;
+  }
+  const pkg = path.relative(workspaceRoot, path.dirname(buildFile)).split(path.sep).join('/');
+  let inAppRule = false;
+  for (const line of content.split('\n')) {
+    if (!inAppRule) {
+      if (APP_RULE_RE.test(line)) inAppRule = true;
+      continue;
+    }
+    const match = line.match(TARGET_NAME_RE);
+    if (match) {
+      const name = match[1]!;
+      const last = pkg.split('/').pop();
+      out.push(
+        pkg === '' || pkg === '.' ? `//:${name}`
+        : last === name ? `//${pkg}`
+        : `//${pkg}:${name}`,
+      );
+      inAppRule = false;
+    } else if (/^\)/.test(line)) {
+      inAppRule = false; // rule closed before a name line we could read
+    }
+  }
+}
+
 /**
  * Reads the workspace's pinned Bazel major version from `.bazelversion`, or
  * null when the file is absent or its first line has no leading integer.

--- a/packages/cli/src/lib/rbe-workspace.ts
+++ b/packages/cli/src/lib/rbe-workspace.ts
@@ -85,6 +85,10 @@ function collectAppTargets(buildFile: string, workspaceRoot: string, out: string
   const pkg = path.relative(workspaceRoot, path.dirname(buildFile)).split(path.sep).join('/');
   let inAppRule = false;
   for (const line of content.split('\n')) {
+    // Skip comment lines so a commented-out `# ios_application(` can't start a
+    // phantom rule (and a commented `# name = ...` can't be captured), which
+    // would otherwise leave inAppRule set and mislabel a later rule's name.
+    if (line.trimStart().startsWith('#')) continue;
     if (!inAppRule) {
       if (APP_RULE_RE.test(line)) inAppRule = true;
       continue;

--- a/tests/cli-rbe-workspace.test.ts
+++ b/tests/cli-rbe-workspace.test.ts
@@ -7,6 +7,7 @@ import {
   detectBazelMajorVersion,
   ensureTryImport,
   findBazelWorkspaceRoot,
+  inferBuildTarget,
   renderLimrunBazelrc,
   renderXcodeConfigBuild,
   writeRbeWorkspaceFiles,
@@ -96,6 +97,66 @@ describe('rbe workspace generation', () => {
       const sub = path.join(dir, 'a', 'b');
       fs.mkdirSync(sub, { recursive: true });
       expect(findBazelWorkspaceRoot(sub)).toBeNull();
+    });
+  });
+
+  describe('inferBuildTarget', () => {
+    let dir: string;
+    beforeEach(() => {
+      dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'infer-')));
+    });
+    afterEach(() => {
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    const writeBuild = (pkg: string, body: string) => {
+      const d = path.join(dir, pkg);
+      fs.mkdirSync(d, { recursive: true });
+      fs.writeFileSync(path.join(d, 'BUILD.bazel'), body);
+    };
+    const iosApp = (name: string) =>
+      `load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")\n\nios_application(\n    name = "${name}",\n    bundle_id = "com.x",\n)\n`;
+
+    test('returns the short label when there is exactly one app target', () => {
+      writeBuild('App', iosApp('App'));
+      // a framework/library nearby must NOT count as an application
+      writeBuild(
+        'Core/UIComponents',
+        'load("@build_bazel_rules_apple//apple:ios.bzl", "ios_framework")\n\nios_framework(\n    name = "UIComponents",\n)\n',
+      );
+      expect(inferBuildTarget(dir)).toBe('//App');
+    });
+
+    test('uses //pkg:name form when the target name differs from the package basename', () => {
+      writeBuild('App', iosApp('MyApp'));
+      expect(inferBuildTarget(dir)).toBe('//App:MyApp');
+    });
+
+    test('returns null when there are multiple app targets (ambiguous)', () => {
+      writeBuild('iOSApp', iosApp('iOSApp'));
+      writeBuild('macOSApp', 'macos_application(\n    name = "macOSApp",\n)\n');
+      expect(inferBuildTarget(dir)).toBeNull();
+    });
+
+    test('returns null when there are no app targets', () => {
+      writeBuild('lib', 'swift_library(\n    name = "lib",\n)\n');
+      expect(inferBuildTarget(dir)).toBeNull();
+    });
+
+    test('does not match the load() import of ios_application', () => {
+      // a BUILD that only imports the symbol but declares no application target
+      writeBuild(
+        'tools',
+        'load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")\n\nfilegroup(\n    name = "tools",\n)\n',
+      );
+      expect(inferBuildTarget(dir)).toBeNull();
+    });
+
+    test('skips bazel-* and node_modules dirs', () => {
+      writeBuild('App', iosApp('App'));
+      writeBuild('bazel-out/x', iosApp('Generated'));
+      writeBuild('node_modules/pkg', iosApp('Vendored'));
+      expect(inferBuildTarget(dir)).toBe('//App');
     });
   });
 

--- a/tests/cli-rbe-workspace.test.ts
+++ b/tests/cli-rbe-workspace.test.ts
@@ -158,6 +158,24 @@ describe('rbe workspace generation', () => {
       writeBuild('node_modules/pkg', iosApp('Vendored'));
       expect(inferBuildTarget(dir)).toBe('//App');
     });
+
+    test('ignores a commented-out application rule (no phantom match into a later rule)', () => {
+      // The commented opening must not set the "in app rule" state and capture
+      // the following library's name as an application target.
+      writeBuild(
+        'App',
+        '# ios_application(\n#     name = "OldApp",\n# )\n\nswift_library(\n    name = "AppLib",\n)\n',
+      );
+      expect(inferBuildTarget(dir)).toBeNull();
+    });
+
+    test('picks the real app when a commented rule precedes it', () => {
+      writeBuild(
+        'App',
+        '# ios_application(\n#     name = "OldApp",\n# )\n\nios_application(\n    name = "App",\n    bundle_id = "com.x",\n)\n',
+      );
+      expect(inferBuildTarget(dir)).toBe('//App');
+    });
   });
 
   describe('detectBazelMajorVersion', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UX-only change to the suggested build string plus local BUILD-file scanning; no RBE tunnel, auth, or remote execution behavior changes.
> 
> **Overview**
> **`lim xcode rbe`** now prints a copy-paste build command with a **real Bazel label** when the workspace has exactly one Apple app target, instead of always showing `//your:target`.
> 
> A new **`inferBuildTarget`** helper walks `BUILD` / `BUILD.bazel` under the workspace (skipping `.git`, `node_modules`, `.limrun`, and `bazel-*`), finds `ios` / `macos` / `tvos` / `watchos` `_application` rules without invoking Bazel, and formats short labels like `//App` when the rule name matches the package basename. It returns `null` when there are zero or multiple apps (ambiguous) or only non-app targets; commented-out rules are ignored so they cannot steal a later rule’s `name`.
> 
> The CLI is bumped to **0.14.0** with **`@limrun/api` ^0.31.0**; behavior is covered by new **`inferBuildTarget`** unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1888849f24c31180bbd6408b7d11aa185176249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->