### PR TITLE
feat: Add `AbortSignal` support for cancelling long-running operations

### DIFF
--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -1444,17 +1444,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
         const id = generateId();
 
+        let timeout: ReturnType<typeof setTimeout> | undefined;
         let abortListener: (() => void) | undefined;
-        if (signal) {
-          abortListener = () => {
-            clearTimeout(timeout);
-            pendingRequests.delete(id);
-            const err = new Error('The operation was aborted');
-            err.name = 'AbortError';
-            reject(err);
-          };
-          signal.addEventListener('abort', abortListener);
-        }
 
         const cleanupAndResolve = (val: T | PromiseLike<T>) => {
           if (signal && abortListener) signal.removeEventListener('abort', abortListener);
@@ -1466,7 +1457,18 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
           reject(reason);
         };
 
-        const timeout = setTimeout(() => {
+        if (signal) {
+          abortListener = () => {
+            if (timeout) clearTimeout(timeout);
+            pendingRequests.delete(id);
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            cleanupAndReject(err);
+          };
+          signal.addEventListener('abort', abortListener, { once: true });
+        }
+
+        timeout = setTimeout(() => {
           pendingRequests.delete(id);
           cleanupAndReject(new Error(`Request ${type} timed out`));
         }, timeoutMs);

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -335,6 +335,8 @@ export type AppInstallationOptions = {
    * - undefined: Don't launch after installation
    */
   launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
+  /** Optional AbortSignal to cancel the installation request locally */
+  signal?: AbortSignal;
 };
 
 // ============================================================================
@@ -594,11 +596,12 @@ export type InstanceClient = {
    *
    * @param actions The actions to run in order.
    * @param options.timeoutMs Custom client-side timeout in milliseconds.
+   * @param options.signal Optional AbortSignal to cancel the request locally.
    * @throws If any action fails — subsequent actions are not executed.
    */
   performActions: (
     actions: PerformAction[],
-    options?: { timeoutMs?: number },
+    options?: { timeoutMs?: number; signal?: AbortSignal },
   ) => Promise<PerformActionsResult>;
 
   /**
@@ -1424,22 +1427,53 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       params: Record<string, unknown> = {},
       transform?: (message: ServerResponse) => T,
       timeoutMs: number = 30000,
+      signal?: AbortSignal,
     ): Promise<T> => {
       return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+          const err = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+          return;
+        }
+
         if (!ws || ws.readyState !== WebSocket.OPEN) {
           reject(new Error('WebSocket is not connected or connection is not open.'));
           return;
         }
 
         const id = generateId();
+
+        let abortListener: (() => void) | undefined;
+        if (signal) {
+          abortListener = () => {
+            clearTimeout(timeout);
+            pendingRequests.delete(id);
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            reject(err);
+          };
+          signal.addEventListener('abort', abortListener);
+        }
+
+        const cleanupAndResolve = (val: T | PromiseLike<T>) => {
+          if (signal && abortListener) signal.removeEventListener('abort', abortListener);
+          resolve(val);
+        };
+
+        const cleanupAndReject = (reason?: any) => {
+          if (signal && abortListener) signal.removeEventListener('abort', abortListener);
+          reject(reason);
+        };
+
         const timeout = setTimeout(() => {
           pendingRequests.delete(id);
-          reject(new Error(`Request ${type} timed out`));
+          cleanupAndReject(new Error(`Request ${type} timed out`));
         }, timeoutMs);
 
         pendingRequests.set(
           id,
-          transform ? { resolve, reject, timeout, transform } : { resolve, reject, timeout },
+          transform ? { resolve: cleanupAndResolve, reject: cleanupAndReject, timeout, transform } : { resolve: cleanupAndResolve, reject: cleanupAndReject, timeout },
         );
 
         const request = { type, id, ...params };
@@ -1450,7 +1484,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             clearTimeout(timeout);
             pendingRequests.delete(id);
             logger.error(`Failed to send ${type} request:`, err);
-            reject(err);
+            cleanupAndReject(err);
           }
         });
       });
@@ -1824,6 +1858,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         },
         undefined,
         options?.timeoutMs ?? 120_000,
+        options?.signal,
       );
     };
 
@@ -1846,14 +1881,14 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
     const performActions = (
       actions: PerformAction[],
-      options?: { timeoutMs?: number },
+      options?: { timeoutMs?: number; signal?: AbortSignal },
     ): Promise<PerformActionsResult> => {
       // Batch duration is unbounded (user-supplied `wait` durations, plus
       // per-action server work), so we grow the timeout with the batch
       // rather than sticking to sendRequest's 30s default.
       const waitMs = actions.reduce((acc, a) => acc + (a.type === 'wait' ? Math.max(0, a.durationMs) : 0), 0);
       const timeoutMs = options?.timeoutMs ?? 30_000 + waitMs + actions.length * 2_000;
-      return sendRequest<PerformActionsResult>('performActions', { actions }, undefined, timeoutMs);
+      return sendRequest<PerformActionsResult>('performActions', { actions }, undefined, timeoutMs, options?.signal);
     };
 
     const startRecording = async (opts?: { quality?: RecordingQuality }): Promise<void> => {


### PR DESCRIPTION
### Description
Fixes #152 

This PR adds `AbortSignal` support to the iOS SDK, allowing consumers to manually cancel long-running requests like `installApp` and `performActions` using a standard `AbortController` without having to wait for the client-side timeout to expire.

### Changes Made
- **`AppInstallationOptions`**: Added `signal?: AbortSignal` property.
- **`InstanceClient`**: Updated `performActions` signature to accept an optional `signal`.
- **`sendRequest`**: 
  - Now accepts an optional `signal?: AbortSignal` parameter.
  - Implements an `abort` event listener that immediately calls `clearTimeout`, removes the request ID from the `pendingRequests` Map, and rejects the promise with an `AbortError`.
  - Cleans up event listeners when the promise resolves or rejects normally to avoid memory leaks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only cancellation of in-flight requests; does not change server protocol or security-sensitive paths.
> 
> **Overview**
> Adds optional **`AbortSignal`** support so callers can cancel long-running WebSocket requests without waiting for the client timeout.
> 
> **`sendRequest`** now accepts an optional signal: it rejects immediately with **`AbortError`** if already aborted, registers a one-shot **`abort`** listener that clears the request timeout, drops the pending entry, and rejects; resolve/reject paths remove the listener to avoid leaks.
> 
> **`installApp`** exposes **`options.signal`** via **`AppInstallationOptions`**; **`performActions`** accepts **`options.signal`** and passes it through with the existing dynamic timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e84380076cf82058ce33dd4e262b9b8a73e27e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->