### PR TITLE
lim xcode rbe: stop leaking abandoned instances; keep download-outputs minimal in config

### DIFF
--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -72,6 +72,12 @@ export abstract class BaseCommand extends Command {
   private _xcodeReplacementIntent?: XcodeReplacementIntent;
   private _overrideInstanceId?: string;
   private _createRetryCount = 0;
+  // Server-side instances THIS invocation created, so a path that abandons one
+  // (e.g. it turns out not to support RBE) can delete it instead of leaking a
+  // billed instance. Only instances we created are eligible — never a user
+  // --id or a pre-existing cached instance. Protected so the factories that
+  // populate it and the helpers that read it stay in one visibility tier.
+  protected _instancesCreatedThisRun = new Set<string>();
 
   protected get parsedFlags(): Record<string, unknown> | undefined {
     return this._parsedFlags;
@@ -481,23 +487,52 @@ export abstract class BaseCommand extends Command {
 
     if (prefix === 'ios' || commandType === 'ios') {
       const instance = await this.client.iosInstances.create({ wait: true, spec: {} });
+      this._instancesCreatedThisRun.add(instance.metadata.id);
       saveLastCreatedInstance(instance);
       return loadLastIosInstance();
     }
 
     if (prefix === 'android' || commandType === 'android') {
       const instance = await this.client.androidInstances.create({ wait: true, spec: {} });
+      this._instancesCreatedThisRun.add(instance.metadata.id);
       saveLastCreatedInstance(instance);
       return loadLastAndroidInstance();
     }
 
     if (prefix === 'xcode' || prefix === 'sandbox' || commandType === 'xcode') {
       const instance = await this.client.xcodeInstances.create({ wait: true, spec: {} });
+      this._instancesCreatedThisRun.add(instance.metadata.id);
       saveLastCreatedInstance(instance);
       return loadLastXcodeInstance();
     }
 
     return null;
+  }
+
+  /** Whether `id` is a server-side instance THIS invocation auto-created. */
+  protected wasCreatedThisRun(id: string | undefined): boolean {
+    return !!id && this._instancesCreatedThisRun.has(id);
+  }
+
+  /**
+   * Best-effort delete of an Xcode instance THIS invocation auto-created, so a
+   * path that creates an instance and then abandons it (e.g. it does not support
+   * RBE) does not leak a billed server-side instance. Deletes directly (not via
+   * withAuth) so a 404 during cleanup can't trigger replacement creation, mirrors
+   * `deleteSim`, and never throws. No-op for an instance we did not create (a user
+   * --id or a pre-existing cached one) or a non-xcode id. Returns whether it
+   * deleted. Idempotent: the id is dropped from the set on success.
+   */
+  protected async deleteCreatedInstance(id: string | undefined): Promise<boolean> {
+    if (!id || !this._instancesCreatedThisRun.has(id)) return false;
+    try {
+      if (detectInstanceType(id) !== 'xcode') return false;
+      await this.client.xcodeInstances.delete(id);
+      this._instancesCreatedThisRun.delete(id);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private getCommandParts(): string[] {
@@ -542,6 +577,7 @@ export abstract class BaseCommand extends Command {
         sandbox: { xcode: { enabled: true } },
       },
     });
+    this._instancesCreatedThisRun.add(instance.metadata.id);
     saveLastCreatedInstance(instance, ['xcode']);
     const target = loadIosInstanceCache(instance.metadata.id);
     if (!target) {
@@ -554,6 +590,7 @@ export abstract class BaseCommand extends Command {
 
   private async createStandaloneXcodeInstance(): Promise<LastXcodeInstance> {
     const instance = await this.client.xcodeInstances.create({ wait: true, spec: {} });
+    this._instancesCreatedThisRun.add(instance.metadata.id);
     saveLastCreatedInstance(instance);
     const target = loadLastXcodeInstance();
     if (!target || target.type !== 'xcode') {

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -19,6 +19,7 @@ import { login } from './lib/auth';
 import { renderTable } from './lib/formatting';
 import { stopDaemon } from './lib/daemon';
 import { detectInstanceType } from './lib/instance-client-factory';
+import { deleteCreatedXcodeInstance } from './lib/instance-cleanup';
 
 const VERSION = require('../package.json').version;
 const INSTANCE_ID_PATTERN = /\b(?:ios|android|xcode|sandbox)_[a-z0-9]+\b/i;
@@ -520,19 +521,13 @@ export abstract class BaseCommand extends Command {
    * RBE) does not leak a billed server-side instance. Deletes directly (not via
    * withAuth) so a 404 during cleanup can't trigger replacement creation, mirrors
    * `deleteSim`, and never throws. No-op for an instance we did not create (a user
-   * --id or a pre-existing cached one) or a non-xcode id. Returns whether it
-   * deleted. Idempotent: the id is dropped from the set on success.
+   * --id or a pre-existing cached one) or a non-xcode id. The decision lives in
+   * `deleteCreatedXcodeInstance` (unit-tested without the oclif runtime).
    */
-  protected async deleteCreatedInstance(id: string | undefined): Promise<boolean> {
-    if (!id || !this._instancesCreatedThisRun.has(id)) return false;
-    try {
-      if (detectInstanceType(id) !== 'xcode') return false;
-      await this.client.xcodeInstances.delete(id);
-      this._instancesCreatedThisRun.delete(id);
-      return true;
-    } catch {
-      return false;
-    }
+  protected deleteCreatedInstance(id: string | undefined): Promise<boolean> {
+    return deleteCreatedXcodeInstance(this._instancesCreatedThisRun, id, async (xcodeId) => {
+      await this.client.xcodeInstances.delete(xcodeId);
+    });
   }
 
   private getCommandParts(): string[] {

--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -233,14 +233,7 @@ export default class XcodeRbe extends BaseCommand {
       // Infer a real app target so the printed command is runnable as-is; fall
       // back to a placeholder when there's no single obvious target.
       const target = inferBuildTarget(workspaceRoot) ?? '//your:target';
-      // --remote_download_outputs=minimal keeps the built .ipa in the instance's
-      // CAS instead of downloading it; `lim xcode rbe install` installs it
-      // server-side from there, so the bytes never round-trip. It lives on the
-      // printed command (not the generated bazelrc) so it's visible and the user
-      // can drop it to materialize the .ipa locally. It's not needed for install
-      // to work: a remote output carries a bytestream:// CAS URI in the BEP under
-      // either download mode, so dropping it only adds a local download.
-      const buildCmd = `bazelisk --digest_function=sha256 build --config=limrun --remote_download_outputs=minimal ${target}`;
+      const buildCmd = `bazelisk --digest_function=sha256 build --config=limrun ${target}`;
 
       // --ios: create + attach a simulator so `lim xcode rbe install` installs on
       // it and the stream URL is printed. Recorded in the pidfile so --stop tears
@@ -636,7 +629,7 @@ export default class XcodeRbe extends BaseCommand {
     this.output('');
     this.info(
       'The built .ipa stays in the instance cache (install it with `lim xcode rbe install`); ' +
-        'drop --remote_download_outputs=minimal to download it to this machine.',
+        'to download it to this machine, add --remote_download_outputs=toplevel to the build command.',
     );
   }
 }

--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -188,11 +188,28 @@ export default class XcodeRbe extends BaseCommand {
         } catch (err) {
           this.reporter.stop('failure');
           if (err instanceof RbeUnsupportedError && !flags.id && attempt === 0) {
-            this.info('That Xcode instance does not support remote build execution; creating a fresh one...');
+            // If WE just created this instance and it can't do RBE, delete it so
+            // we don't leak a billed instance before creating a fresh one. A
+            // pre-existing cached instance is only dropped from the cache below,
+            // never deleted (the user may still want it).
+            if (this.wasCreatedThisRun(instanceId)) {
+              this.info(
+                'The Xcode instance we created does not support remote build execution; replacing it...',
+              );
+              await this.deleteCreatedInstance(instanceId);
+            } else {
+              this.info(
+                'That Xcode instance does not support remote build execution; creating a fresh one...',
+              );
+            }
             clearLastInstanceId(instanceId);
             continue;
           }
           await client.stopRbe().catch(() => {});
+          // Best-effort: delete an instance we created this run before failing,
+          // so a non-RbeUnsupported startup error doesn't leak it. No-op for a
+          // user --id or a pre-existing cached instance.
+          await this.deleteCreatedInstance(instanceId);
           this.error(err instanceof Error ? err.message : String(err));
         }
       }

--- a/packages/cli/src/lib/instance-cleanup.ts
+++ b/packages/cli/src/lib/instance-cleanup.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure cleanup policy for instances `lim` auto-creates during one invocation,
+ * extracted from BaseCommand so it can be unit-tested without the oclif command
+ * runtime (which the repo-root tsc/jest can't load). The command tracks the ids
+ * it created in a Set and delegates the "should I delete this, and do it safely"
+ * decision here.
+ */
+
+/** True for an Xcode instance id (xcode_ / sandbox_ prefix). */
+export function isXcodeInstanceId(id: string): boolean {
+  const prefix = id.split('_')[0];
+  return prefix === 'xcode' || prefix === 'sandbox';
+}
+
+/**
+ * Best-effort delete of an Xcode instance THIS invocation created. Deletes only
+ * when `id` is in `created` AND is an Xcode id, so a user `--id`, a pre-existing
+ * cached instance, or a non-xcode id is never touched. Drops the id from the set
+ * on success (idempotent) and never throws (a failed delete just returns false
+ * and keeps the id). Returns whether it deleted.
+ */
+export async function deleteCreatedXcodeInstance(
+  created: Set<string>,
+  id: string | undefined,
+  deleteXcodeInstance: (id: string) => Promise<void>,
+): Promise<boolean> {
+  if (!id || !created.has(id) || !isXcodeInstanceId(id)) return false;
+  try {
+    await deleteXcodeInstance(id);
+    created.delete(id);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/lib/rbe-workspace.ts
+++ b/packages/cli/src/lib/rbe-workspace.ts
@@ -275,6 +275,13 @@ xcode_config(
  *   the fleet regardless of where bazel runs (the whole point of RBE).
  * - PATH includes /usr/sbin:/sbin so genrules that probe `sysctl` (e.g.
  *   `hw.logicalcpu` for `make -j`) resolve it on the worker.
+ * - `--remote_download_outputs=minimal` keeps the built .ipa in the instance's
+ *   CAS instead of downloading it; `lim xcode rbe install` installs it server-side
+ *   from there, so the bytes never round-trip. It's not needed for install to work
+ *   (a remote output keeps its bytestream:// CAS digest in the BEP either way), so
+ *   the printed `lim xcode rbe` output tells users to add
+ *   `--remote_download_outputs=toplevel` on the command line when they want the
+ *   .ipa materialized locally (a command-line flag overrides this rc setting).
  * - `--build_event_json_file` writes the Build Event Protocol to .limrun/bep.json;
  *   `lim xcode rbe install` reads the built target's .ipa CAS digest from it. The
  *   path is ABSOLUTE on purpose: Bazel expands `%workspace%` only in
@@ -308,6 +315,7 @@ build:limrun --strategy=Genrule=remote
 build:limrun --xcode_version_config=//.limrun:remote_xcode_config
 build:limrun --xcode_version=${shortVersion(versionKey)}
 build:limrun --ios_multi_cpus=sim_arm64
+build:limrun --remote_download_outputs=minimal
 build:limrun --build_event_json_file=${bepPath}
 ${execPlatform}build:limrun --action_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin
 `;

--- a/src/rbe-bep.ts
+++ b/src/rbe-bep.ts
@@ -8,9 +8,10 @@
  * downloads the bytes (`--remote_download_outputs`), because the URI names the
  * output's CAS identity, not its local availability. `lim xcode rbe install`
  * reads that digest and hands it to the instance, which fetches the blob from
- * its own RBE cache and installs it — no round-trip. The printed build command
- * passes `--remote_download_outputs=minimal` to skip the (unneeded) local
- * download by default; dropping it does not affect this parser.
+ * its own RBE cache and installs it — no round-trip. The generated bazelrc sets
+ * `--remote_download_outputs=minimal` to skip the (unneeded) local download by
+ * default; overriding it (e.g. `--remote_download_outputs=toplevel` on the command
+ * line) to materialize the .ipa locally does not affect this parser.
  */
 
 export type BepIpaDigest = {

--- a/tests/cli-rbe-instance-cleanup.test.ts
+++ b/tests/cli-rbe-instance-cleanup.test.ts
@@ -1,0 +1,87 @@
+import { BaseCommand } from '../packages/cli/src/base-command';
+
+/**
+ * Pins the instance-leak guard: `lim xcode rbe` must delete a server-side
+ * instance it auto-created and then abandons (e.g. one that turns out not to
+ * support RBE), but never delete a user `--id` or a pre-existing cached
+ * instance. The cleanup is keyed off `_instancesCreatedThisRun`, so these tests
+ * drive the protected helpers directly via a tiny subclass with a fake client.
+ */
+
+class TestCommand extends BaseCommand {
+  xcodeDelete = jest.fn<Promise<void>, [string]>(async () => {});
+  iosDelete = jest.fn<Promise<void>, [string]>(async () => {});
+
+  // Fake client exposing only the delete methods the cleanup helper touches.
+  protected get client(): any {
+    return {
+      xcodeInstances: { delete: this.xcodeDelete },
+      iosInstances: { delete: this.iosDelete },
+    };
+  }
+
+  async run(): Promise<void> {}
+
+  // Test seams onto the protected surface under test.
+  markCreated(id: string): void {
+    this._instancesCreatedThisRun.add(id);
+  }
+  wasCreated(id: string | undefined): boolean {
+    return this.wasCreatedThisRun(id);
+  }
+  cleanup(id: string | undefined): Promise<boolean> {
+    return this.deleteCreatedInstance(id);
+  }
+}
+
+function newCommand(): TestCommand {
+  return new TestCommand([], {} as never);
+}
+
+const CREATED_XCODE = 'sandbox_euna_01created';
+const USER_XCODE = 'sandbox_user_01pinned';
+const SIM_IOS = 'ios_sim_01attached';
+
+describe('rbe instance-leak cleanup', () => {
+  test('deletes an xcode instance we created, and is idempotent', async () => {
+    const cmd = newCommand();
+    cmd.markCreated(CREATED_XCODE);
+    expect(cmd.wasCreated(CREATED_XCODE)).toBe(true);
+
+    await expect(cmd.cleanup(CREATED_XCODE)).resolves.toBe(true);
+    expect(cmd.xcodeDelete).toHaveBeenCalledTimes(1);
+    expect(cmd.xcodeDelete).toHaveBeenCalledWith(CREATED_XCODE);
+
+    // Dropped from the set on success, so a second attempt is a no-op.
+    await expect(cmd.cleanup(CREATED_XCODE)).resolves.toBe(false);
+    expect(cmd.xcodeDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test('never deletes an instance we did not create (user --id / pre-existing / undefined)', async () => {
+    const cmd = newCommand();
+    for (const id of [USER_XCODE, SIM_IOS, undefined]) {
+      expect(cmd.wasCreated(id)).toBe(false);
+      await expect(cmd.cleanup(id)).resolves.toBe(false);
+    }
+    expect(cmd.xcodeDelete).not.toHaveBeenCalled();
+    expect(cmd.iosDelete).not.toHaveBeenCalled();
+  });
+
+  test('xcode-scoped: a tracked non-xcode id is not routed to the xcode deleter', async () => {
+    const cmd = newCommand();
+    cmd.markCreated(SIM_IOS); // defense-in-depth: even if an ios id were tracked
+    await expect(cmd.cleanup(SIM_IOS)).resolves.toBe(false);
+    expect(cmd.xcodeDelete).not.toHaveBeenCalled();
+    expect(cmd.iosDelete).not.toHaveBeenCalled();
+  });
+
+  test('best-effort: a failing delete never throws, returns false, and keeps the id', async () => {
+    const cmd = newCommand();
+    cmd.xcodeDelete.mockRejectedValueOnce(new Error('server unavailable'));
+    cmd.markCreated(CREATED_XCODE);
+
+    await expect(cmd.cleanup(CREATED_XCODE)).resolves.toBe(false);
+    // Retained so it isn't silently forgotten (matches deleteSim semantics).
+    expect(cmd.wasCreated(CREATED_XCODE)).toBe(true);
+  });
+});

--- a/tests/cli-rbe-instance-cleanup.test.ts
+++ b/tests/cli-rbe-instance-cleanup.test.ts
@@ -1,87 +1,61 @@
-import { BaseCommand } from '../packages/cli/src/base-command';
+import { deleteCreatedXcodeInstance, isXcodeInstanceId } from '../packages/cli/src/lib/instance-cleanup';
 
 /**
  * Pins the instance-leak guard: `lim xcode rbe` must delete a server-side
  * instance it auto-created and then abandons (e.g. one that turns out not to
- * support RBE), but never delete a user `--id` or a pre-existing cached
- * instance. The cleanup is keyed off `_instancesCreatedThisRun`, so these tests
- * drive the protected helpers directly via a tiny subclass with a fake client.
+ * support RBE), but never delete a user `--id`, a pre-existing cached instance,
+ * or a non-xcode instance. The decision is the pure `deleteCreatedXcodeInstance`
+ * policy; BaseCommand only supplies its created-id Set and the SDK delete call.
  */
-
-class TestCommand extends BaseCommand {
-  xcodeDelete = jest.fn<Promise<void>, [string]>(async () => {});
-  iosDelete = jest.fn<Promise<void>, [string]>(async () => {});
-
-  // Fake client exposing only the delete methods the cleanup helper touches.
-  protected get client(): any {
-    return {
-      xcodeInstances: { delete: this.xcodeDelete },
-      iosInstances: { delete: this.iosDelete },
-    };
-  }
-
-  async run(): Promise<void> {}
-
-  // Test seams onto the protected surface under test.
-  markCreated(id: string): void {
-    this._instancesCreatedThisRun.add(id);
-  }
-  wasCreated(id: string | undefined): boolean {
-    return this.wasCreatedThisRun(id);
-  }
-  cleanup(id: string | undefined): Promise<boolean> {
-    return this.deleteCreatedInstance(id);
-  }
-}
-
-function newCommand(): TestCommand {
-  return new TestCommand([], {} as never);
-}
 
 const CREATED_XCODE = 'sandbox_euna_01created';
 const USER_XCODE = 'sandbox_user_01pinned';
 const SIM_IOS = 'ios_sim_01attached';
 
-describe('rbe instance-leak cleanup', () => {
+describe('rbe instance-leak cleanup policy', () => {
   test('deletes an xcode instance we created, and is idempotent', async () => {
-    const cmd = newCommand();
-    cmd.markCreated(CREATED_XCODE);
-    expect(cmd.wasCreated(CREATED_XCODE)).toBe(true);
+    const created = new Set([CREATED_XCODE]);
+    const del = jest.fn(async () => {});
 
-    await expect(cmd.cleanup(CREATED_XCODE)).resolves.toBe(true);
-    expect(cmd.xcodeDelete).toHaveBeenCalledTimes(1);
-    expect(cmd.xcodeDelete).toHaveBeenCalledWith(CREATED_XCODE);
+    await expect(deleteCreatedXcodeInstance(created, CREATED_XCODE, del)).resolves.toBe(true);
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith(CREATED_XCODE);
+    expect(created.has(CREATED_XCODE)).toBe(false);
 
     // Dropped from the set on success, so a second attempt is a no-op.
-    await expect(cmd.cleanup(CREATED_XCODE)).resolves.toBe(false);
-    expect(cmd.xcodeDelete).toHaveBeenCalledTimes(1);
+    await expect(deleteCreatedXcodeInstance(created, CREATED_XCODE, del)).resolves.toBe(false);
+    expect(del).toHaveBeenCalledTimes(1);
   });
 
-  test('never deletes an instance we did not create (user --id / pre-existing / undefined)', async () => {
-    const cmd = newCommand();
+  test('never deletes an id we did not create (user --id / pre-existing / undefined)', async () => {
+    const created = new Set<string>(); // nothing created this run
+    const del = jest.fn(async () => {});
+
     for (const id of [USER_XCODE, SIM_IOS, undefined]) {
-      expect(cmd.wasCreated(id)).toBe(false);
-      await expect(cmd.cleanup(id)).resolves.toBe(false);
+      await expect(deleteCreatedXcodeInstance(created, id, del)).resolves.toBe(false);
     }
-    expect(cmd.xcodeDelete).not.toHaveBeenCalled();
-    expect(cmd.iosDelete).not.toHaveBeenCalled();
+    expect(del).not.toHaveBeenCalled();
   });
 
-  test('xcode-scoped: a tracked non-xcode id is not routed to the xcode deleter', async () => {
-    const cmd = newCommand();
-    cmd.markCreated(SIM_IOS); // defense-in-depth: even if an ios id were tracked
-    await expect(cmd.cleanup(SIM_IOS)).resolves.toBe(false);
-    expect(cmd.xcodeDelete).not.toHaveBeenCalled();
-    expect(cmd.iosDelete).not.toHaveBeenCalled();
+  test('xcode-scoped: a tracked non-xcode id is not deleted', async () => {
+    const created = new Set([SIM_IOS]); // defense-in-depth: even if tracked
+    const del = jest.fn(async () => {});
+
+    await expect(deleteCreatedXcodeInstance(created, SIM_IOS, del)).resolves.toBe(false);
+    expect(del).not.toHaveBeenCalled();
+    expect(isXcodeInstanceId(SIM_IOS)).toBe(false);
+    expect(isXcodeInstanceId('xcode_x_1')).toBe(true);
+    expect(isXcodeInstanceId('sandbox_x_1')).toBe(true);
   });
 
   test('best-effort: a failing delete never throws, returns false, and keeps the id', async () => {
-    const cmd = newCommand();
-    cmd.xcodeDelete.mockRejectedValueOnce(new Error('server unavailable'));
-    cmd.markCreated(CREATED_XCODE);
+    const created = new Set([CREATED_XCODE]);
+    const del = jest.fn(async () => {
+      throw new Error('server unavailable');
+    });
 
-    await expect(cmd.cleanup(CREATED_XCODE)).resolves.toBe(false);
+    await expect(deleteCreatedXcodeInstance(created, CREATED_XCODE, del)).resolves.toBe(false);
     // Retained so it isn't silently forgotten (matches deleteSim semantics).
-    expect(cmd.wasCreated(CREATED_XCODE)).toBe(true);
+    expect(created.has(CREATED_XCODE)).toBe(true);
   });
 });

--- a/tests/cli-rbe-workspace.test.ts
+++ b/tests/cli-rbe-workspace.test.ts
@@ -243,14 +243,14 @@ describe('rbe workspace generation', () => {
     expect(rc).toContain('--action_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin');
   });
 
-  test('renderLimrunBazelrc emits BEP for the install verb and omits the download-mode flag', () => {
+  test('renderLimrunBazelrc keeps outputs in CAS and emits BEP for the install verb', () => {
     const rc = renderLimrunBazelrc(9123, '26.4.0.17E192', true, '/ws/.limrun/bep.json');
+    // minimal download keeps the .ipa in the instance CAS (server-side install);
+    // users add --remote_download_outputs=toplevel on the command line to override.
+    expect(rc).toContain('--remote_download_outputs=minimal');
     // BEP at a fixed path so `lim xcode rbe install` can read the .ipa digest.
     // Absolute path (not %workspace%, which Bazel doesn't expand in flag values).
     expect(rc).toContain('--build_event_json_file=/ws/.limrun/bep.json');
-    // --remote_download_outputs lives on the printed build command (visible and
-    // droppable), not the generated config, so it must NOT appear here.
-    expect(rc).not.toContain('--remote_download_outputs');
   });
 
   test('renderLimrunBazelrc registers a darwin exec platform only for non-mac clients', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes billed instance lifecycle (server deletes) and default Bazel remote download behavior; safeguards limit deletes to auto-created Xcode ids only.
> 
> **Overview**
> **`lim xcode rbe`** now tracks server instances **this CLI run** auto-created and **best-effort deletes** abandoned Xcode instances (e.g. RBE unsupported or startup failure) so billed sandboxes are not left running. User **`--id`** and cached instances are **never** deleted—only cache clears where appropriate. Policy lives in **`instance-cleanup.ts`** with unit tests; **`BaseCommand`** wires the set and direct SDK delete (bypassing **`withAuth`** so cleanup 404s do not spawn replacements).
> 
> **Remote download behavior** moves **`--remote_download_outputs=minimal`** into the generated **`.limrun/bazelrc`** (default under **`--config=limrun`**). The printed sample **`bazelisk`** command drops that flag; ready text tells users to add **`--remote_download_outputs=toplevel`** when they want the **`.ipa`** locally. **`rbe-bep`** / install docs updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65091e177c9cb4124b9c2936c8944082ed907005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->