### PR TITLE
cli: rebuild root SDK before building so tsconfig paths never resolve a stale dist

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "prebuild": "yarn --cwd ../.. build",
     "build": "rm -rf dist && tsc",
     "dev": "node bin/dev.js",
     "prepublishOnly": "npm run build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "prebuild": "yarn --cwd ../.. build",
     "build": "rm -rf dist && tsc",
     "dev": "node bin/dev.js",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "tsc --noEmit -p tsconfig.publish.json && npm run build",
     "lint": "eslint src/",
     "test": "jest"
   },

--- a/packages/cli/tsconfig.publish.json
+++ b/packages/cli/tsconfig.publish.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only npm script and publish-time TypeScript config changes; no runtime CLI behavior changes.
> 
> **Overview**
> **Hardens CLI build and publish** so TypeScript never typechecks or compiles against a stale monorepo `dist` via `tsconfig` path aliases.
> 
> Adds a **`prebuild`** step that runs the **root SDK `yarn build`** before the CLI `tsc` build, matching the PR goal of refreshing `../../dist` before `@limrun/api` path resolution.
> 
> **`prepublishOnly`** now runs **`tsc --noEmit`** with a new **`tsconfig.publish.json`** that **clears `paths`**, then runs the normal build—so publish validation uses the published **`@limrun/api`** dependency instead of local path mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adeb45d9fb83f3b889c1a116db96e81b8a306ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->