### PR TITLE
cli: scope the last-used instance per git worktree

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lim",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@limrun/api": "^0.31.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -16,6 +16,7 @@ import {
   type LastXcodeInstance,
 } from './lib/config';
 import { login } from './lib/auth';
+import { describeScope, setScopeOverride } from './lib/scope';
 import { renderTable } from './lib/formatting';
 import { stopDaemon } from './lib/daemon';
 import { detectInstanceType } from './lib/instance-client-factory';
@@ -46,6 +47,11 @@ export abstract class BaseCommand extends Command {
       description: 'Create a replacement instance automatically if the target instance is not found.',
       default: true,
       allowNo: true,
+    }),
+    scope: Flags.string({
+      description:
+        'Scope used to resolve the most recent instance when no ID is given. Inside a git worktree the scope is that worktree (so parallel agents stay isolated); elsewhere a shared default is used. Pass an explicit value (or set LIM_INSTANCE_SCOPE) to isolate agents that run in separate clones rather than worktrees.',
+      env: 'LIM_INSTANCE_SCOPE',
     }),
   };
 
@@ -86,6 +92,10 @@ export abstract class BaseCommand extends Command {
 
   protected setParsedFlags(flags: Record<string, unknown>): void {
     this._parsedFlags = flags;
+    const scope = flags['scope'];
+    if (typeof scope === 'string' && scope.trim()) {
+      setScopeOverride(scope.trim());
+    }
   }
 
   protected isJsonEnabled(): boolean {
@@ -269,7 +279,7 @@ export abstract class BaseCommand extends Command {
     }
 
     throw new Error(
-      'No instance ID provided and no recentandroid instance found.\n' +
+      `No instance ID provided and no recent android instance for ${describeScope()}.\n` +
         'Provide an instance ID or create one first with: lim android create',
     );
   }
@@ -290,7 +300,7 @@ export abstract class BaseCommand extends Command {
     }
 
     throw new Error(
-      'No instance ID provided and no recentios instance found.\n' +
+      `No instance ID provided and no recent ios instance for ${describeScope()}.\n` +
         'Provide an instance ID or create one first with: lim ios create',
     );
   }
@@ -322,7 +332,7 @@ export abstract class BaseCommand extends Command {
     }
 
     throw new Error(
-      'No instance ID provided and no recentios or android instance found.\n' +
+      `No instance ID provided and no recent ios or android instance for ${describeScope()}.\n` +
         'Provide an instance ID or create one first with: lim ios create or lim android create',
     );
   }
@@ -348,7 +358,7 @@ export abstract class BaseCommand extends Command {
 
     const noun = parts[0] ?? 'xcode';
     throw new Error(
-      `No instance ID provided and no recent${noun} instance found.\n` +
+      `No instance ID provided and no recent ${noun} instance for ${describeScope()}.\n` +
         `Provide an instance ID or create one first with: lim ${noun} create`,
     );
   }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -7,6 +7,7 @@ import { type AndroidInstance } from '@limrun/api/resources/android-instances';
 import { type IosInstance } from '@limrun/api/resources/ios-instances';
 import { type XcodeInstance } from '@limrun/api/resources/xcode-instances';
 import { xcodeSandboxIdFromUrl } from './xcode-sandbox';
+import { getScopeKey, GLOBAL_SCOPE_KEY } from './scope';
 
 const CONFIG_DIR = path.join(os.homedir(), '.lim');
 const CONFIG_FILE = path.join(CONFIG_DIR, 'config.yaml');
@@ -80,6 +81,12 @@ export function clearApiKey(): void {
 // ---------- Last used instance per type ----------
 
 const LAST_INSTANCE_FILE = path.join(CONFIG_DIR, 'last-instances.json');
+const LAST_INSTANCE_LOCK = `${LAST_INSTANCE_FILE}.lock`;
+const SCHEMA_VERSION = 2;
+/** Cap on how many directory scopes we retain; least-recently-used are pruned beyond this. */
+const MAX_SCOPES = 200;
+/** Drop scopes untouched for this long so abandoned worktrees don't accumulate. */
+const SCOPE_TTL_MS = 60 * 24 * 60 * 60 * 1000;
 
 export interface LastAndroidInstance {
   id: string;
@@ -121,28 +128,207 @@ export interface LastXcodeInstance {
   token?: XcodeInstance.Status['token'];
 }
 
-interface LastInstances {
+/** The set of last-used instances bound to a single directory scope. */
+interface ScopeInstances {
+  lastUsedAt?: string;
   ios?: LastIosInstance;
   android?: LastAndroidInstance;
   xcode?: LastIosInstance | LastXcodeInstance;
 }
 
-function readLastInstances(): LastInstances {
-  if (!fs.existsSync(LAST_INSTANCE_FILE)) return {};
-  try {
-    const parsed = JSON.parse(fs.readFileSync(LAST_INSTANCE_FILE, 'utf-8'));
-    if (isLastInstances(parsed)) {
-      return parsed;
-    }
-  } catch {}
-  deleteLastInstancesFile();
-  return {};
+/** On-disk schema: a map of directory scope key -> its last-used instances. */
+interface LastInstancesFile {
+  version: number;
+  scopes: Record<string, ScopeInstances>;
 }
 
-function deleteLastInstancesFile(): void {
+function readParsedLastInstances(): unknown {
+  if (!fs.existsSync(LAST_INSTANCE_FILE)) return null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return JSON.parse(fs.readFileSync(LAST_INSTANCE_FILE, 'utf-8'));
+    } catch {
+      // A concurrent atomic rename can momentarily race a read; retry once.
+    }
+  }
+  return null;
+}
+
+function sanitizeScope(value: unknown): ScopeInstances {
+  const scope: ScopeInstances = {};
+  if (!isRecord(value)) return scope;
+  if (typeof value['lastUsedAt'] === 'string') scope.lastUsedAt = value['lastUsedAt'];
+  if (isLastAndroidInstance(value['android'])) scope.android = value['android'];
+  if (isLastIosInstance(value['ios'])) scope.ios = value['ios'];
+  if (isLastIosInstance(value['xcode']) || isLastXcodeInstance(value['xcode'])) {
+    scope.xcode = value['xcode'] as LastIosInstance | LastXcodeInstance;
+  }
+  return scope;
+}
+
+function scopeHasInstance(scope: ScopeInstances): boolean {
+  return Boolean(scope.ios || scope.android || scope.xcode);
+}
+
+/**
+ * Parse the on-disk file into the current scoped schema. A legacy flat file
+ * (`{ios,android,xcode}` with no `scopes`) is mapped onto the GLOBAL scope,
+ * since pre-scoping data was a single shared "most recent instance" — exactly
+ * what the global (non-worktree) slot represents. It is persisted in the new
+ * shape on the next write; reads work out of the box in the meantime.
+ */
+function readNormalizedFile(): LastInstancesFile {
+  const parsed = readParsedLastInstances();
+  const file: LastInstancesFile = { version: SCHEMA_VERSION, scopes: {} };
+  if (!isRecord(parsed)) return file;
+
+  if (typeof parsed['version'] === 'number' && isRecord(parsed['scopes'])) {
+    for (const [key, value] of Object.entries(parsed['scopes'])) {
+      file.scopes[key] = sanitizeScope(value);
+    }
+    return file;
+  }
+
+  const legacy = sanitizeScope(parsed);
+  if (scopeHasInstance(legacy)) {
+    file.scopes[GLOBAL_SCOPE_KEY] = legacy;
+  }
+  return file;
+}
+
+function getScopeData(file: LastInstancesFile, scopeKey: string): ScopeInstances {
+  return file.scopes[scopeKey] ?? {};
+}
+
+function readScope(scopeKey: string): ScopeInstances {
+  return getScopeData(readNormalizedFile(), scopeKey);
+}
+
+function ensureScope(file: LastInstancesFile, scopeKey: string): ScopeInstances {
+  let scope = file.scopes[scopeKey];
+  if (!scope) {
+    scope = {};
+    file.scopes[scopeKey] = scope;
+  }
+  return scope;
+}
+
+function scopeTimestamp(scope: ScopeInstances): number {
+  const ts = scope.lastUsedAt ? Date.parse(scope.lastUsedAt) : NaN;
+  return Number.isNaN(ts) ? 0 : ts;
+}
+
+/**
+ * Drop empty scopes, TTL-expired worktree scopes, and the least-recently-used
+ * beyond the cap. The GLOBAL scope is exempt from TTL/LRU eviction (it is the
+ * shared default slot), but is still removed once it holds no instances.
+ */
+function pruneScopes(file: LastInstancesFile): boolean {
+  let changed = false;
+  const now = Date.now();
+  for (const key of Object.keys(file.scopes)) {
+    const scope = file.scopes[key]!;
+    const isGlobal = key === GLOBAL_SCOPE_KEY;
+    const expired = !isGlobal && scope.lastUsedAt ? now - scopeTimestamp(scope) > SCOPE_TTL_MS : false;
+    if (!scopeHasInstance(scope) || expired) {
+      delete file.scopes[key];
+      changed = true;
+    }
+  }
+  const keys = Object.keys(file.scopes).filter((k) => k !== GLOBAL_SCOPE_KEY);
+  if (keys.length > MAX_SCOPES) {
+    keys
+      .sort((a, b) => scopeTimestamp(file.scopes[a]!) - scopeTimestamp(file.scopes[b]!))
+      .slice(0, keys.length - MAX_SCOPES)
+      .forEach((key) => {
+        delete file.scopes[key];
+        changed = true;
+      });
+  }
+  return changed;
+}
+
+function atomicWriteFile(file: LastInstancesFile): void {
+  ensureConfigDir();
+  const tmp = `${LAST_INSTANCE_FILE}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(file, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, LAST_INSTANCE_FILE);
+}
+
+function sleepSync(ms: number): void {
   try {
-    fs.unlinkSync(LAST_INSTANCE_FILE);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    const end = Date.now() + ms;
+    while (Date.now() < end) {
+      /* SharedArrayBuffer unavailable; brief busy wait */
+    }
+  }
+}
+
+const LOCK_TIMEOUT_MS = 3000;
+const LOCK_STALE_MS = 15000;
+
+function acquireLock(): number | null {
+  const start = Date.now();
+  for (;;) {
+    try {
+      const fd = fs.openSync(LAST_INSTANCE_LOCK, 'wx');
+      try {
+        fs.writeSync(fd, String(process.pid));
+      } catch {}
+      return fd;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+        return null; // can't create lock (e.g. permissions); proceed best-effort
+      }
+      try {
+        const stat = fs.statSync(LAST_INSTANCE_LOCK);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          try {
+            fs.unlinkSync(LAST_INSTANCE_LOCK);
+          } catch {}
+          continue;
+        }
+      } catch {
+        continue; // lock vanished between open and stat; retry immediately
+      }
+      if (Date.now() - start > LOCK_TIMEOUT_MS) return null;
+      sleepSync(20 + Math.floor(Math.random() * 30));
+    }
+  }
+}
+
+function releaseLock(fd: number | null): void {
+  if (fd === null) return;
+  try {
+    fs.closeSync(fd);
   } catch {}
+  try {
+    fs.unlinkSync(LAST_INSTANCE_LOCK);
+  } catch {}
+}
+
+/**
+ * Serialized, atomic read-modify-write of the last-instances file. The mutator
+ * receives the parsed file plus the active scope key; returning `false` signals
+ * no change so we can skip the write (and avoid needless lock churn for parallel
+ * agents). A legacy flat file is normalized onto the GLOBAL scope on read, so it
+ * is rewritten in the new shape whenever any mutation persists.
+ */
+function mutate(fn: (file: LastInstancesFile, scopeKey: string) => boolean | void): void {
+  ensureConfigDir();
+  const fd = acquireLock();
+  try {
+    const file = readNormalizedFile();
+    const scopeKey = getScopeKey();
+    let changed = false;
+    if (fn(file, scopeKey) !== false) changed = true;
+    if (pruneScopes(file)) changed = true;
+    if (changed) atomicWriteFile(file);
+  } finally {
+    releaseLock(fd);
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -159,22 +345,6 @@ function isLastIosInstance(value: unknown): value is LastIosInstance {
 
 function isLastXcodeInstance(value: unknown): value is LastXcodeInstance {
   return isRecord(value) && value['type'] === 'xcode' && typeof value['id'] === 'string';
-}
-
-function isLastInstances(value: unknown): value is LastInstances {
-  if (!isRecord(value)) return false;
-  const keys = Object.keys(value);
-  if (keys.some((key) => !['ios', 'android', 'xcode'].includes(key))) return false;
-  if (value['android'] !== undefined && !isLastAndroidInstance(value['android'])) return false;
-  if (value['ios'] !== undefined && !isLastIosInstance(value['ios'])) return false;
-  if (
-    value['xcode'] !== undefined &&
-    !isLastIosInstance(value['xcode']) &&
-    !isLastXcodeInstance(value['xcode'])
-  ) {
-    return false;
-  }
-  return true;
 }
 
 function detectLastInstanceType(instanceId: string): 'ios' | 'android' | 'xcode' {
@@ -300,22 +470,21 @@ function buildLastXcodeSlotRecord(instanceOrId: InstanceInput): LastIosInstance 
 }
 
 function saveLastInstance(instanceOrId: InstanceInput, slot?: 'xcode'): void {
-  ensureConfigDir();
   const record = buildLastInstanceRecord(instanceOrId);
-  const data = readLastInstances();
-  if (slot === 'xcode') {
-    const xcodeRecord = buildLastXcodeSlotRecord(instanceOrId);
-    if (xcodeRecord) {
-      data.xcode = xcodeRecord;
+  mutate((file, scopeKey) => {
+    const scope = ensureScope(file, scopeKey);
+    if (slot === 'xcode') {
+      const xcodeRecord = buildLastXcodeSlotRecord(instanceOrId);
+      if (xcodeRecord) scope.xcode = xcodeRecord;
+    } else if (record.type === 'android') {
+      scope.android = record;
+    } else if (record.type === 'ios') {
+      scope.ios = record;
+    } else {
+      scope.xcode = record;
     }
-  } else if (record.type === 'android') {
-    data.android = record;
-  } else if (record.type === 'ios') {
-    data.ios = record;
-  } else {
-    data.xcode = record;
-  }
-  fs.writeFileSync(LAST_INSTANCE_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+    scope.lastUsedAt = new Date().toISOString();
+  });
 }
 
 export function registerCreatedInstance(
@@ -329,18 +498,15 @@ export function registerCreatedInstance(
 }
 
 export function loadLastAndroidInstance(): LastAndroidInstance | null {
-  const data = readLastInstances();
-  return data.android ?? null;
+  return readScope(getScopeKey()).android ?? null;
 }
 
 export function loadLastIosInstance(): LastIosInstance | null {
-  const data = readLastInstances();
-  return data.ios ?? null;
+  return readScope(getScopeKey()).ios ?? null;
 }
 
 export function loadLastXcodeInstance(): LastIosInstance | LastXcodeInstance | null {
-  const data = readLastInstances();
-  return data.xcode ?? null;
+  return readScope(getScopeKey()).xcode ?? null;
 }
 
 function sandboxXcodeIdFromLastIosInstance(instance: LastIosInstance | undefined): string | undefined {
@@ -349,75 +515,80 @@ function sandboxXcodeIdFromLastIosInstance(instance: LastIosInstance | undefined
 }
 
 export function clearLastInstanceId(instanceId: string): void {
-  const data = readLastInstances();
-  const iosRecord = data.ios;
-  let changed = false;
-  for (const key of Object.keys(data) as (keyof LastInstances)[]) {
-    if (data[key]?.id === instanceId) {
-      delete data[key];
-      changed = true;
+  mutate((file) => {
+    let changed = false;
+    for (const scope of Object.values(file.scopes)) {
+      const iosRecord = scope.ios;
+      for (const key of ['ios', 'android', 'xcode'] as const) {
+        if (scope[key]?.id === instanceId) {
+          delete scope[key];
+          changed = true;
+        }
+      }
+      const sandboxXcodeId =
+        iosRecord?.id === instanceId ? sandboxXcodeIdFromLastIosInstance(iosRecord) : undefined;
+      if (sandboxXcodeId && scope.xcode?.type === 'xcode' && scope.xcode.id === sandboxXcodeId) {
+        delete scope.xcode;
+        changed = true;
+      }
     }
-  }
-  const sandboxXcodeId =
-    iosRecord?.id === instanceId ? sandboxXcodeIdFromLastIosInstance(iosRecord) : undefined;
-  if (sandboxXcodeId && data.xcode?.type === 'xcode' && data.xcode.id === sandboxXcodeId) {
-    delete data.xcode;
-    changed = true;
-  }
-  if (changed) {
-    ensureConfigDir();
-    fs.writeFileSync(LAST_INSTANCE_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
-  }
+    return changed;
+  });
 }
 
 export function saveInstanceCache(
   instanceId: string,
   data: Partial<LastAndroidInstance> | Partial<LastIosInstance> | Partial<LastXcodeInstance>,
 ): void {
-  const lastInstances = readLastInstances();
-  let changed = false;
-  if (lastInstances.android?.id === instanceId) {
-    lastInstances.android = {
-      ...lastInstances.android,
-      ...(data as Partial<LastAndroidInstance>),
-      type: 'android',
-    };
-    changed = true;
-  }
-  if (lastInstances.ios?.id === instanceId) {
-    lastInstances.ios = {
-      ...lastInstances.ios,
-      ...(data as Partial<LastIosInstance>),
-      type: 'ios',
-    };
-    changed = true;
-  }
-  if (lastInstances.xcode?.id === instanceId) {
-    lastInstances.xcode =
-      lastInstances.xcode.type === 'ios' ?
-        { ...lastInstances.xcode, ...(data as Partial<LastIosInstance>), type: 'ios' }
-      : { ...lastInstances.xcode, ...(data as Partial<LastXcodeInstance>), type: 'xcode' };
-    changed = true;
-  }
-  if (changed) {
-    ensureConfigDir();
-    fs.writeFileSync(LAST_INSTANCE_FILE, JSON.stringify(lastInstances, null, 2), { mode: 0o600 });
-  }
+  mutate((file) => {
+    let changed = false;
+    for (const scope of Object.values(file.scopes)) {
+      if (scope.android?.id === instanceId) {
+        scope.android = {
+          ...scope.android,
+          ...(data as Partial<LastAndroidInstance>),
+          type: 'android',
+        };
+        changed = true;
+      }
+      if (scope.ios?.id === instanceId) {
+        scope.ios = {
+          ...scope.ios,
+          ...(data as Partial<LastIosInstance>),
+          type: 'ios',
+        };
+        changed = true;
+      }
+      if (scope.xcode?.id === instanceId) {
+        scope.xcode =
+          scope.xcode.type === 'ios' ?
+            { ...scope.xcode, ...(data as Partial<LastIosInstance>), type: 'ios' }
+          : { ...scope.xcode, ...(data as Partial<LastXcodeInstance>), type: 'xcode' };
+        changed = true;
+      }
+    }
+    return changed;
+  });
 }
 
 export function loadAndroidInstanceCache(instanceId: string): LastAndroidInstance | null {
-  const record = readLastInstances().android;
-  return record?.id === instanceId ? record : null;
+  for (const scope of Object.values(readNormalizedFile().scopes)) {
+    if (scope.android?.id === instanceId) return scope.android;
+  }
+  return null;
 }
 
 export function loadIosInstanceCache(instanceId: string): LastIosInstance | null {
-  const data = readLastInstances();
-  if (data.ios?.id === instanceId) return data.ios;
-  if (data.xcode?.type === 'ios' && data.xcode.id === instanceId) return data.xcode;
+  for (const scope of Object.values(readNormalizedFile().scopes)) {
+    if (scope.ios?.id === instanceId) return scope.ios;
+    if (scope.xcode?.type === 'ios' && scope.xcode.id === instanceId) return scope.xcode;
+  }
   return null;
 }
 
 export function loadXcodeInstanceCache(instanceId: string): LastXcodeInstance | null {
-  const record = readLastInstances().xcode;
-  return record?.type === 'xcode' && record.id === instanceId ? record : null;
+  for (const scope of Object.values(readNormalizedFile().scopes)) {
+    if (scope.xcode?.type === 'xcode' && scope.xcode.id === instanceId) return scope.xcode;
+  }
+  return null;
 }

--- a/packages/cli/src/lib/scope.ts
+++ b/packages/cli/src/lib/scope.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+/**
+ * A "scope" isolates the most-recently-used instance per context so parallel AI
+ * agents can each drive their own instance instead of sharing one global slot.
+ *
+ * Hybrid model:
+ *   - Inside a *linked* git worktree (one created via `git worktree add`), the
+ *     scope is that worktree's root, so each worktree gets its own instance.
+ *   - Everywhere else (a repo's main checkout, a plain directory, or outside a
+ *     repo) the scope is a single shared GLOBAL slot, preserving the original
+ *     "use the most recent instance I created" behavior with zero setup.
+ *
+ * Resolution order (first match wins), memoized for the process lifetime:
+ *   1. an explicit in-process override set from the global `--scope` flag,
+ *   2. the LIM_INSTANCE_SCOPE environment variable,
+ *   3. the current linked-worktree root, if any,
+ *   4. the GLOBAL scope.
+ *
+ * Steps 3 and 4 require no setup. An explicit override (1/2) always wins, which
+ * is the escape hatch for isolating agents that run in separate clones rather
+ * than worktrees.
+ */
+
+/** Sentinel scope key for the shared, non-worktree "most recent instance" slot. */
+export const GLOBAL_SCOPE_KEY = '__global__';
+
+let override: string | undefined;
+let cachedDefault: string | undefined;
+
+/**
+ * Override the scope key for this process (used by the global `--scope` flag).
+ * Passing an empty/undefined value clears the override.
+ */
+export function setScopeOverride(key: string | undefined): void {
+  const trimmed = key?.trim();
+  override = trimmed ? normalizeScopeKey(trimmed, true) : undefined;
+}
+
+/** Resolve the active scope key. Memoizes only the worktree/global fallback. */
+export function getScopeKey(): string {
+  if (override) return override;
+
+  const env = process.env['LIM_INSTANCE_SCOPE']?.trim();
+  if (env) return normalizeScopeKey(env, true);
+
+  if (cachedDefault === undefined) {
+    cachedDefault = computeDefaultScopeKey();
+  }
+  return cachedDefault;
+}
+
+/** True when the active scope is the shared global (non-worktree) slot. */
+export function isGlobalScope(): boolean {
+  return getScopeKey() === GLOBAL_SCOPE_KEY;
+}
+
+/** Human-readable description of the active scope, for messages. */
+export function describeScope(): string {
+  const key = getScopeKey();
+  return key === GLOBAL_SCOPE_KEY ? 'the default (non-worktree) context' : `this directory (${key})`;
+}
+
+/** Reset memoized state. Intended for tests only. */
+export function resetScopeCacheForTests(): void {
+  override = undefined;
+  cachedDefault = undefined;
+}
+
+function computeDefaultScopeKey(): string {
+  const worktreeRoot = linkedWorktreeRoot();
+  return worktreeRoot ? normalizeScopeKey(worktreeRoot, false) : GLOBAL_SCOPE_KEY;
+}
+
+/**
+ * Return the toplevel of the current *linked* worktree, or undefined when we are
+ * in a repo's main checkout or not in a git repo at all. A linked worktree is
+ * detected by its per-worktree git dir differing from the shared common git dir.
+ */
+function linkedWorktreeRoot(): string | undefined {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--git-dir', '--git-common-dir', '--show-toplevel'], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+    }).trim();
+    const [gitDir, commonDir, topLevel] = out.split('\n').map((line) => line.trim());
+    if (!gitDir || !commonDir || !topLevel) return undefined;
+    const cwd = process.cwd();
+    if (path.resolve(cwd, gitDir) === path.resolve(cwd, commonDir)) {
+      return undefined; // main checkout
+    }
+    return topLevel;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Normalize a scope key. Real filesystem paths are canonicalized through
+ * `realpath` so symlinks and sibling worktrees resolve to stable, distinct
+ * keys. Explicit overrides that are not real paths (e.g. an arbitrary label or
+ * the GLOBAL sentinel) are kept verbatim so they stay stable regardless of cwd.
+ */
+function normalizeScopeKey(input: string, allowLiteral: boolean): string {
+  try {
+    return fs.realpathSync.native(input);
+  } catch {
+    return allowLiteral ? input : path.resolve(input);
+  }
+}

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -4,11 +4,24 @@ import path from 'path';
 
 import { type IosInstance } from '@limrun/api/resources/ios-instances';
 
+interface ConfigTestContext {
+  homeDir: string;
+  configFile: string;
+  /** Switch the active directory scope for subsequent config calls. */
+  setScope: (key: string) => void;
+}
+
+const DEFAULT_TEST_SCOPE = '/limrun-test-scope-default';
+// Must match GLOBAL_SCOPE_KEY in packages/cli/src/lib/scope.ts.
+const GLOBAL_SCOPE_KEY = '__global__';
+
 async function withConfigModule<T>(
-  fn: (config: typeof import('../packages/cli/src/lib/config')) => T,
+  fn: (config: typeof import('../packages/cli/src/lib/config'), ctx: ConfigTestContext) => T,
 ): Promise<T> {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-cli-config-test-'));
   const homedir = () => homeDir;
+  const previousScope = process.env['LIM_INSTANCE_SCOPE'];
+  process.env['LIM_INSTANCE_SCOPE'] = DEFAULT_TEST_SCOPE;
   jest.resetModules();
   jest.doMock('os', () => {
     const actual = jest.requireActual<typeof import('os')>('os');
@@ -17,12 +30,29 @@ async function withConfigModule<T>(
 
   try {
     const config = await import('../packages/cli/src/lib/config');
-    return fn(config);
+    const ctx: ConfigTestContext = {
+      homeDir,
+      configFile: path.join(homeDir, '.lim', 'last-instances.json'),
+      setScope: (key: string) => {
+        process.env['LIM_INSTANCE_SCOPE'] = key;
+      },
+    };
+    return fn(config, ctx);
   } finally {
+    if (previousScope === undefined) {
+      delete process.env['LIM_INSTANCE_SCOPE'];
+    } else {
+      process.env['LIM_INSTANCE_SCOPE'] = previousScope;
+    }
     jest.dontMock('os');
     jest.resetModules();
     fs.rmSync(homeDir, { recursive: true, force: true });
   }
+}
+
+function iosInstanceWithId(id: string): IosInstance {
+  const base = iosInstanceWithXcodeUrl();
+  return { ...base, metadata: { ...base.metadata, id } };
 }
 
 function iosInstanceWithXcodeUrl(url?: string): IosInstance {
@@ -118,6 +148,115 @@ describe('CLI last instance config', () => {
         id: 'ios_euna_01test',
         type: 'ios',
       });
+    });
+  });
+
+  test('isolates the last instance per directory scope', async () => {
+    await withConfigModule((config, ctx) => {
+      ctx.setScope('/work/worktree-a');
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01aaaa'));
+
+      ctx.setScope('/work/worktree-b');
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01bbbb'));
+
+      ctx.setScope('/work/worktree-a');
+      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01aaaa' });
+
+      ctx.setScope('/work/worktree-b');
+      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01bbbb' });
+
+      ctx.setScope('/work/worktree-c');
+      expect(config.loadLastIosInstance()).toBeNull();
+    });
+  });
+
+  test('does not leak the last instance across unrelated directory scopes', async () => {
+    await withConfigModule((config, ctx) => {
+      ctx.setScope('/work/worktree-a');
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01aaaa'));
+
+      ctx.setScope('/work/worktree-b');
+      expect(config.loadLastIosInstance()).toBeNull();
+    });
+  });
+
+  test('clearLastInstanceId removes the instance from every scope', async () => {
+    await withConfigModule((config, ctx) => {
+      ctx.setScope('/work/worktree-a');
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01shared'));
+      ctx.setScope('/work/worktree-b');
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01shared'));
+
+      config.clearLastInstanceId('ios_euna_01shared');
+
+      ctx.setScope('/work/worktree-a');
+      expect(config.loadLastIosInstance()).toBeNull();
+      ctx.setScope('/work/worktree-b');
+      expect(config.loadLastIosInstance()).toBeNull();
+    });
+  });
+
+  test('by-id cache lookups resolve across scopes', async () => {
+    await withConfigModule((config, ctx) => {
+      ctx.setScope('/work/worktree-a');
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01aaaa'));
+
+      // From a different scope, an explicit --id should still find the cached record.
+      ctx.setScope('/work/worktree-b');
+      expect(config.loadIosInstanceCache('ios_euna_01aaaa')).toMatchObject({
+        id: 'ios_euna_01aaaa',
+        type: 'ios',
+        apiUrl: 'https://ios.example.test',
+        token: 'lim_ios_token',
+      });
+    });
+  });
+
+  test('migrates a legacy flat file onto the global scope, not worktrees', async () => {
+    await withConfigModule((config, ctx) => {
+      fs.mkdirSync(path.dirname(ctx.configFile), { recursive: true });
+      fs.writeFileSync(
+        ctx.configFile,
+        JSON.stringify({
+          ios: { id: 'ios_euna_01legacy', type: 'ios', apiUrl: 'https://ios.example.test' },
+        }),
+      );
+
+      // A worktree must NOT inherit the legacy/global instance.
+      ctx.setScope('/work/worktree-a');
+      expect(config.loadLastIosInstance()).toBeNull();
+
+      // The global (non-worktree) context reads the legacy instance out of the box.
+      ctx.setScope(GLOBAL_SCOPE_KEY);
+      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01legacy' });
+
+      // A write rewrites the file in the new shape with legacy data under the global key.
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01new'));
+      const persisted = JSON.parse(fs.readFileSync(ctx.configFile, 'utf-8'));
+      expect(persisted.version).toBe(2);
+      expect(persisted.ios).toBeUndefined();
+      expect(persisted.scopes[GLOBAL_SCOPE_KEY].ios).toMatchObject({ id: 'ios_euna_01new' });
+    });
+  });
+
+  test('shares the global scope across non-worktree contexts but isolates worktrees', async () => {
+    await withConfigModule((config, ctx) => {
+      ctx.setScope(GLOBAL_SCOPE_KEY);
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01global'));
+
+      // Any other non-worktree context resolves the same global instance.
+      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01global' });
+
+      // A worktree does not see the global instance.
+      ctx.setScope('/work/worktree-a');
+      expect(config.loadLastIosInstance()).toBeNull();
+
+      // The worktree gets its own, independent of global.
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01wt'));
+      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01wt' });
+
+      ctx.setScope(GLOBAL_SCOPE_KEY);
+      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01global' });
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how every command resolves the default instance and migrates on-disk CLI state; behavior is designed to preserve global defaults but wrong scope detection could surprise users switching worktrees.
> 
> **Overview**
> **Scopes the CLI “most recent instance” cache** so parallel agents (e.g. per git worktree) do not stomp each other’s default target when commands omit `--id`.
> 
> Adds `scope` resolution: global `--scope` / `LIM_INSTANCE_SCOPE` override, else **linked git worktree root**, else a shared **`__global__`** slot (main checkout behavior unchanged). `BaseCommand` wires the flag and improves missing-instance errors with `describeScope()`.
> 
> **Reworks `~/.lim/last-instances.json`** to schema v2 (`scopes` map per scope key) with legacy flat files read as global-only, file locking + atomic writes, LRU/TTL pruning, scope-local “last used” writes, cross-scope cache lookup by instance id, and global cleanup on `clearLastInstanceId`. Bumps `lim` to **0.14.4** and adds config tests for isolation, migration, and global vs worktree semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1689f109ae21e392560a5aa65da144a2480491af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->