### PR TITLE
maestro-ios: drop simctl spawn now that the server rejects it

### DIFF
--- a/examples/maestro-ios/index.ts
+++ b/examples/maestro-ios/index.ts
@@ -74,8 +74,8 @@ try {
 }
 if (!wdaRunning) {
   console.log('Runner is not running, launching it...');
-  await lim.simctl(['spawn', 'booted', 'launchctl', 'setenv', 'PORT', String(MAESTRO_RUNNER_PORT)]).wait();
-  await lim
+  // The patched runner listens on MAESTRO_RUNNER_PORT by default, so launching it is enough.
+  const launch = await lim
     .simctl([
       'launch',
       '--terminate-running-process',
@@ -83,6 +83,9 @@ if (!wdaRunning) {
       'dev.mobile.maestro-driver-iosUITests.xctrunner',
     ])
     .wait();
+  if (launch.code !== 0) {
+    throw new Error(`Failed to launch the Maestro runner (exit code ${launch.code}): ${launch.stderr}`);
+  }
   console.log('Runner launched');
 }
 

--- a/src/ios-shim.ts
+++ b/src/ios-shim.ts
@@ -13,7 +13,6 @@ const FORWARDED_SIMCTL_COMMANDS = new Set([
   'privacy',
   'location',
   'status_bar',
-  'spawn',
 ]);
 
 export type IosXcrunShimServer = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example and shim-only changes that follow an existing server security restriction; no auth, data, or core API behavior changes.
> 
> **Overview**
> Aligns the Maestro iOS example and xcrun shim with limrun’s removal of **`simctl spawn`** from the server allowlist (sandbox escape fix).
> 
> **`examples/maestro-ios`**: Drops the obsolete `spawn` / `launchctl setenv PORT` step—the patched runner already listens on the default port. **`simctl launch`** failures now surface immediately via exit code and stderr instead of failing later as a Maestro timeout.
> 
> **`src/ios-shim`**: Stops forwarding **`spawn`** so tools that call `xcrun simctl spawn` get the shim’s standard “does not support simctl spawn” response (exit 64) rather than a raw server rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073e1f35b7d56114e832942e68f73444331894f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->