### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:limrun-inc/typescript-sdk",
+  "homepage": "https://lim.run",
+  "bugs": {
+    "url": "https://github.com/limrun-inc/typescript-sdk/issues"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
## Summary

Adds npm package support metadata for `@limrun/api`:

- `homepage` points to the Limrun API documentation site referenced by the README.
- `bugs.url` points to this repository's GitHub Issues page.

The existing repository metadata, runtime code, dependencies, exports, and package version are unchanged.

## Verification

- `node -e` manifest assertion for `name`, `repository`, `homepage`, and `bugs.url`
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only metadata; no runtime, dependency, or export changes.
> 
> **Overview**
> Adds standard npm package metadata to `@limrun/api` without changing runtime code, dependencies, exports, or version.
> 
> **`homepage`** is set to `https://lim.run` so the registry and tooling surface the public API/docs site. **`bugs.url`** is set to this repo’s GitHub Issues page for support and bug reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac5e9832e797340b5865daca86b21d9ef93136c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->