### PR TITLE
cli: scope most-recent instance per workspace 

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lim",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@limrun/api": "^0.31.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -16,7 +16,7 @@ import {
   type LastXcodeInstance,
 } from './lib/config';
 import { login } from './lib/auth';
-import { describeScope, setScopeOverride } from './lib/scope';
+import { getScopeKey, isGlobalScopeKey, setScopeOverride } from './lib/scope';
 import { renderTable } from './lib/formatting';
 import { stopDaemon } from './lib/daemon';
 import { detectInstanceType } from './lib/instance-client-factory';
@@ -48,10 +48,10 @@ export abstract class BaseCommand extends Command {
       default: true,
       allowNo: true,
     }),
-    scope: Flags.string({
+    workspace: Flags.string({
       description:
-        'Scope used to resolve the most recent instance when no ID is given. Inside a git worktree the scope is that worktree (so parallel agents stay isolated); elsewhere a shared default is used. Pass an explicit value (or set LIM_INSTANCE_SCOPE) to isolate agents that run in separate clones rather than worktrees.',
-      env: 'LIM_INSTANCE_SCOPE',
+        'Workspace used to resolve the most recent instance when no ID is given. Defaults to the current git repo/worktree (or a `lim set-workspace-dir` assignment), so parallel agents in separate worktrees stay isolated automatically. Can also be set via LIM_WORKSPACE.',
+      env: 'LIM_WORKSPACE',
     }),
   };
 
@@ -92,9 +92,9 @@ export abstract class BaseCommand extends Command {
 
   protected setParsedFlags(flags: Record<string, unknown>): void {
     this._parsedFlags = flags;
-    const scope = flags['scope'];
-    if (typeof scope === 'string' && scope.trim()) {
-      setScopeOverride(scope.trim());
+    const workspace = flags['workspace'];
+    if (typeof workspace === 'string' && workspace.trim()) {
+      setScopeOverride(workspace.trim());
     }
   }
 
@@ -108,6 +108,12 @@ export abstract class BaseCommand extends Command {
 
   protected shouldSuppressInfo(): boolean {
     return this.isJsonEnabled() || this.isQuietEnabled();
+  }
+
+  /** ` in this workspace (<key>)`, or empty when resolved to the shared global slot. */
+  private scopeSuffix(): string {
+    const key = getScopeKey();
+    return isGlobalScopeKey(key) ? '' : ` in this workspace (${key})`;
   }
 
   protected info(message = ''): void {
@@ -279,7 +285,7 @@ export abstract class BaseCommand extends Command {
     }
 
     throw new Error(
-      `No instance ID provided and no recent android instance for ${describeScope()}.\n` +
+      `No instance ID provided and no recent android instance found${this.scopeSuffix()}.\n` +
         'Provide an instance ID or create one first with: lim android create',
     );
   }
@@ -300,7 +306,7 @@ export abstract class BaseCommand extends Command {
     }
 
     throw new Error(
-      `No instance ID provided and no recent ios instance for ${describeScope()}.\n` +
+      `No instance ID provided and no recent ios instance found${this.scopeSuffix()}.\n` +
         'Provide an instance ID or create one first with: lim ios create',
     );
   }
@@ -332,7 +338,7 @@ export abstract class BaseCommand extends Command {
     }
 
     throw new Error(
-      `No instance ID provided and no recent ios or android instance for ${describeScope()}.\n` +
+      `No instance ID provided and no recent ios or android instance found${this.scopeSuffix()}.\n` +
         'Provide an instance ID or create one first with: lim ios create or lim android create',
     );
   }
@@ -358,7 +364,7 @@ export abstract class BaseCommand extends Command {
 
     const noun = parts[0] ?? 'xcode';
     throw new Error(
-      `No instance ID provided and no recent ${noun} instance for ${describeScope()}.\n` +
+      `No instance ID provided and no recent ${noun} instance found${this.scopeSuffix()}.\n` +
         `Provide an instance ID or create one first with: lim ${noun} create`,
     );
   }

--- a/packages/cli/src/commands/set-workspace-dir.ts
+++ b/packages/cli/src/commands/set-workspace-dir.ts
@@ -1,0 +1,63 @@
+import path from 'path';
+import { Args, Command, Flags } from '@oclif/core';
+import { assignWorkspaceDir, normalizeDir, unassignWorkspaceDir } from '../lib/workspace';
+
+export default class SetWorkspaceDir extends Command {
+  static summary = 'Assign a directory to an isolated lim workspace.';
+  static description = `Bind a directory to a named workspace so that 'lim' commands run from it (and its subdirectories) share one set of "most recent" instances — even when the directory is not a git repo or worktree.
+
+Inside a git repo, lim already isolates by the repo/worktree root automatically. Use this to give a plain directory its own isolated workspace, or to deliberately share one workspace across directories by assigning them the same name.
+
+The assignment governs the directory and everything beneath it, except a nested git worktree or clone whose root is deeper than the assignment, which keeps its own isolated workspace (the most specific boundary wins).`;
+
+  static examples = [
+    '<%= config.bin %> set-workspace-dir my-agent',
+    '<%= config.bin %> set-workspace-dir shared-pool --dir ./service-a',
+    '<%= config.bin %> set-workspace-dir --clear',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Workspace name to assign. Directories sharing a name share one workspace.',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    dir: Flags.string({
+      description: 'Directory to assign (defaults to the current directory).',
+    }),
+    clear: Flags.boolean({
+      description: 'Remove the workspace assignment for the directory instead of setting it.',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(SetWorkspaceDir);
+    const dir = flags.dir ? path.resolve(flags.dir) : process.cwd();
+    const normalized = normalizeDir(dir);
+
+    if (flags.clear) {
+      const removed = unassignWorkspaceDir(dir);
+      this.log(
+        removed ?
+          `Removed workspace assignment for ${normalized}.`
+        : `No workspace assignment found for ${normalized}.`,
+      );
+      return;
+    }
+
+    const name = args.name?.trim();
+    if (!name) {
+      this.error('Provide a workspace name, or pass --clear to remove an existing assignment.');
+    }
+    if (name.startsWith('__lim_')) {
+      this.error('Workspace names starting with "__lim_" are reserved for internal use.');
+    }
+
+    assignWorkspaceDir(dir, name);
+    this.log(`Assigned ${normalized} to workspace "${name}".`);
+    this.log(`lim commands run from here (and its subdirectories) now share the "${name}" workspace.`);
+  }
+}

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -85,6 +85,8 @@ const LAST_INSTANCE_LOCK = `${LAST_INSTANCE_FILE}.lock`;
 const SCHEMA_VERSION = 2;
 /** Reserved scope key holding pre-scoping (legacy flat-file) data until the next write migrates it. */
 const LEGACY_SCOPE_KEY = '__lim_legacy__';
+/** Pre-rename key for the shared non-repo slot; remapped to GLOBAL_SCOPE_KEY on read. */
+const LEGACY_GLOBAL_SCOPE_KEY = '__global__';
 /** Cap on how many directory scopes we retain; least-recently-used are pruned beyond this. */
 const MAX_SCOPES = 200;
 /** Drop scopes untouched for this long so abandoned worktrees don't accumulate. */
@@ -172,10 +174,24 @@ function scopeHasInstance(scope: ScopeInstances): boolean {
   return Boolean(scope.ios || scope.android || scope.xcode);
 }
 
+/** Copy any slots missing from `primary` out of `fallback`. */
+function fillMissingScope(primary: ScopeInstances, fallback: ScopeInstances): ScopeInstances {
+  const out: ScopeInstances = { ...primary };
+  if (!out.ios && fallback.ios) out.ios = fallback.ios;
+  if (!out.android && fallback.android) out.android = fallback.android;
+  if (!out.xcode && fallback.xcode) out.xcode = fallback.xcode;
+  if (!out.lastUsedAt && fallback.lastUsedAt) out.lastUsedAt = fallback.lastUsedAt;
+  return out;
+}
+
 /**
- * Parse the on-disk file into the current scoped schema. A legacy flat file
- * (`{ios,android,xcode}` with no `scopes`) is surfaced under LEGACY_SCOPE_KEY so
- * reads keep working out of the box; the next write folds it into the active scope.
+ * Parse the on-disk file into the current scoped schema. Two migrations happen
+ * here so upgrades keep resolving instances without recreating them:
+ *   - a legacy flat file (`{ios,android,xcode}` with no `scopes`) is surfaced
+ *     under LEGACY_SCOPE_KEY (folded into the active scope on the next write), and
+ *   - the pre-rename global slot key (`__global__`) is remapped onto the current
+ *     GLOBAL_SCOPE_KEY (the current key wins for any overlapping slots).
+ * Both are persisted on the next write.
  */
 function readNormalizedFile(): LastInstancesFile {
   const parsed = readParsedLastInstances();
@@ -183,8 +199,17 @@ function readNormalizedFile(): LastInstancesFile {
   if (!isRecord(parsed)) return file;
 
   if (typeof parsed['version'] === 'number' && isRecord(parsed['scopes'])) {
+    let legacyGlobal: ScopeInstances | undefined;
     for (const [key, value] of Object.entries(parsed['scopes'])) {
+      if (key === LEGACY_GLOBAL_SCOPE_KEY) {
+        legacyGlobal = sanitizeScope(value);
+        continue;
+      }
       file.scopes[key] = sanitizeScope(value);
+    }
+    if (legacyGlobal && scopeHasInstance(legacyGlobal)) {
+      const current = file.scopes[GLOBAL_SCOPE_KEY];
+      file.scopes[GLOBAL_SCOPE_KEY] = current ? fillMissingScope(current, legacyGlobal) : legacyGlobal;
     }
     return file;
   }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -83,6 +83,8 @@ export function clearApiKey(): void {
 const LAST_INSTANCE_FILE = path.join(CONFIG_DIR, 'last-instances.json');
 const LAST_INSTANCE_LOCK = `${LAST_INSTANCE_FILE}.lock`;
 const SCHEMA_VERSION = 2;
+/** Reserved scope key holding pre-scoping (legacy flat-file) data until the next write migrates it. */
+const LEGACY_SCOPE_KEY = '__lim_legacy__';
 /** Cap on how many directory scopes we retain; least-recently-used are pruned beyond this. */
 const MAX_SCOPES = 200;
 /** Drop scopes untouched for this long so abandoned worktrees don't accumulate. */
@@ -172,10 +174,8 @@ function scopeHasInstance(scope: ScopeInstances): boolean {
 
 /**
  * Parse the on-disk file into the current scoped schema. A legacy flat file
- * (`{ios,android,xcode}` with no `scopes`) is mapped onto the GLOBAL scope,
- * since pre-scoping data was a single shared "most recent instance" — exactly
- * what the global (non-worktree) slot represents. It is persisted in the new
- * shape on the next write; reads work out of the box in the meantime.
+ * (`{ios,android,xcode}` with no `scopes`) is surfaced under LEGACY_SCOPE_KEY so
+ * reads keep working out of the box; the next write folds it into the active scope.
  */
 function readNormalizedFile(): LastInstancesFile {
   const parsed = readParsedLastInstances();
@@ -191,13 +191,13 @@ function readNormalizedFile(): LastInstancesFile {
 
   const legacy = sanitizeScope(parsed);
   if (scopeHasInstance(legacy)) {
-    file.scopes[GLOBAL_SCOPE_KEY] = legacy;
+    file.scopes[LEGACY_SCOPE_KEY] = legacy;
   }
   return file;
 }
 
 function getScopeData(file: LastInstancesFile, scopeKey: string): ScopeInstances {
-  return file.scopes[scopeKey] ?? {};
+  return file.scopes[scopeKey] ?? file.scopes[LEGACY_SCOPE_KEY] ?? {};
 }
 
 function readScope(scopeKey: string): ScopeInstances {
@@ -213,29 +213,48 @@ function ensureScope(file: LastInstancesFile, scopeKey: string): ScopeInstances 
   return scope;
 }
 
+/** Fold legacy flat-file data into the active scope (only slots not already set), once. */
+function foldLegacyInto(file: LastInstancesFile, scopeKey: string): boolean {
+  const legacy = file.scopes[LEGACY_SCOPE_KEY];
+  if (!legacy) return false;
+  delete file.scopes[LEGACY_SCOPE_KEY];
+  const scope = ensureScope(file, scopeKey);
+  if (!scope.android && legacy.android) scope.android = legacy.android;
+  if (!scope.ios && legacy.ios) scope.ios = legacy.ios;
+  if (!scope.xcode && legacy.xcode) scope.xcode = legacy.xcode;
+  if (!scope.lastUsedAt) scope.lastUsedAt = legacy.lastUsedAt ?? new Date().toISOString();
+  return true;
+}
+
 function scopeTimestamp(scope: ScopeInstances): number {
   const ts = scope.lastUsedAt ? Date.parse(scope.lastUsedAt) : NaN;
   return Number.isNaN(ts) ? 0 : ts;
 }
 
 /**
- * Drop empty scopes, TTL-expired worktree scopes, and the least-recently-used
- * beyond the cap. The GLOBAL scope is exempt from TTL/LRU eviction (it is the
- * shared default slot), but is still removed once it holds no instances.
+ * Drop empty scopes, TTL-expired scopes, and the least-recently-used beyond the
+ * cap. The global (non-repo) slot is exempt from TTL/LRU pruning so the "use my
+ * most recent instance" fallback persists like the old single-slot behavior; it
+ * is still removed once empty.
  */
 function pruneScopes(file: LastInstancesFile): boolean {
   let changed = false;
   const now = Date.now();
   for (const key of Object.keys(file.scopes)) {
+    if (key === LEGACY_SCOPE_KEY) continue;
     const scope = file.scopes[key]!;
-    const isGlobal = key === GLOBAL_SCOPE_KEY;
-    const expired = !isGlobal && scope.lastUsedAt ? now - scopeTimestamp(scope) > SCOPE_TTL_MS : false;
-    if (!scopeHasInstance(scope) || expired) {
+    if (!scopeHasInstance(scope)) {
+      delete file.scopes[key];
+      changed = true;
+      continue;
+    }
+    if (key === GLOBAL_SCOPE_KEY) continue;
+    if (scope.lastUsedAt && now - scopeTimestamp(scope) > SCOPE_TTL_MS) {
       delete file.scopes[key];
       changed = true;
     }
   }
-  const keys = Object.keys(file.scopes).filter((k) => k !== GLOBAL_SCOPE_KEY);
+  const keys = Object.keys(file.scopes).filter((k) => k !== LEGACY_SCOPE_KEY && k !== GLOBAL_SCOPE_KEY);
   if (keys.length > MAX_SCOPES) {
     keys
       .sort((a, b) => scopeTimestamp(file.scopes[a]!) - scopeTimestamp(file.scopes[b]!))
@@ -313,8 +332,7 @@ function releaseLock(fd: number | null): void {
  * Serialized, atomic read-modify-write of the last-instances file. The mutator
  * receives the parsed file plus the active scope key; returning `false` signals
  * no change so we can skip the write (and avoid needless lock churn for parallel
- * agents). A legacy flat file is normalized onto the GLOBAL scope on read, so it
- * is rewritten in the new shape whenever any mutation persists.
+ * agents). Legacy data is migrated into the active scope before the mutator runs.
  */
 function mutate(fn: (file: LastInstancesFile, scopeKey: string) => boolean | void): void {
   ensureConfigDir();
@@ -322,7 +340,7 @@ function mutate(fn: (file: LastInstancesFile, scopeKey: string) => boolean | voi
   try {
     const file = readNormalizedFile();
     const scopeKey = getScopeKey();
-    let changed = false;
+    let changed = foldLegacyInto(file, scopeKey);
     if (fn(file, scopeKey) !== false) changed = true;
     if (pruneScopes(file)) changed = true;
     if (changed) atomicWriteFile(file);

--- a/packages/cli/src/lib/scope.ts
+++ b/packages/cli/src/lib/scope.ts
@@ -1,37 +1,46 @@
 import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
+import { lookupWorkspaceMatch } from './workspace';
 
 /**
- * A "scope" isolates the most-recently-used instance per context so parallel AI
- * agents can each drive their own instance instead of sharing one global slot.
+ * A "scope" (surfaced to users as a "workspace") isolates the most-recently-used
+ * instance per directory so that separate git worktrees / clones (and the
+ * parallel AI agents working in them) each get their own last-instance binding
+ * instead of all sharing one slot.
  *
- * Hybrid model:
- *   - Inside a *linked* git worktree (one created via `git worktree add`), the
- *     scope is that worktree's root, so each worktree gets its own instance.
- *   - Everywhere else (a repo's main checkout, a plain directory, or outside a
- *     repo) the scope is a single shared GLOBAL slot, preserving the original
- *     "use the most recent instance I created" behavior with zero setup.
+ * Resolution order (first match wins), memoized for the lifetime of the process:
+ *   1. an explicit in-process override set from the global `--workspace` flag,
+ *   2. the LIM_WORKSPACE environment variable,
+ *   3. the most specific of: a `lim set-workspace-dir` assignment (cwd or an
+ *      ancestor) and the current git repo/worktree root,
+ *   4. GLOBAL_SCOPE_KEY when neither applies.
  *
- * Resolution order (first match wins), memoized for the process lifetime:
- *   1. an explicit in-process override set from the global `--scope` flag,
- *   2. the LIM_INSTANCE_SCOPE environment variable,
- *   3. the current linked-worktree root, if any,
- *   4. the GLOBAL scope.
- *
- * Steps 3 and 4 require no setup. An explicit override (1/2) always wins, which
- * is the escape hatch for isolating agents that run in separate clones rather
- * than worktrees.
+ * These require zero setup. Any command run inside a git repo (a clone or a
+ * linked worktree) resolves to that root and is isolated from every other
+ * checkout. A `set-workspace-dir` assignment governs its directory and
+ * everything beneath it, EXCEPT a nested git worktree/clone whose root is deeper
+ * than the assignment keeps its own isolation (most-specific boundary wins).
+ * Anything else shares a single global slot, preserving the convenient "use my
+ * most recent instance anywhere" behavior for casual, non-repo usage.
  */
 
-/** Sentinel scope key for the shared, non-worktree "most recent instance" slot. */
-export const GLOBAL_SCOPE_KEY = '__global__';
+/**
+ * Shared scope used for invocations that are not inside any git repo. It is a
+ * non-path sentinel so it can never collide with a real directory scope key.
+ */
+export const GLOBAL_SCOPE_KEY = '__lim_global__';
+
+/** Whether a resolved scope key is the shared non-repo global slot. */
+export function isGlobalScopeKey(key: string): boolean {
+  return key === GLOBAL_SCOPE_KEY;
+}
 
 let override: string | undefined;
 let cachedDefault: string | undefined;
 
 /**
- * Override the scope key for this process (used by the global `--scope` flag).
+ * Override the scope key for this process (used by the global `--workspace` flag).
  * Passing an empty/undefined value clears the override.
  */
 export function setScopeOverride(key: string | undefined): void {
@@ -39,28 +48,17 @@ export function setScopeOverride(key: string | undefined): void {
   override = trimmed ? normalizeScopeKey(trimmed, true) : undefined;
 }
 
-/** Resolve the active scope key. Memoizes only the worktree/global fallback. */
+/** Resolve the active scope key. Memoizes only the assignment/git/global fallback. */
 export function getScopeKey(): string {
   if (override) return override;
 
-  const env = process.env['LIM_INSTANCE_SCOPE']?.trim();
+  const env = process.env['LIM_WORKSPACE']?.trim();
   if (env) return normalizeScopeKey(env, true);
 
   if (cachedDefault === undefined) {
     cachedDefault = computeDefaultScopeKey();
   }
   return cachedDefault;
-}
-
-/** True when the active scope is the shared global (non-worktree) slot. */
-export function isGlobalScope(): boolean {
-  return getScopeKey() === GLOBAL_SCOPE_KEY;
-}
-
-/** Human-readable description of the active scope, for messages. */
-export function describeScope(): string {
-  const key = getScopeKey();
-  return key === GLOBAL_SCOPE_KEY ? 'the default (non-worktree) context' : `this directory (${key})`;
 }
 
 /** Reset memoized state. Intended for tests only. */
@@ -70,29 +68,39 @@ export function resetScopeCacheForTests(): void {
 }
 
 function computeDefaultScopeKey(): string {
-  const worktreeRoot = linkedWorktreeRoot();
-  return worktreeRoot ? normalizeScopeKey(worktreeRoot, false) : GLOBAL_SCOPE_KEY;
+  const cwd = process.cwd();
+  const match = lookupWorkspaceMatch(cwd);
+  const top = gitWorktreeRoot();
+  const gitRoot = top ? normalizeScopeKey(top, false) : undefined;
+
+  if (match && gitRoot) {
+    // Both boundaries cover the cwd. The more specific (deeper) one wins, so a
+    // nested git worktree/clone keeps its own isolation even under a broad
+    // parent assignment, while an assignment at or below the git root still
+    // overrides git auto-detection.
+    return isStrictDescendant(gitRoot, match.dir) ? gitRoot : match.name;
+  }
+  if (match) return match.name;
+  if (gitRoot) return gitRoot;
+  // Outside any repo and with no assignment, share the global slot.
+  return GLOBAL_SCOPE_KEY;
 }
 
-/**
- * Return the toplevel of the current *linked* worktree, or undefined when we are
- * in a repo's main checkout or not in a git repo at all. A linked worktree is
- * detected by its per-worktree git dir differing from the shared common git dir.
- */
-function linkedWorktreeRoot(): string | undefined {
+/** Whether `child` is a strict subdirectory of `parent` (both normalized absolute paths). */
+function isStrictDescendant(child: string, parent: string): boolean {
+  if (child === parent) return false;
+  const base = parent.endsWith(path.sep) ? parent : parent + path.sep;
+  return child.startsWith(base);
+}
+
+function gitWorktreeRoot(): string | undefined {
   try {
-    const out = execFileSync('git', ['rev-parse', '--git-dir', '--git-common-dir', '--show-toplevel'], {
+    const out = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: process.cwd(),
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8',
     }).trim();
-    const [gitDir, commonDir, topLevel] = out.split('\n').map((line) => line.trim());
-    if (!gitDir || !commonDir || !topLevel) return undefined;
-    const cwd = process.cwd();
-    if (path.resolve(cwd, gitDir) === path.resolve(cwd, commonDir)) {
-      return undefined; // main checkout
-    }
-    return topLevel;
+    return out || undefined;
   } catch {
     return undefined;
   }
@@ -101,8 +109,8 @@ function linkedWorktreeRoot(): string | undefined {
 /**
  * Normalize a scope key. Real filesystem paths are canonicalized through
  * `realpath` so symlinks and sibling worktrees resolve to stable, distinct
- * keys. Explicit overrides that are not real paths (e.g. an arbitrary label or
- * the GLOBAL sentinel) are kept verbatim so they stay stable regardless of cwd.
+ * keys. Explicit overrides that are not real paths (e.g. an arbitrary label)
+ * are kept verbatim so they stay stable regardless of the working directory.
  */
 function normalizeScopeKey(input: string, allowLiteral: boolean): string {
   try {

--- a/packages/cli/src/lib/workspace.ts
+++ b/packages/cli/src/lib/workspace.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Persistent "directory -> workspace name" assignments created by
+ * `lim set-workspace-dir`. This lets a plain directory (one that is not a git
+ * repo or worktree) opt into an isolated workspace, or lets several directories
+ * deliberately share one workspace by assigning them the same name.
+ *
+ * Kept in its own module (no dependency on config.ts) so scope.ts can consult it
+ * during scope resolution without creating an import cycle.
+ */
+
+const CONFIG_DIR = path.join(os.homedir(), '.lim');
+const WORKSPACE_DIRS_FILE = path.join(CONFIG_DIR, 'workspace-dirs.json');
+const SCHEMA_VERSION = 1;
+
+interface WorkspaceDirsFile {
+  version: number;
+  /** Map of normalized absolute directory path -> workspace name. */
+  dirs: Record<string, string>;
+}
+
+function ensureConfigDir(): void {
+  if (!fs.existsSync(CONFIG_DIR)) {
+    fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+}
+
+function readFileRaw(): WorkspaceDirsFile {
+  if (!fs.existsSync(WORKSPACE_DIRS_FILE)) return { version: SCHEMA_VERSION, dirs: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(WORKSPACE_DIRS_FILE, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && parsed.dirs && typeof parsed.dirs === 'object') {
+      const dirs: Record<string, string> = {};
+      for (const [key, value] of Object.entries(parsed.dirs as Record<string, unknown>)) {
+        if (typeof value === 'string') dirs[key] = value;
+      }
+      return { version: SCHEMA_VERSION, dirs };
+    }
+  } catch {
+    // Corrupt file; treat as empty.
+  }
+  return { version: SCHEMA_VERSION, dirs: {} };
+}
+
+function writeFileAtomic(file: WorkspaceDirsFile): void {
+  ensureConfigDir();
+  const tmp = `${WORKSPACE_DIRS_FILE}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(file, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, WORKSPACE_DIRS_FILE);
+}
+
+/** Canonicalize a directory path (realpath when it exists, else resolve). */
+export function normalizeDir(dir: string): string {
+  try {
+    return fs.realpathSync.native(dir);
+  } catch {
+    return path.resolve(dir);
+  }
+}
+
+/** Bind a directory to a workspace name. */
+export function assignWorkspaceDir(dir: string, name: string): void {
+  const file = readFileRaw();
+  file.dirs[normalizeDir(dir)] = name;
+  writeFileAtomic(file);
+}
+
+/** Remove a directory's workspace binding. Returns whether anything was removed. */
+export function unassignWorkspaceDir(dir: string): boolean {
+  const file = readFileRaw();
+  const key = normalizeDir(dir);
+  if (!(key in file.dirs)) return false;
+  delete file.dirs[key];
+  writeFileAtomic(file);
+  return true;
+}
+
+/** A directory's nearest workspace assignment: the directory that holds it and the name. */
+export interface WorkspaceMatch {
+  /** Normalized directory the assignment is attached to (cwd or an ancestor). */
+  dir: string;
+  /** Assigned workspace name. */
+  name: string;
+}
+
+/**
+ * Resolve the nearest workspace assignment for `dir`, walking up parent
+ * directories so a subdirectory inherits its closest ancestor's assignment
+ * (mirroring how a git worktree root applies to everything beneath it). Returns
+ * both the matched directory and name so callers can reason about specificity.
+ */
+export function lookupWorkspaceMatch(dir: string): WorkspaceMatch | undefined {
+  const file = readFileRaw();
+  if (Object.keys(file.dirs).length === 0) return undefined;
+  let current = normalizeDir(dir);
+  for (;;) {
+    const name = file.dirs[current];
+    if (name) return { dir: current, name };
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/** Convenience wrapper returning only the workspace name. */
+export function lookupWorkspaceForDir(dir: string): string | undefined {
+  return lookupWorkspaceMatch(dir)?.name;
+}
+
+/** All directory -> workspace assignments. */
+export function listWorkspaceDirs(): Record<string, string> {
+  return readFileRaw().dirs;
+}

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 
 import { type IosInstance } from '@limrun/api/resources/ios-instances';
+import { GLOBAL_SCOPE_KEY } from '../packages/cli/src/lib/scope';
 
 interface ConfigTestContext {
   homeDir: string;
@@ -12,16 +13,14 @@ interface ConfigTestContext {
 }
 
 const DEFAULT_TEST_SCOPE = '/limrun-test-scope-default';
-// Must match GLOBAL_SCOPE_KEY in packages/cli/src/lib/scope.ts.
-const GLOBAL_SCOPE_KEY = '__global__';
 
 async function withConfigModule<T>(
   fn: (config: typeof import('../packages/cli/src/lib/config'), ctx: ConfigTestContext) => T,
 ): Promise<T> {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-cli-config-test-'));
   const homedir = () => homeDir;
-  const previousScope = process.env['LIM_INSTANCE_SCOPE'];
-  process.env['LIM_INSTANCE_SCOPE'] = DEFAULT_TEST_SCOPE;
+  const previousScope = process.env['LIM_WORKSPACE'];
+  process.env['LIM_WORKSPACE'] = DEFAULT_TEST_SCOPE;
   jest.resetModules();
   jest.doMock('os', () => {
     const actual = jest.requireActual<typeof import('os')>('os');
@@ -34,15 +33,15 @@ async function withConfigModule<T>(
       homeDir,
       configFile: path.join(homeDir, '.lim', 'last-instances.json'),
       setScope: (key: string) => {
-        process.env['LIM_INSTANCE_SCOPE'] = key;
+        process.env['LIM_WORKSPACE'] = key;
       },
     };
     return fn(config, ctx);
   } finally {
     if (previousScope === undefined) {
-      delete process.env['LIM_INSTANCE_SCOPE'];
+      delete process.env['LIM_WORKSPACE'];
     } else {
-      process.env['LIM_INSTANCE_SCOPE'] = previousScope;
+      process.env['LIM_WORKSPACE'] = previousScope;
     }
     jest.dontMock('os');
     jest.resetModules();
@@ -212,7 +211,7 @@ describe('CLI last instance config', () => {
     });
   });
 
-  test('migrates a legacy flat file onto the global scope, not worktrees', async () => {
+  test('migrates a legacy flat last-instances file into the active scope', async () => {
     await withConfigModule((config, ctx) => {
       fs.mkdirSync(path.dirname(ctx.configFile), { recursive: true });
       fs.writeFileSync(
@@ -222,41 +221,56 @@ describe('CLI last instance config', () => {
         }),
       );
 
-      // A worktree must NOT inherit the legacy/global instance.
-      ctx.setScope('/work/worktree-a');
-      expect(config.loadLastIosInstance()).toBeNull();
-
-      // The global (non-worktree) context reads the legacy instance out of the box.
-      ctx.setScope(GLOBAL_SCOPE_KEY);
+      ctx.setScope('/work/first-dir');
+      // Reads bridge the legacy data so it is usable out of the box.
       expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01legacy' });
 
-      // A write rewrites the file in the new shape with legacy data under the global key.
+      // A write migrates the legacy data into the active scope and rewrites the file.
       config.registerCreatedInstance(iosInstanceWithId('ios_euna_01new'));
+
       const persisted = JSON.parse(fs.readFileSync(ctx.configFile, 'utf-8'));
       expect(persisted.version).toBe(2);
       expect(persisted.ios).toBeUndefined();
-      expect(persisted.scopes[GLOBAL_SCOPE_KEY].ios).toMatchObject({ id: 'ios_euna_01new' });
+      expect(persisted.scopes['/work/first-dir'].ios).toMatchObject({ id: 'ios_euna_01new' });
+
+      // The legacy bridge no longer applies to other scopes once migrated.
+      ctx.setScope('/work/other-dir');
+      expect(config.loadLastIosInstance()).toBeNull();
     });
   });
 
-  test('shares the global scope across non-worktree contexts but isolates worktrees', async () => {
+  test('keeps the global (non-repo) slot but prunes stale directory scopes', async () => {
     await withConfigModule((config, ctx) => {
-      ctx.setScope(GLOBAL_SCOPE_KEY);
-      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01global'));
+      const stale = new Date('2000-01-01T00:00:00Z').toISOString();
+      fs.mkdirSync(path.dirname(ctx.configFile), { recursive: true });
+      fs.writeFileSync(
+        ctx.configFile,
+        JSON.stringify({
+          version: 2,
+          scopes: {
+            [GLOBAL_SCOPE_KEY]: {
+              lastUsedAt: stale,
+              ios: { id: 'ios_euna_01global', type: 'ios' },
+            },
+            '/work/stale-dir': {
+              lastUsedAt: stale,
+              ios: { id: 'ios_euna_01stale', type: 'ios' },
+            },
+          },
+        }),
+      );
 
-      // Any other non-worktree context resolves the same global instance.
-      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01global' });
+      // Any write triggers pruning.
+      ctx.setScope('/work/fresh-dir');
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01fresh'));
 
-      // A worktree does not see the global instance.
-      ctx.setScope('/work/worktree-a');
-      expect(config.loadLastIosInstance()).toBeNull();
-
-      // The worktree gets its own, independent of global.
-      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01wt'));
-      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01wt' });
-
-      ctx.setScope(GLOBAL_SCOPE_KEY);
-      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01global' });
+      const persisted = JSON.parse(fs.readFileSync(ctx.configFile, 'utf-8'));
+      // Global slot survives despite being long stale.
+      expect(persisted.scopes[GLOBAL_SCOPE_KEY].ios).toMatchObject({ id: 'ios_euna_01global' });
+      // A stale directory scope is pruned.
+      expect(persisted.scopes['/work/stale-dir']).toBeUndefined();
+      // The fresh scope we just wrote is kept.
+      expect(persisted.scopes['/work/fresh-dir'].ios).toMatchObject({ id: 'ios_euna_01fresh' });
     });
   });
 });

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -239,6 +239,33 @@ describe('CLI last instance config', () => {
     });
   });
 
+  test('migrates the pre-rename global slot key (__global__) onto the current global key', async () => {
+    await withConfigModule((config, ctx) => {
+      fs.mkdirSync(path.dirname(ctx.configFile), { recursive: true });
+      fs.writeFileSync(
+        ctx.configFile,
+        JSON.stringify({
+          version: 2,
+          scopes: {
+            __global__: {
+              ios: { id: 'ios_euna_01oldglobal', type: 'ios', apiUrl: 'https://ios.example.test' },
+            },
+          },
+        }),
+      );
+
+      // Resolving the global slot finds the pre-rename data immediately (read-time remap).
+      ctx.setScope(GLOBAL_SCOPE_KEY);
+      expect(config.loadLastIosInstance()).toMatchObject({ id: 'ios_euna_01oldglobal' });
+
+      // A write persists the data under the current key and drops the old one.
+      config.registerCreatedInstance(iosInstanceWithId('ios_euna_01newglobal'));
+      const persisted = JSON.parse(fs.readFileSync(ctx.configFile, 'utf-8'));
+      expect(persisted.scopes.__global__).toBeUndefined();
+      expect(persisted.scopes[GLOBAL_SCOPE_KEY].ios).toMatchObject({ id: 'ios_euna_01newglobal' });
+    });
+  });
+
   test('keeps the global (non-repo) slot but prunes stale directory scopes', async () => {
     await withConfigModule((config, ctx) => {
       const stale = new Date('2000-01-01T00:00:00Z').toISOString();

--- a/tests/cli-scope.test.ts
+++ b/tests/cli-scope.test.ts
@@ -1,0 +1,164 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { GLOBAL_SCOPE_KEY } from '../packages/cli/src/lib/scope';
+
+type ScopeModule = typeof import('../packages/cli/src/lib/scope');
+type WorkspaceModule = typeof import('../packages/cli/src/lib/workspace');
+
+interface ScopeTestContext {
+  scope: ScopeModule;
+  workspace: WorkspaceModule;
+  homeDir: string;
+}
+
+/**
+ * Load fresh copies of scope.ts + workspace.ts with a temp home directory and
+ * `git rev-parse --show-toplevel` stubbed to either return a path or throw
+ * (simulating "not in a git repo"). LIM_WORKSPACE is cleared so the
+ * assignment/git/global fallback is what gets exercised.
+ */
+async function withScopeModule<T>(gitTop: string | null, fn: (ctx: ScopeTestContext) => T): Promise<T> {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-scope-test-'));
+  const homedir = () => homeDir;
+  const previousWorkspace = process.env['LIM_WORKSPACE'];
+  delete process.env['LIM_WORKSPACE'];
+  jest.resetModules();
+  jest.doMock('os', () => {
+    const actual = jest.requireActual<typeof import('os')>('os');
+    return { ...actual, homedir, default: { ...actual, homedir } };
+  });
+  jest.doMock('child_process', () => ({
+    execFileSync: jest.fn(() => {
+      if (gitTop === null) {
+        throw new Error('fatal: not a git repository');
+      }
+      return `${gitTop}\n`;
+    }),
+  }));
+
+  try {
+    const scope = await import('../packages/cli/src/lib/scope');
+    const workspace = await import('../packages/cli/src/lib/workspace');
+    return fn({ scope, workspace, homeDir });
+  } finally {
+    if (previousWorkspace === undefined) {
+      delete process.env['LIM_WORKSPACE'];
+    } else {
+      process.env['LIM_WORKSPACE'] = previousWorkspace;
+    }
+    jest.dontMock('os');
+    jest.dontMock('child_process');
+    jest.resetModules();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+describe('CLI scope resolution', () => {
+  test('shares the global slot when not inside a git repo', async () => {
+    await withScopeModule(null, ({ scope }) => {
+      expect(scope.getScopeKey()).toBe(GLOBAL_SCOPE_KEY);
+      expect(scope.isGlobalScopeKey(scope.getScopeKey())).toBe(true);
+    });
+  });
+
+  test('isolates by the git repo/worktree root when inside a repo', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-scope-repo-'));
+    try {
+      await withScopeModule(dir, ({ scope }) => {
+        expect(scope.getScopeKey()).toBe(fs.realpathSync.native(dir));
+        expect(scope.isGlobalScopeKey(scope.getScopeKey())).toBe(false);
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('LIM_WORKSPACE overrides the assignment/git/global fallback', async () => {
+    await withScopeModule(null, ({ scope }) => {
+      process.env['LIM_WORKSPACE'] = 'my-shared-agent';
+      try {
+        expect(scope.getScopeKey()).toBe('my-shared-agent');
+      } finally {
+        delete process.env['LIM_WORKSPACE'];
+      }
+    });
+  });
+
+  test('setScopeOverride takes precedence over everything', async () => {
+    await withScopeModule(null, ({ scope }) => {
+      process.env['LIM_WORKSPACE'] = 'from-env';
+      scope.setScopeOverride('from-flag');
+      try {
+        expect(scope.getScopeKey()).toBe('from-flag');
+      } finally {
+        scope.setScopeOverride(undefined);
+        delete process.env['LIM_WORKSPACE'];
+      }
+    });
+  });
+
+  test('an assignment at or below the git root overrides git auto-detection', async () => {
+    const cwd = process.cwd();
+    const parent = path.dirname(cwd); // git root is shallower than the assignment
+    await withScopeModule(parent, ({ scope, workspace }) => {
+      workspace.assignWorkspaceDir(cwd, 'leaf-ws');
+      expect(scope.getScopeKey()).toBe('leaf-ws');
+    });
+  });
+
+  test('an unrelated git root does not shadow an assignment at cwd', async () => {
+    await withScopeModule('/some/unrelated/git/repo', ({ scope, workspace }) => {
+      workspace.assignWorkspaceDir(process.cwd(), 'assigned-ws');
+      expect(scope.getScopeKey()).toBe('assigned-ws');
+    });
+  });
+
+  test('a deeper git worktree keeps its own isolation under a broad parent assignment', async () => {
+    const cwd = process.cwd();
+    const grandparent = path.dirname(path.dirname(cwd)); // assignment is shallower than git root
+    await withScopeModule(cwd, ({ scope, workspace }) => {
+      workspace.assignWorkspaceDir(grandparent, 'broad-ws');
+      expect(scope.getScopeKey()).toBe(fs.realpathSync.native(cwd));
+    });
+  });
+
+  test('LIM_WORKSPACE still beats a directory assignment', async () => {
+    await withScopeModule(null, ({ scope, workspace }) => {
+      workspace.assignWorkspaceDir(process.cwd(), 'assigned-ws');
+      process.env['LIM_WORKSPACE'] = 'env-ws';
+      try {
+        expect(scope.getScopeKey()).toBe('env-ws');
+      } finally {
+        delete process.env['LIM_WORKSPACE'];
+      }
+    });
+  });
+});
+
+describe('workspace directory assignments', () => {
+  test('subdirectories inherit an ancestor assignment, and unassign removes it', async () => {
+    await withScopeModule(null, ({ workspace }) => {
+      workspace.assignWorkspaceDir('/projects/service-a', 'service-a');
+
+      expect(workspace.lookupWorkspaceForDir('/projects/service-a')).toBe('service-a');
+      expect(workspace.lookupWorkspaceForDir('/projects/service-a/src/deep')).toBe('service-a');
+      expect(workspace.lookupWorkspaceForDir('/projects/service-b')).toBeUndefined();
+
+      expect(workspace.unassignWorkspaceDir('/projects/service-a')).toBe(true);
+      expect(workspace.lookupWorkspaceForDir('/projects/service-a')).toBeUndefined();
+      expect(workspace.unassignWorkspaceDir('/projects/service-a')).toBe(false);
+    });
+  });
+
+  test('different directories can share one workspace by name', async () => {
+    await withScopeModule(null, ({ workspace }) => {
+      workspace.assignWorkspaceDir('/projects/a', 'shared-pool');
+      workspace.assignWorkspaceDir('/projects/b', 'shared-pool');
+
+      expect(workspace.lookupWorkspaceForDir('/projects/a')).toBe('shared-pool');
+      expect(workspace.lookupWorkspaceForDir('/projects/b')).toBe('shared-pool');
+    });
+  });
+});


### PR DESCRIPTION
cli: scope most-recent instance per workspace (git root or set-workspace-dir) with non-repo global fallback and add `lim set-workspace-dir` for arbitrary, named workspace generation. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default instance resolution for all CLI users (main git checkouts now isolate by repo root; env/flag renames), though on-disk migrations aim to preserve existing caches.
> 
> **Overview**
> Renames instance isolation from **scope** to **workspace** (`--workspace`, `LIM_WORKSPACE`) and bumps the CLI to **0.14.5**.
> 
> **Workspace resolution** now picks the active key from, in order: flag/env override, then the more specific of a git repo/worktree root (`git rev-parse --show-toplevel`) or a `lim set-workspace-dir` binding (nested deeper git roots still win over a broad parent assignment). Outside git with no assignment, commands share the global slot (`__lim_global__`, migrated from `__global__`).
> 
> Adds **`lim set-workspace-dir`** and persists directory→name maps in `~/.lim/workspace-dirs.json`, so non-repo trees (or deliberate name sharing) get isolated “most recent instance” caches.
> 
> **`last-instances.json`** migrations: legacy flat files bridge via `__lim_legacy__` and fold into the active workspace on write; stale directory scopes are TTL-pruned while the global slot is kept. Missing-instance errors now mention the resolved workspace when it isn’t global.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0965162ab1b20b97f7d8214213bcaa554da02c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->