### PR TITLE
lim xcode rbe: surface --remote_download_outputs=minimal on the build command

### DIFF
--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -216,7 +216,14 @@ export default class XcodeRbe extends BaseCommand {
       // Infer a real app target so the printed command is runnable as-is; fall
       // back to a placeholder when there's no single obvious target.
       const target = inferBuildTarget(workspaceRoot) ?? '//your:target';
-      const buildCmd = `bazelisk --digest_function=sha256 build --config=limrun ${target}`;
+      // --remote_download_outputs=minimal keeps the built .ipa in the instance's
+      // CAS instead of downloading it; `lim xcode rbe install` installs it
+      // server-side from there, so the bytes never round-trip. It lives on the
+      // printed command (not the generated bazelrc) so it's visible and the user
+      // can drop it to materialize the .ipa locally. It's not needed for install
+      // to work: a remote output carries a bytestream:// CAS URI in the BEP under
+      // either download mode, so dropping it only adds a local download.
+      const buildCmd = `bazelisk --digest_function=sha256 build --config=limrun --remote_download_outputs=minimal ${target}`;
 
       // --ios: create + attach a simulator so `lim xcode rbe install` installs on
       // it and the stream URL is printed. Recorded in the pidfile so --stop tears
@@ -609,6 +616,11 @@ export default class XcodeRbe extends BaseCommand {
       this.output('');
       this.info('Tunnel is running. Press Ctrl+C to stop.');
     }
+    this.output('');
+    this.info(
+      'The built .ipa stays in the instance cache (install it with `lim xcode rbe install`); ' +
+        'drop --remote_download_outputs=minimal to download it to this machine.',
+    );
   }
 }
 

--- a/packages/cli/src/lib/rbe-workspace.ts
+++ b/packages/cli/src/lib/rbe-workspace.ts
@@ -275,12 +275,6 @@ xcode_config(
  *   the fleet regardless of where bazel runs (the whole point of RBE).
  * - PATH includes /usr/sbin:/sbin so genrules that probe `sysctl` (e.g.
  *   `hw.logicalcpu` for `make -j`) resolve it on the worker.
- * - `--remote_download_outputs=minimal` keeps build outputs (the .ipa) in the
- *   instance's CAS instead of downloading them to the client. `lim xcode rbe
- *   install` then installs the artifact on the attached simulator server-side
- *   (fast diff-sync), so the bytes never round-trip — pointless on a Linux
- *   client, and the artifact is produced in the instance anyway. Scoped to
- *   --config=limrun, so a plain `bazel build` still materializes outputs.
  * - `--build_event_json_file` writes the Build Event Protocol to .limrun/bep.json;
  *   `lim xcode rbe install` reads the built target's .ipa CAS digest from it. The
  *   path is ABSOLUTE on purpose: Bazel expands `%workspace%` only in
@@ -314,7 +308,6 @@ build:limrun --strategy=Genrule=remote
 build:limrun --xcode_version_config=//.limrun:remote_xcode_config
 build:limrun --xcode_version=${shortVersion(versionKey)}
 build:limrun --ios_multi_cpus=sim_arm64
-build:limrun --remote_download_outputs=minimal
 build:limrun --build_event_json_file=${bepPath}
 ${execPlatform}build:limrun --action_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin
 `;

--- a/src/rbe-bep.ts
+++ b/src/rbe-bep.ts
@@ -3,11 +3,14 @@
  * newline-delimited JSON) to find a built target's top-level `.ipa` and its
  * content-addressed (CAS) digest.
  *
- * Under `--config=limrun` the generated bazelrc sets `--remote_download_outputs=
- * minimal`, so outputs are NOT downloaded to the client; their BEP `file`
- * entries instead carry a `bytestream://<host>[/<instance>]/blobs/<hash>/<size>`
- * URI. `lim xcode rbe install` reads that digest and hands it to the instance,
- * which fetches the blob from its own RBE cache and installs it — no round-trip.
+ * A remotely-executed output carries a `bytestream://<host>[/<instance>]/blobs/
+ * <hash>/<size>` URI in its BEP `file` entry regardless of whether Bazel also
+ * downloads the bytes (`--remote_download_outputs`), because the URI names the
+ * output's CAS identity, not its local availability. `lim xcode rbe install`
+ * reads that digest and hands it to the instance, which fetches the blob from
+ * its own RBE cache and installs it — no round-trip. The printed build command
+ * passes `--remote_download_outputs=minimal` to skip the (unneeded) local
+ * download by default; dropping it does not affect this parser.
  */
 
 export type BepIpaDigest = {
@@ -146,9 +149,9 @@ export function parseTopLevelIpaDigest(bepJson: string, label: string): BepIpaDi
 
   if (localOnlyIpa) {
     throw new Error(
-      `Found ${label}'s .ipa (${localOnlyIpa}) but it has no remote (bytestream) digest — its ` +
-        `output was downloaded locally. Ensure you built with --config=limrun (which keeps outputs ` +
-        `in the instance cache via --remote_download_outputs=minimal).`,
+      `Found ${label}'s .ipa (${localOnlyIpa}) but it has no remote (bytestream) digest — it was ` +
+        `built locally, not remotely executed. Ensure you built with --config=limrun so the .ipa is ` +
+        `produced in the instance's cache.`,
     );
   }
   throw new Error(`No .ipa output found for ${label} in the build event log.`);

--- a/tests/cli-rbe-workspace.test.ts
+++ b/tests/cli-rbe-workspace.test.ts
@@ -243,13 +243,14 @@ describe('rbe workspace generation', () => {
     expect(rc).toContain('--action_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin');
   });
 
-  test('renderLimrunBazelrc keeps outputs in CAS and emits BEP for the install verb', () => {
+  test('renderLimrunBazelrc emits BEP for the install verb and omits the download-mode flag', () => {
     const rc = renderLimrunBazelrc(9123, '26.4.0.17E192', true, '/ws/.limrun/bep.json');
-    // minimal download keeps the .ipa in the instance CAS (server-side install).
-    expect(rc).toContain('--remote_download_outputs=minimal');
     // BEP at a fixed path so `lim xcode rbe install` can read the .ipa digest.
     // Absolute path (not %workspace%, which Bazel doesn't expand in flag values).
     expect(rc).toContain('--build_event_json_file=/ws/.limrun/bep.json');
+    // --remote_download_outputs lives on the printed build command (visible and
+    // droppable), not the generated config, so it must NOT appear here.
+    expect(rc).not.toContain('--remote_download_outputs');
   });
 
   test('renderLimrunBazelrc registers a darwin exec platform only for non-mac clients', () => {

--- a/tests/rbe-bep.test.ts
+++ b/tests/rbe-bep.test.ts
@@ -53,9 +53,9 @@ describe('parseTopLevelIpaDigest', () => {
     );
   });
 
-  test('errors when the output was downloaded locally (file:// URI, no remote digest)', () => {
+  test('errors when the output was built locally (file:// URI, no remote digest)', () => {
     const local = bep('file:///Users/me/bazel-bin/App/App.ipa');
-    expect(() => parseTopLevelIpaDigest(local, '//App:App')).toThrow(/downloaded locally/);
+    expect(() => parseTopLevelIpaDigest(local, '//App:App')).toThrow(/built locally, not remotely executed/);
   });
 
   test('errors when there is no .ipa output for the target', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI UX and documentation around Bazel flags and BEP error text; no change to remote install mechanics beyond where the download-mode flag is applied.
> 
> **Overview**
> Moves **`--remote_download_outputs=minimal`** out of the generated **`--config=limrun`** `.limrun/bazelrc` and onto the **printed example `bazelisk` build command**, so skipping local `.ipa` downloads is visible and users can remove the flag to materialize the artifact on their machine without touching generated config.
> 
> The ready banner now explains that **`lim xcode rbe install`** pulls from the instance cache and that dropping the flag enables a local download. **BEP parsing docs/errors** are updated to state that **`bytestream://` digests come from remote execution** (not from minimal download mode); a **`file://`** `.ipa` is reported as **built locally**, not “downloaded locally.” Tests assert the flag is **omitted** from `renderLimrunBazelrc` and still expected on the suggested build command path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef88af3b3ff28677900dc71527e7aec39cb817c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->