### PR TITLE
chore: add homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,9 @@
       "import": "./dist/*.mjs",
       "require": "./dist/*.js"
     }
+  },
+  "homepage": "https://lim.run",
+  "bugs": {
+    "url": "https://github.com/limrun-inc/typescript-sdk/issues"
   }
 }


### PR DESCRIPTION
This PR adds missing \homepage\ and \ugs.url\ metadata to \package.json\, as identified in charles-microbounties#961.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-style `package.json` fields only; no code paths or publishing behavior are modified.
> 
> **Overview**
> Adds standard npm package metadata to `package.json`: **`homepage`** (`https://lim.run`) and **`bugs.url`** (GitHub issues on `limrun-inc/typescript-sdk`).
> 
> No runtime, build, or export behavior changes—metadata only for registry UIs and tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594454fcbb0f0aa3c5300b998f79999667253a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->