### PR TITLE
cli: auto-install RBE builds on the attached simulator

### DIFF
--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -81,12 +81,9 @@ export default class XcodeRbe extends BaseCommand {
     }),
     'bep-file': Flags.string({
       description:
-        "Where the generated .limrun config points Bazel's --build_event_json_file, and where the " +
-        'auto-install watcher reads the built .ipa digest from after each build. Defaults to ' +
-        '.limrun/bep.json. Set this only if your build already directs --build_event_json_file to a ' +
-        'specific path (so the config matches it instead of clobbering it), or to keep the log out of ' +
-        '.limrun/. `lim xcode rbe install` picks up the same path automatically, so you do not need to ' +
-        'repeat it there.',
+        "Path for Bazel's build event log (--build_event_json_file), which the auto-install watcher reads " +
+        'after each build. Defaults to .limrun/bep.json; set it only if your build already writes the log ' +
+        'elsewhere. `lim xcode rbe install` reuses this path automatically.',
     }),
     serve: Flags.boolean({
       hidden: true,

--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -81,7 +81,12 @@ export default class XcodeRbe extends BaseCommand {
     }),
     'bep-file': Flags.string({
       description:
-        "Where the generated config writes Bazel's build event log, and where the auto-install watcher reads it. Defaults to .limrun/bep.json. Set this if you already direct --build_event_json_file elsewhere.",
+        "Where the generated .limrun config points Bazel's --build_event_json_file, and where the " +
+        'auto-install watcher reads the built .ipa digest from after each build. Defaults to ' +
+        '.limrun/bep.json. Set this only if your build already directs --build_event_json_file to a ' +
+        'specific path (so the config matches it instead of clobbering it), or to keep the log out of ' +
+        '.limrun/. `lim xcode rbe install` picks up the same path automatically, so you do not need to ' +
+        'repeat it there.',
     }),
     serve: Flags.boolean({
       hidden: true,

--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -11,6 +11,7 @@ import {
   findBazelWorkspaceRoot,
   inferBuildTarget,
   writeRbeWorkspaceFiles,
+  resolveBepPath,
   LIMRUN_DIR,
   type RbeWorkspaceFiles,
 } from '../../lib/rbe-workspace';
@@ -26,6 +27,7 @@ import {
   waitForRbeRunning,
   writeRbePidFile,
 } from '../../lib/rbe-session';
+import { startBepWatcher, type BepWatcher } from '../../lib/rbe-bep-watcher';
 
 export default class XcodeRbe extends BaseCommand {
   static summary = 'Serve a local Bazel remote-execution endpoint backed by a Limrun Xcode instance';
@@ -64,13 +66,31 @@ export default class XcodeRbe extends BaseCommand {
     }),
     ios: Flags.boolean({
       description:
-        'Also create an iOS simulator and attach it, so `lim xcode rbe install` installs on it and you can watch it live. The simulator is torn down on --stop.',
+        'Also create an iOS simulator and attach it, so builds auto-install on it and you can watch it live. The simulator is torn down on --stop.',
       default: false,
+    }),
+    'auto-install': Flags.boolean({
+      description:
+        'After each build, automatically install it on the attached simulator (and replay the last build when a simulator is attached later). Use --no-auto-install for a tunnel-only session (e.g. CI).',
+      default: true,
+      allowNo: true,
+    }),
+    target: Flags.string({
+      description:
+        'Build target to auto-install after each build (e.g. //App:App). Defaults to the inferred app target; required to auto-install when the workspace has multiple app targets.',
+    }),
+    'bep-file': Flags.string({
+      description:
+        "Where the generated config writes Bazel's build event log, and where the auto-install watcher reads it. Defaults to .limrun/bep.json. Set this if you already direct --build_event_json_file elsewhere.",
     }),
     serve: Flags.boolean({
       hidden: true,
       default: false,
       description: 'Internal: run only the tunnel serve loop (used by the detached background process).',
+    }),
+    'workspace-root': Flags.string({
+      hidden: true,
+      description: 'Internal: workspace root passed to the detached serve process for the auto-install watcher.',
     }),
   };
 
@@ -87,10 +107,34 @@ export default class XcodeRbe extends BaseCommand {
       if (!flags.id) {
         this.error('--serve requires --id (it is set automatically by the background launcher).');
       }
+      // This detached process holds the only RBE tunnel. The auto-install watcher
+      // runs async work (fs.watch callbacks, BEP parsing, HTTP) whose throws/
+      // rejections would otherwise reach Node's default handler and terminate the
+      // process, silently dropping Bazel's remote executor mid-build. Swallow them
+      // here so a watcher fault can never kill the tunnel; the tunnel's own
+      // terminal-disconnect path is handled in awaitTunnel.
+      installDaemonCrashGuards((msg) => console.error(`[lim] ${msg}`));
       await this.withAuth(async () => {
-        const target = await this.resolveXcodeTarget(flags.id);
-        const client = await this.resolveXcodeClient(target);
-        await this.runTunnel(client, flags.port);
+        const xcodeTarget = await this.resolveXcodeTarget(flags.id);
+        const client = await this.resolveXcodeClient(xcodeTarget);
+        const workspaceRoot = flags['workspace-root'];
+        const buildTarget = flags.target;
+        let watcher: BepWatcher | undefined;
+        if (workspaceRoot && buildTarget) {
+          // The parent passes an already-absolute --bep-file; resolveBepPath also
+          // handles a manual --serve invocation with a relative path (the child's
+          // cwd is the parent's, not necessarily the workspace root).
+          const bepPath = resolveBepPath(workspaceRoot, flags['bep-file']);
+          watcher = startBepWatcher({
+            bepPath,
+            target: buildTarget,
+            getClient: () => client,
+            log: (msg) => console.error(`[lim] ${msg}`),
+          });
+        }
+        // Close the watcher inside the tunnel teardown, BEFORE the tunnel/stack
+        // are stopped, so an in-flight install never races a dead stack.
+        await this.runTunnel(client, flags.port, watcher ? () => watcher.close() : undefined);
       });
       return;
     }
@@ -214,9 +258,13 @@ export default class XcodeRbe extends BaseCommand {
         }
       }
 
+      // Where Bazel writes its build event log and the watcher reads it: a custom
+      // --bep-file (absolute) or the default under .limrun/.
+      const bepPath = resolveBepPath(workspaceRoot, flags['bep-file']);
+
       let generated: RbeWorkspaceFiles;
       try {
-        generated = writeRbeWorkspaceFiles(workspaceRoot, xcodeVersion, flags.port);
+        generated = writeRbeWorkspaceFiles(workspaceRoot, xcodeVersion, flags.port, bepPath);
       } catch (err) {
         await client.stopRbe().catch(() => {});
         this.error(`Failed to generate .limrun config: ${err instanceof Error ? err.message : String(err)}`);
@@ -232,8 +280,20 @@ export default class XcodeRbe extends BaseCommand {
       // builds if put in .bazelrc), hence it precedes `build` in the command.
       // Infer a real app target so the printed command is runnable as-is; fall
       // back to a placeholder when there's no single obvious target.
-      const target = inferBuildTarget(workspaceRoot) ?? '//your:target';
+      const inferredTarget = inferBuildTarget(workspaceRoot);
+      const target = inferredTarget ?? '//your:target';
       const buildCmd = `bazelisk --digest_function=sha256 build --config=limrun ${target}`;
+
+      // Decide auto-install: on by default, but only when we have a concrete
+      // target to watch. An explicit --target wins over inference; an ambiguous
+      // workspace with no --target cannot auto-install.
+      const watchTarget = flags.target ?? inferredTarget ?? undefined;
+      const autoInstall = flags['auto-install'] && !!watchTarget;
+      if (flags['auto-install'] && !watchTarget) {
+        this.info(
+          'Auto-install is off: could not infer a single app target. Pass --target <label> to enable it.',
+        );
+      }
 
       // --ios: create + attach a simulator so `lim xcode rbe install` installs on
       // it and the stream URL is printed. Recorded in the pidfile so --stop tears
@@ -264,6 +324,9 @@ export default class XcodeRbe extends BaseCommand {
             xcodeVersion,
             generated,
             buildCmd,
+            autoInstall,
+            target: autoInstall ? watchTarget : undefined,
+            bepPath,
           });
         } catch (err) {
           // spawnBackgroundTunnel records simInstanceId in the pidfile only after
@@ -300,8 +363,20 @@ export default class XcodeRbe extends BaseCommand {
         instanceId,
         background: false,
       });
+      // Foreground auto-install: watch the BEP for the lifetime of this tunnel.
+      const watcher =
+        autoInstall && watchTarget ?
+          startBepWatcher({
+            bepPath,
+            target: watchTarget,
+            getClient: () => client,
+            log: (msg) => this.info(msg),
+          })
+        : undefined;
       try {
-        await this.awaitTunnel(tunnel, client);
+        // Close the watcher before the tunnel/stack teardown (inside awaitTunnel),
+        // so an in-flight install never races a stopped stack.
+        await this.awaitTunnel(tunnel, client, watcher ? () => watcher.close() : undefined);
       } finally {
         await this.deleteSim(simInstanceId);
       }
@@ -434,6 +509,9 @@ export default class XcodeRbe extends BaseCommand {
     xcodeVersion: string;
     generated: RbeWorkspaceFiles;
     buildCmd: string;
+    autoInstall: boolean;
+    target?: string;
+    bepPath: string;
   }): Promise<void> {
     const apiKey = this.parsedFlags?.['api-key'] as string | undefined;
     const logPath = path.join(opts.workspaceRoot, LIMRUN_DIR, 'rbe.log');
@@ -447,6 +525,11 @@ export default class XcodeRbe extends BaseCommand {
         id: opts.instanceId,
         port: opts.port,
         apiKey,
+        // Pass the workspace + target (+ bep path) only when auto-install is on,
+        // so the child starts the BEP watcher; otherwise it just holds the tunnel.
+        ...(opts.autoInstall && opts.target ?
+          { workspaceRoot: opts.workspaceRoot, target: opts.target, bepFile: opts.bepPath }
+        : {}),
       }),
       { detached: true, stdio: ['ignore', logFd, logFd] },
     );
@@ -502,6 +585,9 @@ export default class XcodeRbe extends BaseCommand {
       instanceId: opts.instanceId,
       port: opts.port,
       ...(opts.simInstanceId ? { simInstanceId: opts.simInstanceId } : {}),
+      // Record target+bepFile (when auto-installing) so `lim xcode rbe install`
+      // can recover a custom --bep-file path.
+      ...(opts.autoInstall && opts.target ? { target: opts.target, bepFile: opts.bepPath } : {}),
     });
 
     this.printReady({
@@ -534,17 +620,20 @@ export default class XcodeRbe extends BaseCommand {
    * the child if it exits within a short liveness window, so a slow tunnel-open
    * failure would otherwise leave the remote stack running with no owner.
    */
-  private async runTunnel(client: XcodeClient, port: number): Promise<void> {
+  private async runTunnel(client: XcodeClient, port: number, beforeStop?: () => Promise<void>): Promise<void> {
     let tunnel: Tunnel;
     try {
       tunnel = await this.openTunnel(client, port);
     } catch (err) {
+      // The tunnel never opened, so there's no watcher steady state to drain, but
+      // a watcher may already be running — close it before stopping the stack.
+      if (beforeStop) await beforeStop().catch(() => {});
       await client.stopRbe().catch(() => {});
       this.error(
         `Failed to open the remote-execution tunnel: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    await this.awaitTunnel(tunnel, client);
+    await this.awaitTunnel(tunnel, client, beforeStop);
   }
 
   /**
@@ -552,7 +641,11 @@ export default class XcodeRbe extends BaseCommand {
    * best-effort stop the remote stack. Rejects if the tunnel reports a terminal
    * disconnect (after its own reconnect attempts are exhausted).
    */
-  private async awaitTunnel(tunnel: Tunnel, client: XcodeClient): Promise<void> {
+  private async awaitTunnel(
+    tunnel: Tunnel,
+    client: XcodeClient,
+    beforeStop?: () => Promise<void>,
+  ): Promise<void> {
     try {
       await new Promise<void>((resolve, reject) => {
         const keepAlive = setInterval(() => {}, 1 << 30);
@@ -579,6 +672,9 @@ export default class XcodeRbe extends BaseCommand {
         process.once('SIGTERM', shutdown);
       });
     } finally {
+      // Drain the auto-install watcher first, so a registration in flight can't
+      // land against an already-closed tunnel / stopped stack.
+      if (beforeStop) await beforeStop().catch(() => {});
       tunnel.close();
       await client.stopRbe().catch(() => {});
     }
@@ -642,6 +738,26 @@ function signalIfAlive(pid: number, signal: NodeJS.Signals): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Backstops the detached serve daemon. The auto-install watcher already catches
+ * its own read/parse/HTTP errors internally, so a floating *rejection* here is
+ * almost always benign (e.g. the tunnel's reconnect machinery); log and continue
+ * rather than let Node's default crash drop the tunnel mid-build. A thrown
+ * *exception* that reaches the top level is a genuine fault we can't reason
+ * about: log and exit non-zero so the port frees and the next `lim xcode rbe`
+ * reaps the stale pidfile — far better than lingering as a zombie that holds the
+ * port with a dead tunnel and blocks restart.
+ */
+function installDaemonCrashGuards(log: (msg: string) => void): void {
+  process.on('unhandledRejection', (reason) => {
+    log(`auto-install: ignoring unhandled rejection to keep the tunnel alive: ${String(reason)}`);
+  });
+  process.on('uncaughtException', (err) => {
+    log(`daemon: fatal uncaught exception, exiting so the tunnel can be restarted: ${err?.message ?? err}`);
+    process.exit(1);
+  });
 }
 
 /** Reads the last `lines` lines of a log file for error surfacing; best-effort. */

--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -90,7 +90,8 @@ export default class XcodeRbe extends BaseCommand {
     }),
     'workspace-root': Flags.string({
       hidden: true,
-      description: 'Internal: workspace root passed to the detached serve process for the auto-install watcher.',
+      description:
+        'Internal: workspace root passed to the detached serve process for the auto-install watcher.',
     }),
   };
 
@@ -585,9 +586,11 @@ export default class XcodeRbe extends BaseCommand {
       instanceId: opts.instanceId,
       port: opts.port,
       ...(opts.simInstanceId ? { simInstanceId: opts.simInstanceId } : {}),
-      // Record target+bepFile (when auto-installing) so `lim xcode rbe install`
-      // can recover a custom --bep-file path.
-      ...(opts.autoInstall && opts.target ? { target: opts.target, bepFile: opts.bepPath } : {}),
+      // Always record where the build event log is written (it follows --bep-file
+      // regardless of auto-install), so `lim xcode rbe install` finds it even with
+      // --no-auto-install. `target` is the watcher's, recorded only when watching.
+      bepFile: opts.bepPath,
+      ...(opts.autoInstall && opts.target ? { target: opts.target } : {}),
     });
 
     this.printReady({
@@ -620,7 +623,11 @@ export default class XcodeRbe extends BaseCommand {
    * the child if it exits within a short liveness window, so a slow tunnel-open
    * failure would otherwise leave the remote stack running with no owner.
    */
-  private async runTunnel(client: XcodeClient, port: number, beforeStop?: () => Promise<void>): Promise<void> {
+  private async runTunnel(
+    client: XcodeClient,
+    port: number,
+    beforeStop?: () => Promise<void>,
+  ): Promise<void> {
     let tunnel: Tunnel;
     try {
       tunnel = await this.openTunnel(client, port);

--- a/packages/cli/src/commands/xcode/rbe/install.ts
+++ b/packages/cli/src/commands/xcode/rbe/install.ts
@@ -32,12 +32,9 @@ export default class XcodeRbeInstall extends BaseCommand {
     }),
     'bep-file': Flags.string({
       description:
-        "Path to the Bazel build event log (--build_event_json_file) to read the built .ipa's CAS digest " +
-        'from; that digest is what tells the instance which cached artifact to install. ' +
-        'By default the path is taken from the running `lim xcode rbe` (it records the log location it ' +
-        'configured, including any --bep-file it was started with), falling back to .limrun/bep.json. ' +
-        'You only need to set this when there is no matching `lim xcode rbe` to read it from (e.g. a CI or ' +
-        'one-off run) AND your build wrote the event log somewhere other than .limrun/bep.json.',
+        "Bazel build event log to read the built .ipa's CAS digest from. Defaults to the path " +
+        '`lim xcode rbe` recorded, then .limrun/bep.json; set it only for a standalone run (no running ' +
+        '`lim xcode rbe`) whose build wrote the log to a non-default path.',
     }),
   };
 

--- a/packages/cli/src/commands/xcode/rbe/install.ts
+++ b/packages/cli/src/commands/xcode/rbe/install.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command';
-import { findBazelWorkspaceRoot, inferBuildTarget, LIMRUN_DIR } from '../../../lib/rbe-workspace';
+import { findBazelWorkspaceRoot, inferBuildTarget, defaultBepPath } from '../../../lib/rbe-workspace';
 import { readRbePidFile } from '../../../lib/rbe-session';
 
 export default class XcodeRbeInstall extends BaseCommand {
@@ -29,6 +29,10 @@ export default class XcodeRbeInstall extends BaseCommand {
     id: Flags.string({
       description:
         'Xcode instance ID to target. Defaults to the most recent standalone Xcode target (the one `lim xcode rbe` used).',
+    }),
+    'bep-file': Flags.string({
+      description:
+        "Path to Bazel's build event log to read the .ipa digest from. Defaults to the path `lim xcode rbe` recorded, or .limrun/bep.json.",
     }),
   };
 
@@ -57,9 +61,15 @@ export default class XcodeRbeInstall extends BaseCommand {
       );
     }
 
-    // The generated bazelrc writes the build event log here on every
-    // --config=limrun build; read the just-built target's .ipa digest from it.
-    const bepPath = path.join(workspaceRoot, LIMRUN_DIR, 'bep.json');
+    // The generated bazelrc writes the build event log on every --config=limrun
+    // build; read the just-built target's .ipa digest from it. Prefer an explicit
+    // --bep-file, then the path `lim xcode rbe` recorded in the pidfile (in case a
+    // custom --bep-file was used), then the default under .limrun/.
+    const pidInfo = readRbePidFile(workspaceRoot);
+    const bepPath =
+      (flags['bep-file'] ? path.resolve(flags['bep-file']) : undefined) ??
+      pidInfo?.bepFile ??
+      defaultBepPath(workspaceRoot);
     let bepJson: string;
     try {
       bepJson = fs.readFileSync(bepPath, 'utf8');
@@ -74,7 +84,7 @@ export default class XcodeRbeInstall extends BaseCommand {
     // (recorded in .limrun/rbe.pid by `lim xcode rbe`), since that's the one
     // whose CAS holds the build. An explicit --id wins; otherwise fall back to
     // the pidfile, then to the most recent Xcode target.
-    const instanceId = flags.id ?? readRbePidFile(workspaceRoot)?.instanceId;
+    const instanceId = flags.id ?? pidInfo?.instanceId;
 
     await this.withAuth(async () => {
       // Target an existing instance (do not create): install needs the instance

--- a/packages/cli/src/commands/xcode/rbe/install.ts
+++ b/packages/cli/src/commands/xcode/rbe/install.ts
@@ -32,7 +32,12 @@ export default class XcodeRbeInstall extends BaseCommand {
     }),
     'bep-file': Flags.string({
       description:
-        "Path to Bazel's build event log to read the .ipa digest from. Defaults to the path `lim xcode rbe` recorded, or .limrun/bep.json.",
+        "Path to the Bazel build event log (--build_event_json_file) to read the built .ipa's CAS digest " +
+        'from; that digest is what tells the instance which cached artifact to install. ' +
+        'By default the path is taken from the running `lim xcode rbe` (it records the log location it ' +
+        'configured, including any --bep-file it was started with), falling back to .limrun/bep.json. ' +
+        'You only need to set this when there is no matching `lim xcode rbe` to read it from (e.g. a CI or ' +
+        'one-off run) AND your build wrote the event log somewhere other than .limrun/bep.json.',
     }),
   };
 

--- a/packages/cli/src/lib/rbe-bep-watcher.ts
+++ b/packages/cli/src/lib/rbe-bep-watcher.ts
@@ -1,0 +1,264 @@
+import fs from 'fs';
+import path from 'path';
+import { inspectBuildCompletion, parseTopLevelIpaDigest, RbeBepError } from '@limrun/api';
+import type { BepIpaDigest, XcodeClient } from '@limrun/api';
+
+/**
+ * Watches a workspace's `.limrun/bep.json` and, after each completed build,
+ * registers the built target's `.ipa` with the instance so it is installed on
+ * the attached simulator now (and replayed on a later attach). This is the
+ * client-side trigger for `lim xcode rbe` auto-install: only Bazel (on the
+ * client) knows the build finished and which CAS digest is the top-level `.ipa`,
+ * so the daemon holding the tunnel watches the BEP and the instance does the
+ * install server-side.
+ *
+ * Robustness is the priority: this runs inside the detached daemon that holds
+ * the only RBE tunnel, so every read/parse/HTTP error is caught and logged, and
+ * the watcher never throws into the daemon (a crash here would drop the tunnel
+ * mid-build). It is also idempotent: it acts once per Bazel invocation, even
+ * when a build reproduces an earlier `.ipa` digest (e.g. a `git stash` revert),
+ * because the instance keys "already installed" on the CAS digest.
+ */
+
+export type BepWatcherOptions = {
+  /** Absolute path to Bazel's build-event JSON log (`--build_event_json_file`). */
+  bepPath: string;
+  /** The build target to select from the BEP and install (e.g. //App:App). */
+  target: string;
+  /** Returns the XcodeClient to use; called per install so a refreshed client is picked up. */
+  getClient: () => XcodeClient;
+  /** Sink for status/diagnostic lines (the daemon redirects stdout/stderr to .limrun/rbe.log). */
+  log: (msg: string) => void;
+  /** Debounce window after a BEP change before acting. */
+  debounceMs?: number;
+  /** mtime-poll backstop interval (covers FSEvents coalescing/drops on macOS). */
+  pollIntervalMs?: number;
+};
+
+export type BepWatcher = {
+  /** Stops watching and awaits any in-flight registration. Idempotent. */
+  close: () => Promise<void>;
+};
+
+export function startBepWatcher(opts: BepWatcherOptions): BepWatcher {
+  const { bepPath, target, getClient, log, debounceMs = 400, pollIntervalMs = 1500 } = opts;
+
+  const watchDir = path.dirname(bepPath);
+  const bepName = path.basename(bepPath);
+
+  // Act once per build. We dedupe on the Bazel invocation id (not the digest) so
+  // a rebuild that reproduces an earlier digest (git stash revert) still
+  // re-registers — the instance, keyed on the CAS digest, then reinstalls only
+  // if the on-sim digest actually differs. When a BEP carries no invocation id
+  // (older Bazel), we fall back to the digest hash so we still avoid re-acting on
+  // the same build's repeated change events.
+  let lastHandledInvocation: string | undefined;
+  let lastHandledHash: string | undefined;
+  let authExpired = false;
+  const loggedOnce = new Set<string>();
+
+  let closed = false;
+  let dirty = false;
+  let currentTick: Promise<void> | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  // Seed from the current file (if any) so the first poll doesn't spuriously fire,
+  // and so we notice a rewrite by size even when mtime granularity is coarse.
+  let lastMtimeMs = -1;
+  let lastSize = -1;
+  try {
+    const st = fs.statSync(bepPath);
+    lastMtimeMs = st.mtimeMs;
+    lastSize = st.size;
+  } catch {
+    /* no BEP yet */
+  }
+
+  const logOnce = (key: string, msg: string): void => {
+    if (loggedOnce.has(key)) return;
+    loggedOnce.add(key);
+    log(msg);
+  };
+
+  const trigger = (): void => {
+    if (closed) return;
+    if (currentTick) {
+      // A tick is in flight; mark dirty so we re-run once it settles.
+      dirty = true;
+      return;
+    }
+    currentTick = tick()
+      .catch((err) => log(`auto-install: unexpected error: ${errMsg(err)}`))
+      .finally(() => {
+        currentTick = null;
+        // A BEP change during the registration (e.g. a new build) set `dirty`;
+        // re-run so we converge on the latest on-disk build.
+        if (dirty && !closed) {
+          dirty = false;
+          trigger();
+        }
+      });
+  };
+
+  const onChange = (): void => {
+    if (closed) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      trigger();
+    }, debounceMs);
+  };
+
+  async function tick(): Promise<void> {
+    if (authExpired) return; // a detached daemon cannot relogin; stop trying.
+    if (closed) return;
+    let bep: string;
+    try {
+      bep = await fs.promises.readFile(bepPath, 'utf8');
+    } catch {
+      return; // file missing/unreadable; a later change re-triggers.
+    }
+
+    const completion = inspectBuildCompletion(bep);
+    if (!completion.complete || !completion.success) {
+      // Build still flushing, or it failed: leave prior state untouched. A
+      // failed build must not register anything.
+      return;
+    }
+    if (completion.invocationId && completion.invocationId === lastHandledInvocation) {
+      return; // already handled this build.
+    }
+
+    // The BEP is fully flushed (gated on the terminal `lastMessage` event), so a
+    // parse failure here is definitive, not a not-yet-written race: this build
+    // either didn't produce our target or used wrong flags (BLAKE3 / local-only).
+    // Either way, mark the build handled so its remaining change events don't
+    // reprocess; log the wrong-flags case once.
+    let digest: BepIpaDigest;
+    try {
+      digest = parseTopLevelIpaDigest(bep, target);
+    } catch (err) {
+      if (err instanceof RbeBepError && err.terminal) {
+        logOnce(`terminal:${completion.invocationId ?? 'no-invocation'}`, `auto-install: ${errMsg(err)}`);
+      }
+      markHandled(completion.invocationId, undefined);
+      return;
+    }
+
+    // Fall back to the digest for the rare BEP without an invocation id, so the
+    // same build's repeated change events don't re-register.
+    if (!completion.invocationId && digest.hash === lastHandledHash) {
+      return;
+    }
+
+    await register(bep, digest, completion.invocationId);
+  }
+
+  function markHandled(invocationId: string | undefined, hash: string | undefined): void {
+    // Update each dedupe key only when we actually have a value, so a terminal
+    // parse failure (which has an invocation id but no digest) doesn't wipe the
+    // hash-fallback key used for invocation-less BEP streams.
+    if (invocationId !== undefined) lastHandledInvocation = invocationId;
+    if (hash !== undefined) lastHandledHash = hash;
+  }
+
+  async function register(bep: string, digest: BepIpaDigest, invocationId?: string): Promise<void> {
+    let result;
+    try {
+      result = await getClient().installRbeBuildFromBep({ bep, target });
+    } catch (err) {
+      if (isAuthError(err)) {
+        authExpired = true;
+        logOnce('auth', 'auto-install: session expired; restart `lim xcode rbe` to resume auto-install.');
+        return;
+      }
+      // Transient (network/instance blip): do NOT mark handled, so the next BEP
+      // change or poll retries this build.
+      log(`auto-install: failed to install ${digest.ipaName}: ${errMsg(err)}`);
+      return;
+    }
+
+    // The build is handled — don't retry it on the next change.
+    markHandled(invocationId, digest.hash);
+    if (result.installed) {
+      const timing =
+        result.syncDurationMs !== undefined ?
+          ` (synced ${result.syncDurationMs}ms, installed ${result.installDurationMs ?? 0}ms)`
+        : '';
+      log(`auto-install: installed ${result.appName ?? digest.ipaName}${timing}`);
+    } else {
+      log(`auto-install: recorded ${digest.ipaName}; will install when a simulator is attached.`);
+    }
+  }
+
+  // fs.watch on the directory (Bazel truncates+rewrites bep.json, changing the
+  // inode, so watching the file path directly is unreliable). Filter to bep.json.
+  let watcher: fs.FSWatcher | null = null;
+  try {
+    watcher = fs.watch(watchDir, (_event, filename) => {
+      if (!filename || path.basename(filename.toString()) === bepName) onChange();
+    });
+    watcher.on('error', (err) => log(`auto-install: watch error: ${errMsg(err)}`));
+  } catch (err) {
+    log(`auto-install: could not watch ${watchDir}: ${errMsg(err)}`);
+  }
+
+  // mtime-poll backstop: macOS FSEvents can coalesce or drop the single
+  // completion event, so also poll the BEP's mtime and act on a change.
+  const poll = setInterval(() => {
+    fs.promises
+      .stat(bepPath)
+      .then((st) => {
+        // Compare size too: a fast cached rebuild's truncate+rewrite can land
+        // within one mtime tick on coarse-granularity filesystems.
+        if (st.mtimeMs !== lastMtimeMs || st.size !== lastSize) {
+          lastMtimeMs = st.mtimeMs;
+          lastSize = st.size;
+          onChange();
+        }
+      })
+      .catch(() => {
+        /* no BEP yet */
+      });
+  }, pollIntervalMs);
+  // Don't let the poll timer keep the event loop alive on its own.
+  if (typeof poll.unref === 'function') poll.unref();
+
+  // Catch a build that completed before the watcher started (e.g. daemon restart).
+  trigger();
+
+  return {
+    async close(): Promise<void> {
+      closed = true;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      clearInterval(poll);
+      watcher?.close();
+      if (currentTick) {
+        try {
+          await currentTick;
+        } catch {
+          /* already logged */
+        }
+      }
+    },
+  };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Detects an expired/invalid session (HTTP 401). The SDK throws a typed
+ * AuthenticationError (status 401) on some paths; the instance-direct path
+ * (installRbeBuildFromBep) instead throws a plain Error whose message is
+ * `"<op> failed: <status> <body>"`. Match the status POSITION (`failed: 401`),
+ * not a bare `401` anywhere — a transient 5xx whose body merely contains "401"
+ * (a trace id, a JSON offset) must not latch auto-install off.
+ */
+function isAuthError(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    const e = err as { name?: string; status?: number };
+    if (e.name === 'AuthenticationError' || e.status === 401) return true;
+  }
+  return /\bfailed: 401\b/.test(errMsg(err));
+}

--- a/packages/cli/src/lib/rbe-bep-watcher.ts
+++ b/packages/cli/src/lib/rbe-bep-watcher.ts
@@ -33,6 +33,10 @@ export type BepWatcherOptions = {
   debounceMs?: number;
   /** mtime-poll backstop interval (covers FSEvents coalescing/drops on macOS). */
   pollIntervalMs?: number;
+  /** Delay before retrying a build after a transient install failure. */
+  retryDelayMs?: number;
+  /** Max transient-failure retries for one build before giving up (rebuild to retry). */
+  maxRetries?: number;
 };
 
 export type BepWatcher = {
@@ -41,7 +45,16 @@ export type BepWatcher = {
 };
 
 export function startBepWatcher(opts: BepWatcherOptions): BepWatcher {
-  const { bepPath, target, getClient, log, debounceMs = 400, pollIntervalMs = 1500 } = opts;
+  const {
+    bepPath,
+    target,
+    getClient,
+    log,
+    debounceMs = 400,
+    pollIntervalMs = 1500,
+    retryDelayMs = 5000,
+    maxRetries = 3,
+  } = opts;
 
   const watchDir = path.dirname(bepPath);
   const bepName = path.basename(bepPath);
@@ -60,6 +73,11 @@ export function startBepWatcher(opts: BepWatcherOptions): BepWatcher {
   let closed = false;
   let dirty = false;
   let currentTick: Promise<void> | null = null;
+  // Bounded retry for transient install failures (the mtime/size poll only fires
+  // on a file change, so a settled build wouldn't otherwise be retried).
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryInvocation: string | undefined;
+  let retryCount = 0;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   // Seed from the current file (if any) so the first poll doesn't spuriously fire,
   // and so we notice a rewrite by size even when mtime granularity is coarse.
@@ -161,6 +179,35 @@ export function startBepWatcher(opts: BepWatcherOptions): BepWatcher {
     if (hash !== undefined) lastHandledHash = hash;
   }
 
+  /**
+   * Schedules a re-attempt after a transient install failure (the build is not
+   * marked handled, so the re-triggered tick re-reads and retries the same
+   * build). Bounded per build: after maxRetries we give up and mark it handled so
+   * a permanent failure can't loop forever — the user rebuilds to retry.
+   */
+  function scheduleRetry(invocationId: string | undefined, digest: BepIpaDigest): void {
+    if (closed) return;
+    if (invocationId !== retryInvocation) {
+      retryInvocation = invocationId;
+      retryCount = 0;
+    }
+    if (retryCount >= maxRetries) {
+      logOnce(
+        `giveup:${invocationId ?? digest.hash}`,
+        `auto-install: gave up installing ${digest.ipaName} after ${maxRetries} retries; rebuild to retry.`,
+      );
+      markHandled(invocationId, digest.hash);
+      return;
+    }
+    retryCount++;
+    if (retryTimer) clearTimeout(retryTimer);
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      trigger();
+    }, retryDelayMs);
+    if (typeof retryTimer.unref === 'function') retryTimer.unref();
+  }
+
   async function register(bep: string, digest: BepIpaDigest, invocationId?: string): Promise<void> {
     let result;
     try {
@@ -171,9 +218,11 @@ export function startBepWatcher(opts: BepWatcherOptions): BepWatcher {
         logOnce('auth', 'auto-install: session expired; restart `lim xcode rbe` to resume auto-install.');
         return;
       }
-      // Transient (network/instance blip): do NOT mark handled, so the next BEP
-      // change or poll retries this build.
+      // Transient (network/instance blip). The mtime/size poll won't re-fire for
+      // a settled build, so schedule a bounded retry rather than dropping it until
+      // the next build.
       log(`auto-install: failed to install ${digest.ipaName}: ${errMsg(err)}`);
+      scheduleRetry(invocationId, digest);
       return;
     }
 
@@ -230,6 +279,7 @@ export function startBepWatcher(opts: BepWatcherOptions): BepWatcher {
     async close(): Promise<void> {
       closed = true;
       if (debounceTimer) clearTimeout(debounceTimer);
+      if (retryTimer) clearTimeout(retryTimer);
       clearInterval(poll);
       watcher?.close();
       if (currentTick) {

--- a/packages/cli/src/lib/rbe-session.ts
+++ b/packages/cli/src/lib/rbe-session.ts
@@ -86,12 +86,21 @@ export async function waitForRbeRunning(
  * Builds the argv for the detached child that holds the tunnel: re-invokes this
  * same CLI as `xcode rbe --serve --id <id> --port <port> [--api-key <key>]`.
  * `scriptPath` is the CLI entry (process.argv[1]).
+ *
+ * When `workspaceRoot` and `target` are both present the child also starts the
+ * BEP auto-install watcher (watching `<workspaceRoot>/.limrun/bep.json` and
+ * registering the built `target`'s `.ipa` after each build). argv is the source
+ * of truth here because the child needs these at startup, before any pidfile is
+ * written.
  */
 export function buildServeChildArgs(opts: {
   scriptPath: string;
   id: string;
   port: number;
   apiKey?: string;
+  workspaceRoot?: string;
+  target?: string;
+  bepFile?: string;
 }): string[] {
   // --no-create: the child must never own instance creation. The parent already
   // resolved/created the instance and started RBE on it; if that instance has
@@ -108,6 +117,15 @@ export function buildServeChildArgs(opts: {
     '--port',
     String(opts.port),
   ];
+  if (opts.workspaceRoot) {
+    args.push('--workspace-root', opts.workspaceRoot);
+  }
+  if (opts.target) {
+    args.push('--target', opts.target);
+  }
+  if (opts.bepFile) {
+    args.push('--bep-file', opts.bepFile);
+  }
   if (opts.apiKey) {
     args.push('--api-key', opts.apiKey);
   }
@@ -126,6 +144,10 @@ export type RbePidInfo = {
   port: number;
   /** iOS simulator created by `--ios`, torn down on --stop. Absent otherwise. */
   simInstanceId?: string;
+  /** Build target the auto-install watcher tracks, when enabled. */
+  target?: string;
+  /** Absolute path to the build-event log the watcher reads (`--bep-file`); absent means the default. */
+  bepFile?: string;
 };
 
 export function rbePidFilePath(workspaceRoot: string): string {

--- a/packages/cli/src/lib/rbe-workspace.ts
+++ b/packages/cli/src/lib/rbe-workspace.ts
@@ -14,6 +14,25 @@ export const LIMRUN_DIR = '.limrun';
 export const TRY_IMPORT_LINE = 'try-import %workspace%/.limrun/bazelrc';
 const TRY_IMPORT_COMMENT = '# Added by lim xcode rbe: loads the generated remote-execution config.';
 
+/**
+ * Where Bazel writes its build-event log by default — under the self-gitignored
+ * `.limrun/`, the directory this module owns and writes the generated config
+ * into. Single source of truth for the default path the watcher reads and the
+ * generated bazelrc points `--build_event_json_file` at.
+ */
+export function defaultBepPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, LIMRUN_DIR, 'bep.json');
+}
+
+/**
+ * Resolves the BEP path for a run: an explicit `--bep-file` (made absolute
+ * against the invocation cwd, so it resolves regardless of bazel's cwd) or the
+ * default under `.limrun/`.
+ */
+export function resolveBepPath(workspaceRoot: string, bepFileFlag?: string): string {
+  return bepFileFlag ? path.resolve(bepFileFlag) : defaultBepPath(workspaceRoot);
+}
+
 const WORKSPACE_MARKERS = ['MODULE.bazel', 'WORKSPACE', 'WORKSPACE.bazel'];
 
 /**
@@ -359,6 +378,7 @@ export function writeRbeWorkspaceFiles(
   workspaceDir: string,
   xcodeVersionKey: string,
   port: number,
+  bepFile: string = defaultBepPath(workspaceDir),
   isMacClient: boolean = process.platform === 'darwin',
   bazelMajor: number | null = detectBazelMajorVersion(workspaceDir),
 ): RbeWorkspaceFiles {
@@ -370,10 +390,11 @@ export function writeRbeWorkspaceFiles(
   // longer native globals. On a known Bazel 8 workspace they ARE native (and
   // loading would fail), so omit the loads.
   const emitLoads = isBazel9OrLater(bazelMajor);
-  // Absolute BEP path so it resolves regardless of bazel's cwd; lim xcode rbe
-  // install reads the same path. .limrun/ is gitignored and regenerated per run,
-  // so a machine-specific absolute path here is fine.
-  const bepFile = path.join(dir, 'bep.json');
+  // The BEP path is absolute so it resolves regardless of bazel's cwd; the
+  // watcher and `lim xcode rbe install` read the same path. Defaults under the
+  // self-gitignored .limrun/; a custom --bep-file may point elsewhere, so make
+  // sure its parent exists before bazel tries to write it.
+  fs.mkdirSync(path.dirname(bepFile), { recursive: true });
   fs.writeFileSync(buildFile, renderXcodeConfigBuild(xcodeVersionKey, emitLoads));
   fs.writeFileSync(bazelrcFragment, renderLimrunBazelrc(port, xcodeVersionKey, isMacClient, bepFile));
   fs.writeFileSync(path.join(dir, '.gitignore'), '*\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,7 @@ export * from './instance-client';
 export * as Ios from './ios-client';
 export { startHttpProxy, type HttpProxy, type StartHttpProxyOptions } from './http-proxy';
 export { buildSettingKeyPattern, parseBuildSettingEntries, validateBuildSettings } from './build-settings';
-export {
-  parseTopLevelIpaDigest,
-  inspectBuildCompletion,
-  RbeBepError,
-  type BepIpaDigest,
-} from './rbe-bep';
+export { parseTopLevelIpaDigest, inspectBuildCompletion, RbeBepError, type BepIpaDigest } from './rbe-bep';
 export {
   exec,
   type ExecRequest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ export * from './instance-client';
 export * as Ios from './ios-client';
 export { startHttpProxy, type HttpProxy, type StartHttpProxyOptions } from './http-proxy';
 export { buildSettingKeyPattern, parseBuildSettingEntries, validateBuildSettings } from './build-settings';
-export { parseTopLevelIpaDigest, type BepIpaDigest } from './rbe-bep';
+export {
+  parseTopLevelIpaDigest,
+  inspectBuildCompletion,
+  RbeBepError,
+  type BepIpaDigest,
+} from './rbe-bep';
 export {
   exec,
   type ExecRequest,

--- a/src/rbe-bep.ts
+++ b/src/rbe-bep.ts
@@ -12,6 +12,10 @@
  * `--remote_download_outputs=minimal` to skip the (unneeded) local download by
  * default; overriding it (e.g. `--remote_download_outputs=toplevel` on the command
  * line) to materialize the .ipa locally does not affect this parser.
+ *
+ * A fully-cached rebuild (0 actions executed) still emits the bytestream URI and
+ * reproduces the same digest, so the auto-install watcher can rely on this parser
+ * after a no-op or revert (e.g. `git stash`) rebuild. Verified empirically.
  */
 
 export type BepIpaDigest = {
@@ -27,7 +31,12 @@ type BepEvent = {
   id?: {
     targetCompleted?: { label?: string };
     namedSet?: { id?: string };
+    buildFinished?: unknown;
   };
+  started?: { uuid?: string };
+  finished?: { overallSuccess?: boolean; exitCode?: { name?: string; code?: number } };
+  /** Bazel sets this on the final BEP event once the stream is fully flushed. */
+  lastMessage?: boolean;
   completed?: {
     success?: boolean;
     outputGroup?: Array<{ name?: string; fileSets?: Array<{ id?: string }> }>;
@@ -38,17 +47,62 @@ type BepEvent = {
   };
 };
 
+/**
+ * Why a BEP could not yield an .ipa digest for a label.
+ *
+ * `terminal` failures will not resolve by re-reading the same completed BEP
+ * (the build used the wrong flags); `no-build` / `no-output` / `no-ipa` are
+ * transient while the build is still flushing and become terminal only once
+ * the build is confirmed complete. The watcher uses this to decide whether to
+ * retry the read or to log-once and give up.
+ */
+export type RbeBepErrorKind = 'no-build' | 'no-output' | 'no-ipa' | 'local-only' | 'non-sha256';
+
+export class RbeBepError extends Error {
+  readonly kind: RbeBepErrorKind;
+  constructor(kind: RbeBepErrorKind, message: string) {
+    super(message);
+    this.name = 'RbeBepError';
+    this.kind = kind;
+  }
+
+  /**
+   * True when re-reading the same (completed) BEP cannot help — the build was
+   * produced with flags the instance cache can't use (local download or a
+   * non-SHA256 digest). The watcher logs these once instead of retrying.
+   */
+  get terminal(): boolean {
+    return this.kind === 'local-only' || this.kind === 'non-sha256';
+  }
+}
+
 /** A SHA-256 digest is exactly 64 lowercase hex chars; the instance CAS is keyed by it. */
 const SHA256_HEX = /^[0-9a-f]{64}$/;
 
-/** Extracts (hash, size) from a `bytestream://…/blobs/<hash>/<size>` URI. */
-function parseBytestreamDigest(uri: string): { hash: string; sizeBytes: number } | null {
-  // Tolerate an optional instance-name segment before /blobs/ by anchoring on
-  // the /blobs/<hash>/<size> tail rather than a fixed segment count. The hash is
-  // left length-agnostic here (validated as SHA-256 by the caller).
-  const m = uri.match(/\/blobs\/([0-9a-f]+)\/(\d+)(?:$|\/)/);
-  if (!m || m[1] === undefined || m[2] === undefined) return null;
-  return { hash: m[1], sizeBytes: Number(m[2]) };
+/**
+ * Extracts (digestFunction, hash, size) from a Bazel/REAPI bytestream blob URI:
+ * `bytestream://…/blobs/[<digest_function>/]<hash>/<size>`. The digest-function
+ * segment is OMITTED for functions inferable from hash length (SHA-256 among
+ * them) and PRESENT otherwise — notably BLAKE3, whose 256-bit output is also 64
+ * hex chars and so cannot be told apart from SHA-256 by length. Capturing the
+ * function lets the caller reject a non-SHA256 build (e.g. Bazel 9's BLAKE3
+ * default) with the right guidance instead of misreading the URI.
+ */
+function parseBytestreamDigest(
+  uri: string,
+): { digestFunction?: string; hash: string; sizeBytes: number } | null {
+  // Anchor on the /blobs/[func/]<hash>/<size> tail (tolerating an instance-name
+  // prefix). The optional function group only matches a real function segment:
+  // for the SHA-256 form (`/blobs/<hash>/<size>`) it backtracks to absent, and
+  // for `/blobs/blake3/<hash>/<size>` the non-hex 'l'/'k' force it to be captured
+  // as the function rather than the hash.
+  const m = uri.match(/\/blobs\/(?:([a-z0-9_]+)\/)?([0-9a-fA-F]+)\/(\d+)(?:$|\/)/);
+  if (!m || m[2] === undefined || m[3] === undefined) return null;
+  return {
+    ...(m[1] !== undefined ? { digestFunction: m[1] } : {}),
+    hash: m[2].toLowerCase(),
+    sizeBytes: Number(m[3]),
+  };
 }
 
 /**
@@ -67,14 +121,8 @@ function canonicalizeLabel(label: string): string {
   return name ? `${pkg}:${name}` : pkg;
 }
 
-/**
- * Finds the `.ipa` produced for `label` in a BEP stream and returns its CAS
- * digest. Throws a descriptive Error when the target/.ipa is absent, its output
- * was materialized locally (a `file://` URI) instead of left in CAS, or it was
- * built with a non-SHA256 digest the instance cache cannot resolve.
- */
-export function parseTopLevelIpaDigest(bepJson: string, label: string): BepIpaDigest {
-  const canonical = canonicalizeLabel(label);
+/** Parses the BEP stream into events, ignoring partial/garbled lines. */
+function parseEvents(bepJson: string): BepEvent[] {
   const events: BepEvent[] = [];
   for (const line of bepJson.split('\n')) {
     const trimmed = line.trim();
@@ -85,32 +133,83 @@ export function parseTopLevelIpaDigest(bepJson: string, label: string): BepIpaDi
       // Ignore partial/garbled lines (BEP is flushed incrementally).
     }
   }
+  return events;
+}
 
-  // The successful TargetComplete for the requested label (matched against the
-  // canonical //pkg:name form Bazel records, so `//App` matches `//App:App`).
-  const completed = events.find((e) => e.id?.targetCompleted?.label === canonical && e.completed?.success)
-    ?.completed;
-  if (!completed) {
-    throw new Error(
-      `No successful build of ${label} found in the build event log. ` +
-        `Build it first with --config=limrun (e.g. \`bazelisk --digest_function=sha256 build --config=limrun ${label}\`).`,
-    );
+export type BepCompletion = {
+  /**
+   * True once Bazel has flushed the terminal event (`lastMessage`), so every
+   * earlier event — including the .ipa's namedSetOfFiles — is durably on disk.
+   * Gate the digest read on this, NOT on the presence of `buildFinished`:
+   * `buildFinished` is followed by `buildToolLogs` and `buildMetrics`
+   * (the `lastMessage` carrier), so it is not the last line.
+   */
+  complete: boolean;
+  /** Whether the build itself succeeded (overallSuccess / exit code 0). */
+  success: boolean;
+  /** Bazel's invocation UUID — distinguishes one build from the next. */
+  invocationId?: string;
+};
+
+/**
+ * Inspects a BEP stream for build completion. The watcher reads the BEP on every
+ * change but only acts once `complete` is true (the stream is fully flushed) and
+ * `success` is true (the build did not fail). `invocationId` lets the watcher act
+ * once per build even when consecutive builds reproduce the same .ipa digest
+ * (e.g. a `git stash` revert that rebuilds to an earlier digest).
+ */
+export function inspectBuildCompletion(bepJson: string): BepCompletion {
+  let complete = false;
+  let sawFinished = false;
+  let success = false;
+  let invocationId: string | undefined;
+  for (const e of parseEvents(bepJson)) {
+    if (e.started?.uuid) invocationId = e.started.uuid;
+    if (e.id?.buildFinished !== undefined || e.finished !== undefined) {
+      sawFinished = true;
+      // proto3 JSON omits zero-valued scalars, so a SUCCESS exit code serializes
+      // as `{name:"SUCCESS"}` with `code` omitted — checking `code === 0` would be
+      // a dead branch. Trust overallSuccess (present=true on success, omitted on
+      // failure) and fall back to the exit code's symbolic name.
+      success = e.finished?.overallSuccess === true || e.finished?.exitCode?.name === 'SUCCESS';
+    }
+    if (e.lastMessage === true) complete = true;
   }
+  return {
+    complete,
+    success: sawFinished && success,
+    ...(invocationId !== undefined ? { invocationId } : {}),
+  };
+}
 
+/** Indexes namedSetOfFiles events by id for transitive fileset resolution. */
+function indexNamedSets(events: BepEvent[]): Map<string, NonNullable<BepEvent['namedSetOfFiles']>> {
+  const namedSets = new Map<string, NonNullable<BepEvent['namedSetOfFiles']>>();
+  for (const e of events) {
+    const id = e.id?.namedSet?.id;
+    if (id && e.namedSetOfFiles) namedSets.set(id, e.namedSetOfFiles);
+  }
+  return namedSets;
+}
+
+/**
+ * Resolves the top-level `.ipa` CAS digest for one successful target's
+ * `completed` event, walking its default output group's filesets transitively.
+ * Throws a typed RbeBepError when no .ipa is present, it was materialized
+ * locally (`file://`), or it carries a non-SHA256 (e.g. BLAKE3) digest.
+ */
+function resolveIpaDigest(
+  label: string,
+  completed: NonNullable<BepEvent['completed']>,
+  namedSets: Map<string, NonNullable<BepEvent['namedSetOfFiles']>>,
+): BepIpaDigest {
   // Default output group -> the fileSet (namedSetOfFiles) ids holding its outputs.
   const rootFileSetIds = (completed.outputGroup ?? [])
     .filter((og) => og.name === 'default' || !og.name)
     .flatMap((og) => (og.fileSets ?? []).map((fs) => fs.id))
     .filter((id): id is string => !!id);
   if (rootFileSetIds.length === 0) {
-    throw new Error(`Build of ${label} reported no default output files.`);
-  }
-
-  // Index namedSetOfFiles by id and walk transitively (sets can nest).
-  const namedSets = new Map<string, NonNullable<BepEvent['namedSetOfFiles']>>();
-  for (const e of events) {
-    const id = e.id?.namedSet?.id;
-    if (id && e.namedSetOfFiles) namedSets.set(id, e.namedSetOfFiles);
+    throw new RbeBepError('no-output', `Build of ${label} reported no default output files.`);
   }
 
   const seen = new Set<string>();
@@ -128,15 +227,21 @@ export function parseTopLevelIpaDigest(bepJson: string, label: string): BepIpaDi
       if (!f.name || !f.name.endsWith('.ipa')) continue;
       const digest = f.uri ? parseBytestreamDigest(f.uri) : null;
       if (digest) {
-        // The instance cache is keyed by SHA-256. A non-64-hex digest means the
-        // build used a different digest function (Bazel 9 defaults to BLAKE3),
-        // which the server CAS cannot resolve — surface that clearly here rather
-        // than letting it fail later as a cryptic cache miss.
-        if (!SHA256_HEX.test(digest.hash)) {
-          throw new Error(
-            `Built ${f.name} with a non-SHA256 digest (got ${digest.hash.length} hex chars, expected 64; ` +
-              `likely BLAKE3 on Bazel 9). The instance cache is keyed by SHA-256 — rebuild with ` +
-              `--digest_function=sha256, e.g. \`bazelisk --digest_function=sha256 build --config=limrun ${label}\`.`,
+        // The instance cache is keyed by SHA-256. Reject any other digest
+        // function — Bazel 9 defaults to BLAKE3, whose URI carries an explicit
+        // `blake3` function segment (and whose 64-hex hash is indistinguishable
+        // from SHA-256 by length, so the hash form alone can't catch it). Surface
+        // it here with the fix rather than letting it fail later as a cryptic
+        // server cache miss.
+        const isSha256 =
+          digest.digestFunction === undefined ? SHA256_HEX.test(digest.hash) : digest.digestFunction === 'sha256';
+        if (!isSha256) {
+          const got = digest.digestFunction ?? `${digest.hash.length} hex chars`;
+          throw new RbeBepError(
+            'non-sha256',
+            `Built ${f.name} with a non-SHA256 digest (${got}; Bazel 9 defaults to BLAKE3). The instance ` +
+              `cache is keyed by SHA-256 — rebuild with --digest_function=sha256, e.g. ` +
+              `\`bazelisk --digest_function=sha256 build --config=limrun ${label}\`.`,
           );
         }
         return { hash: digest.hash, sizeBytes: digest.sizeBytes, ipaName: f.name };
@@ -149,11 +254,37 @@ export function parseTopLevelIpaDigest(bepJson: string, label: string): BepIpaDi
   }
 
   if (localOnlyIpa) {
-    throw new Error(
+    throw new RbeBepError(
+      'local-only',
       `Found ${label}'s .ipa (${localOnlyIpa}) but it has no remote (bytestream) digest — it was ` +
         `built locally, not remotely executed. Ensure you built with --config=limrun so the .ipa is ` +
         `produced in the instance's cache.`,
     );
   }
-  throw new Error(`No .ipa output found for ${label} in the build event log.`);
+  throw new RbeBepError('no-ipa', `No .ipa output found for ${label} in the build event log.`);
+}
+
+/**
+ * Finds the `.ipa` produced for `label` in a BEP stream and returns its CAS
+ * digest. Throws a typed RbeBepError when the target/.ipa is absent, its output
+ * was materialized locally (a `file://` URI) instead of left in CAS, or it was
+ * built with a non-SHA256 digest the instance cache cannot resolve.
+ */
+export function parseTopLevelIpaDigest(bepJson: string, label: string): BepIpaDigest {
+  const canonical = canonicalizeLabel(label);
+  const events = parseEvents(bepJson);
+
+  // The successful TargetComplete for the requested label (matched against the
+  // canonical //pkg:name form Bazel records, so `//App` matches `//App:App`).
+  const completed = events.find((e) => e.id?.targetCompleted?.label === canonical && e.completed?.success)
+    ?.completed;
+  if (!completed) {
+    throw new RbeBepError(
+      'no-build',
+      `No successful build of ${label} found in the build event log. ` +
+        `Build it first with --config=limrun (e.g. \`bazelisk --digest_function=sha256 build --config=limrun ${label}\`).`,
+    );
+  }
+
+  return resolveIpaDigest(label, completed, indexNamedSets(events));
 }

--- a/src/rbe-bep.ts
+++ b/src/rbe-bep.ts
@@ -234,7 +234,9 @@ function resolveIpaDigest(
         // it here with the fix rather than letting it fail later as a cryptic
         // server cache miss.
         const isSha256 =
-          digest.digestFunction === undefined ? SHA256_HEX.test(digest.hash) : digest.digestFunction === 'sha256';
+          digest.digestFunction === undefined ?
+            SHA256_HEX.test(digest.hash)
+          : digest.digestFunction === 'sha256';
         if (!isSha256) {
           const got = digest.digestFunction ?? `${digest.hash.length} hex chars`;
           throw new RbeBepError(

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -220,9 +220,9 @@ export type XcodeClient = {
 
   /**
    * Attach a simulator to this xcode instance.
-   * After attaching, the latest xcodebuild build (if any) is installed on the
-   * simulator. RBE builds are not auto-installed on attach — install them
-   * explicitly with `installRbeBuildFromBep` while a simulator is attached.
+   * After attaching, the latest installable build is installed on the simulator:
+   * the latest xcodebuild build or the latest RBE build (whichever is newer),
+   * unless that build's exact digest is already on the simulator.
    */
   attachSimulator: (
     simulator: IosInstance | { apiUrl: string; token: string },

--- a/tests/cli-rbe-bep-watcher.test.ts
+++ b/tests/cli-rbe-bep-watcher.test.ts
@@ -1,0 +1,233 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { XcodeClient } from '@limrun/api';
+import { startBepWatcher } from '../packages/cli/src/lib/rbe-bep-watcher';
+
+// Build a fully-flushed BEP for one build: started(uuid) -> namedSetOfFiles(.ipa)
+// -> successful targetCompleted -> buildFinished -> lastMessage. `hash` controls
+// the .ipa CAS digest so we can simulate edit/revert rebuilds.
+function completedBep(opts: { invocation: string; hash: string; label?: string; success?: boolean }): string {
+  const label = opts.label ?? '//App:App';
+  const uri = `bytestream://127.0.0.1:8980/blobs/${opts.hash}/1024`;
+  return [
+    { started: { uuid: opts.invocation } },
+    { id: { namedSet: { id: '0' } }, namedSetOfFiles: { files: [{ name: 'App/App.ipa', uri }] } },
+    {
+      id: { targetCompleted: { label } },
+      completed: { success: true, outputGroup: [{ name: 'default', fileSets: [{ id: '0' }] }] },
+    },
+    { id: { buildFinished: {} }, finished: { overallSuccess: opts.success ?? true } },
+    { id: { buildMetrics: {} }, lastMessage: true },
+  ]
+    .map((e) => JSON.stringify(e))
+    .join('\n');
+}
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+
+function fakeClient(calls: string[], result?: { installed?: boolean }): XcodeClient {
+  return {
+    installRbeBuildFromBep: async (opts: { bep: string; target: string }) => {
+      // Parse the hash out of the bep the watcher passed, to assert it forwards
+      // the right build.
+      const m = opts.bep.match(/\/blobs\/([0-9a-f]+)\//);
+      calls.push(m?.[1] ?? '');
+      return {
+        installed: result?.installed ?? true,
+        ipaName: 'App/App.ipa',
+      };
+    },
+  } as unknown as XcodeClient;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+function setupWorkspace(): { root: string; bepPath: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rbe-watcher-'));
+  const dir = path.join(root, '.limrun');
+  fs.mkdirSync(dir, { recursive: true });
+  return { root, bepPath: path.join(dir, 'bep.json') };
+}
+
+const fast = { debounceMs: 20, pollIntervalMs: 30 };
+
+describe('startBepWatcher', () => {
+  test('installs a completed build, dedupes the same invocation, re-installs a reverted digest', async () => {
+    const { root, bepPath } = setupWorkspace();
+    const calls: string[] = [];
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => fakeClient(calls),
+      log: () => {},
+      ...fast,
+    });
+    try {
+      // Build A -> one install carrying digest A.
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
+      await waitFor(() => calls.length === 1);
+      expect(calls[0]).toBe(HASH_A);
+
+      // Re-touch the same invocation: no new install (dedup on invocation id).
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
+      await new Promise((r) => setTimeout(r, 150));
+      expect(calls.length).toBe(1);
+
+      // Edit -> build B (new invocation, new digest).
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-2', hash: HASH_B }));
+      await waitFor(() => calls.length === 2);
+      expect(calls[1]).toBe(HASH_B);
+
+      // git stash + rebuild: new invocation, digest reverts to A. The watcher acts
+      // because the invocation id is new, even though the digest equals an earlier one.
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-3', hash: HASH_A }));
+      await waitFor(() => calls.length === 3);
+      expect(calls[2]).toBe(HASH_A);
+    } finally {
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('watches a custom bep path outside .limrun', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rbe-watcher-'));
+    const customDir = path.join(root, 'out', 'events');
+    fs.mkdirSync(customDir, { recursive: true });
+    const bepPath = path.join(customDir, 'build_events.json'); // non-default dir AND filename
+    const calls: string[] = [];
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => fakeClient(calls),
+      log: () => {},
+      ...fast,
+    });
+    try {
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
+      await waitFor(() => calls.length === 1);
+      expect(calls[0]).toBe(HASH_A);
+    } finally {
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('does not install a failed build', async () => {
+    const { root, bepPath } = setupWorkspace();
+    const calls: string[] = [];
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => fakeClient(calls),
+      log: () => {},
+      ...fast,
+    });
+    try {
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A, success: false }));
+      await new Promise((r) => setTimeout(r, 200));
+      expect(calls.length).toBe(0);
+    } finally {
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('gates on lastMessage: a parseable-but-not-flushed BEP does not install until terminal', async () => {
+    const { root, bepPath } = setupWorkspace();
+    const calls: string[] = [];
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => fakeClient(calls),
+      log: () => {},
+      ...fast,
+    });
+    try {
+      // A complete build minus the terminal lastMessage line (digest already parseable).
+      const full = completedBep({ invocation: 'inv-1', hash: HASH_A });
+      const withoutLast = full.split('\n').slice(0, -1).join('\n');
+      fs.writeFileSync(bepPath, withoutLast);
+      await new Promise((r) => setTimeout(r, 200));
+      expect(calls.length).toBe(0); // not flushed -> must not act
+      fs.writeFileSync(bepPath, full); // lastMessage arrives
+      await waitFor(() => calls.length === 1);
+      expect(calls[0]).toBe(HASH_A);
+    } finally {
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('does not latch auth off on a 5xx whose body merely contains 401', async () => {
+    const { root, bepPath } = setupWorkspace();
+    let attempt = 0;
+    const calls: string[] = [];
+    // First install throws a 502 whose body text contains "401"; it must be treated
+    // as transient (not an auth latch), so a later build still installs.
+    const client = {
+      installRbeBuildFromBep: async (opts: { bep: string; target: string }) => {
+        attempt++;
+        if (attempt === 1) throw new Error('POST /rbe/install failed: 502 upstream {"traceId":"7f-401-bad"}');
+        const m = opts.bep.match(/\/blobs\/([0-9a-f]+)\//);
+        calls.push(m?.[1] ?? '');
+        return { installed: true, ipaName: 'App/App.ipa' };
+      },
+    } as unknown as XcodeClient;
+    const watcher = startBepWatcher({ bepPath, target: '//App:App', getClient: () => client, log: () => {}, ...fast });
+    try {
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
+      await new Promise((r) => setTimeout(r, 200)); // first attempt throws the 502-with-401
+      // A later build must still install — proving the 502 did NOT latch auth off.
+      // (We assert on the new digest rather than call count: a transient failure
+      // isn't marked handled, so inv-1 may be retried by a second trigger.)
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-2', hash: HASH_B }));
+      await waitFor(() => calls.includes(HASH_B));
+      expect(attempt).toBeGreaterThanOrEqual(2);
+    } finally {
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('close() awaits an in-flight install and does not double-fire a queued build', async () => {
+    const { root, bepPath } = setupWorkspace();
+    const calls: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const client = {
+      installRbeBuildFromBep: async (opts: { bep: string; target: string }) => {
+        const m = opts.bep.match(/\/blobs\/([0-9a-f]+)\//);
+        calls.push(m?.[1] ?? '');
+        await gate; // block the first install in-flight
+        return { installed: true, ipaName: 'App/App.ipa' };
+      },
+    } as unknown as XcodeClient;
+    const watcher = startBepWatcher({ bepPath, target: '//App:App', getClient: () => client, log: () => {}, ...fast });
+    try {
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
+      await waitFor(() => calls.length === 1); // install A is now in-flight, blocked on the gate
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-2', hash: HASH_B })); // queue B while closing
+      let closed = false;
+      const closing = watcher.close().then(() => (closed = true));
+      await new Promise((r) => setTimeout(r, 100));
+      expect(closed).toBe(false); // close() must await the in-flight install
+      release();
+      await closing;
+      expect(closed).toBe(true);
+      await new Promise((r) => setTimeout(r, 100));
+      expect(calls).toEqual([HASH_A]); // B must NOT fire after close()
+    } finally {
+      release();
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-rbe-bep-watcher.test.ts
+++ b/tests/cli-rbe-bep-watcher.test.ts
@@ -140,6 +140,75 @@ describe('startBepWatcher', () => {
     }
   });
 
+  test('retries a transient install failure and eventually installs the same build', async () => {
+    const { root, bepPath } = setupWorkspace();
+    let attempt = 0;
+    const calls: string[] = [];
+    const client = {
+      installRbeBuildFromBep: async (opts: { bep: string; target: string }) => {
+        attempt++;
+        if (attempt < 3) throw new Error('POST /rbe/install failed: 503 instance warming up');
+        const m = opts.bep.match(/\/blobs\/([0-9a-f]+)\//);
+        calls.push(m?.[1] ?? '');
+        return { installed: true, ipaName: 'App/App.ipa' };
+      },
+    } as unknown as XcodeClient;
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => client,
+      log: () => {},
+      debounceMs: 20,
+      pollIntervalMs: 5000, // keep the poll out of the way; retries drive this
+      retryDelayMs: 30,
+      maxRetries: 5,
+    });
+    try {
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
+      // No new build is written; the same build must be retried until it installs.
+      await waitFor(() => calls.length === 1);
+      expect(calls[0]).toBe(HASH_A);
+      expect(attempt).toBeGreaterThanOrEqual(3);
+    } finally {
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('gives up after maxRetries transient failures (bounded, no infinite retry)', async () => {
+    const { root, bepPath } = setupWorkspace();
+    let attempt = 0;
+    const calls: string[] = [];
+    const logs: string[] = [];
+    const client = {
+      installRbeBuildFromBep: async () => {
+        attempt++;
+        throw new Error('POST /rbe/install failed: 503 still down');
+      },
+    } as unknown as XcodeClient;
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => client,
+      log: (m) => logs.push(m),
+      debounceMs: 20,
+      pollIntervalMs: 5000,
+      retryDelayMs: 20,
+      maxRetries: 2,
+    });
+    try {
+      fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
+      await waitFor(() => logs.some((l) => /gave up/.test(l)));
+      const settled = attempt; // initial + maxRetries
+      await new Promise((r) => setTimeout(r, 120));
+      expect(attempt).toBe(settled); // bounded — no further retries after giving up
+      expect(calls.length).toBe(0);
+    } finally {
+      await watcher.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('gates on lastMessage: a parseable-but-not-flushed BEP does not install until terminal', async () => {
     const { root, bepPath } = setupWorkspace();
     const calls: string[] = [];
@@ -181,7 +250,13 @@ describe('startBepWatcher', () => {
         return { installed: true, ipaName: 'App/App.ipa' };
       },
     } as unknown as XcodeClient;
-    const watcher = startBepWatcher({ bepPath, target: '//App:App', getClient: () => client, log: () => {}, ...fast });
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => client,
+      log: () => {},
+      ...fast,
+    });
     try {
       fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
       await new Promise((r) => setTimeout(r, 200)); // first attempt throws the 502-with-401
@@ -210,7 +285,13 @@ describe('startBepWatcher', () => {
         return { installed: true, ipaName: 'App/App.ipa' };
       },
     } as unknown as XcodeClient;
-    const watcher = startBepWatcher({ bepPath, target: '//App:App', getClient: () => client, log: () => {}, ...fast });
+    const watcher = startBepWatcher({
+      bepPath,
+      target: '//App:App',
+      getClient: () => client,
+      log: () => {},
+      ...fast,
+    });
     try {
       fs.writeFileSync(bepPath, completedBep({ invocation: 'inv-1', hash: HASH_A }));
       await waitFor(() => calls.length === 1); // install A is now in-flight, blocked on the gate

--- a/tests/cli-rbe-session.test.ts
+++ b/tests/cli-rbe-session.test.ts
@@ -140,6 +140,22 @@ describe('buildServeChildArgs', () => {
       '--api-key',
     );
   });
+
+  test('passes the watcher workspace/target/bep-file through for the auto-install daemon', () => {
+    const args = buildServeChildArgs({
+      scriptPath: '/bin/lim',
+      id: 'xc_1',
+      port: 8980,
+      workspaceRoot: '/ws',
+      target: '//App:App',
+      bepFile: '/ws/build/bep.json',
+    });
+    expect(args).toEqual(
+      expect.arrayContaining(['--workspace-root', '/ws', '--target', '//App:App', '--bep-file', '/ws/build/bep.json']),
+    );
+    // Omitted when not auto-installing.
+    expect(buildServeChildArgs({ scriptPath: '/bin/lim', id: 'xc_1', port: 8980 })).not.toContain('--bep-file');
+  });
 });
 
 describe('rbe pidfile helpers', () => {

--- a/tests/cli-rbe-session.test.ts
+++ b/tests/cli-rbe-session.test.ts
@@ -151,10 +151,19 @@ describe('buildServeChildArgs', () => {
       bepFile: '/ws/build/bep.json',
     });
     expect(args).toEqual(
-      expect.arrayContaining(['--workspace-root', '/ws', '--target', '//App:App', '--bep-file', '/ws/build/bep.json']),
+      expect.arrayContaining([
+        '--workspace-root',
+        '/ws',
+        '--target',
+        '//App:App',
+        '--bep-file',
+        '/ws/build/bep.json',
+      ]),
     );
     // Omitted when not auto-installing.
-    expect(buildServeChildArgs({ scriptPath: '/bin/lim', id: 'xc_1', port: 8980 })).not.toContain('--bep-file');
+    expect(buildServeChildArgs({ scriptPath: '/bin/lim', id: 'xc_1', port: 8980 })).not.toContain(
+      '--bep-file',
+    );
   });
 });
 

--- a/tests/cli-rbe-workspace.test.ts
+++ b/tests/cli-rbe-workspace.test.ts
@@ -287,6 +287,16 @@ describe('rbe workspace generation', () => {
       expect(rc).not.toContain('%workspace%');
     });
 
+    test('writeRbeWorkspaceFiles honors a custom bep path and creates its parent dir', () => {
+      const customBep = path.join(dir, 'out', 'events', 'bep.json');
+      const result = writeRbeWorkspaceFiles(dir, '26.4.0.17E192', 8980, customBep);
+      const rc = fs.readFileSync(result.bazelrcFragment, 'utf8');
+      expect(rc).toContain(`--build_event_json_file=${customBep}`);
+      expect(rc).not.toContain(path.join(dir, '.limrun', 'bep.json'));
+      // The parent of a custom path is created so bazel can write there.
+      expect(fs.existsSync(path.dirname(customBep))).toBe(true);
+    });
+
     test('writeRbeWorkspaceFiles emits apple_support loads only on Bazel 9+ (per .bazelversion)', () => {
       fs.writeFileSync(path.join(dir, '.bazelversion'), '9.1.1\n');
       const r9 = writeRbeWorkspaceFiles(dir, '26.4.0.17E192', 8980);

--- a/tests/rbe-bep.test.ts
+++ b/tests/rbe-bep.test.ts
@@ -1,4 +1,4 @@
-import { parseTopLevelIpaDigest } from '@limrun/api';
+import { parseTopLevelIpaDigest, inspectBuildCompletion, RbeBepError } from '@limrun/api';
 
 // A minimal BEP stream mirroring the validated shape:
 // targetCompleted{label} -> outputGroup "default" -> fileSet id -> namedSet ->
@@ -99,5 +99,108 @@ describe('parseTopLevelIpaDigest', () => {
       .join('\n');
     const d = parseTopLevelIpaDigest(nested, '//App:App');
     expect(d.sizeBytes).toBe(40960);
+  });
+
+  test('classifies BLAKE3 and local-only as terminal, missing target as transient', () => {
+    const blake3 = bep('bytestream://127.0.0.1:8980/blobs/abcabcabcabcabcabcabcabcabcabcab/40960');
+    try {
+      parseTopLevelIpaDigest(blake3, '//App:App');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(RbeBepError);
+      expect((err as RbeBepError).kind).toBe('non-sha256');
+      expect((err as RbeBepError).terminal).toBe(true);
+    }
+    try {
+      parseTopLevelIpaDigest(bep('file:///tmp/App.ipa'), '//App:App');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as RbeBepError).kind).toBe('local-only');
+      expect((err as RbeBepError).terminal).toBe(true);
+    }
+    try {
+      parseTopLevelIpaDigest(bep(REMOTE_URI, '//App:App'), '//Other');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as RbeBepError).kind).toBe('no-build');
+      expect((err as RbeBepError).terminal).toBe(false);
+    }
+  });
+});
+
+describe('inspectBuildCompletion', () => {
+  // The terminal BEP order is buildFinished -> buildToolLogs -> buildMetrics(lastMessage),
+  // so completion gates on lastMessage, not on buildFinished being the last line.
+  const stream = (events: object[]) => events.map((e) => JSON.stringify(e)).join('\n');
+
+  test('is incomplete until the lastMessage event is flushed', () => {
+    const midBuild = stream([
+      { started: { uuid: 'inv-1' } },
+      { id: { targetCompleted: { label: '//App:App' } }, completed: { success: true } },
+      { id: { buildFinished: {} }, finished: { overallSuccess: true } },
+    ]);
+    const r = inspectBuildCompletion(midBuild);
+    expect(r.complete).toBe(false);
+    expect(r.invocationId).toBe('inv-1');
+  });
+
+  test('reports complete + success once lastMessage arrives after buildFinished', () => {
+    const done = stream([
+      { started: { uuid: 'inv-2' } },
+      { id: { buildFinished: {} }, finished: { overallSuccess: true } },
+      { id: { buildToolLogs: {} } },
+      { id: { buildMetrics: {} }, lastMessage: true },
+    ]);
+    const r = inspectBuildCompletion(done);
+    expect(r.complete).toBe(true);
+    expect(r.success).toBe(true);
+    expect(r.invocationId).toBe('inv-2');
+  });
+
+  test('reports a failed build as not successful', () => {
+    const failed = stream([
+      { started: { uuid: 'inv-3' } },
+      { id: { buildFinished: {} }, finished: { overallSuccess: false, exitCode: { code: 1 } } },
+      { id: { buildMetrics: {} }, lastMessage: true },
+    ]);
+    const r = inspectBuildCompletion(failed);
+    expect(r.complete).toBe(true);
+    expect(r.success).toBe(false);
+  });
+
+  test('reports success via the exit code name when overallSuccess is absent (proto3 omits it)', () => {
+    const done = [
+      { started: { uuid: 'inv-x' } },
+      { id: { buildFinished: {} }, finished: { exitCode: { name: 'SUCCESS' } } },
+      { id: { buildMetrics: {} }, lastMessage: true },
+    ]
+      .map((e) => JSON.stringify(e))
+      .join('\n');
+    const r = inspectBuildCompletion(done);
+    expect(r.complete).toBe(true);
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('parseTopLevelIpaDigest BLAKE3 handling', () => {
+  test('rejects a BLAKE3 build (function segment in the bytestream URI) with the sha256 fix', () => {
+    // Bazel 9 default: /blobs/blake3/<64hex>/<size>. The 64-hex hash is
+    // indistinguishable from sha256 by length, so the function segment is what
+    // catches it.
+    const blake3Hash = 'b'.repeat(64);
+    const blake3 = bep(`bytestream://127.0.0.1:8980/blobs/blake3/${blake3Hash}/40960`);
+    try {
+      parseTopLevelIpaDigest(blake3, '//App:App');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(RbeBepError);
+      expect((err as RbeBepError).kind).toBe('non-sha256');
+      expect((err as Error).message).toMatch(/--digest_function=sha256/);
+    }
+  });
+
+  test('still resolves the plain sha256 URI shape (no function segment)', () => {
+    const d = parseTopLevelIpaDigest(bep(REMOTE_URI), '//App:App');
+    expect(d.hash).toBe('deadbeefcafe0000111122223333444455556666777788889999aaaabbbbcccc');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the long-lived RBE daemon (watcher, retries, process handlers) and the install path after remote builds; failures are mostly logged rather than fatal, but a buggy watcher could still affect tunnel reliability.
> 
> **Overview**
> Adds **auto-install** to `lim xcode rbe`: while the RBE tunnel runs (foreground or background daemon), a new BEP watcher reacts to each **successful, fully flushed** Bazel build and calls `installRbeBuildFromBep` so the `.ipa` lands on the attached simulator (or is recorded for a later attach). **`--auto-install`** is on by default; **`--no-auto-install`**, **`--target`**, and **`--bep-file`** control behavior when inference or paths are ambiguous.
> 
> The detached **`--serve`** child gets **`--workspace-root` / `--target` / `--bep-file`** via `buildServeChildArgs`, starts the watcher when auto-install is enabled, and uses **crash guards** so watcher faults do not drop the tunnel mid-build. Watcher teardown runs **before** tunnel/stack shutdown to avoid racing installs.
> 
> **BEP handling** is centralized: `defaultBepPath` / `resolveBepPath`, generated bazelrc honors a custom log path, and **`.limrun/rbe.pid`** stores `bepFile` (and `target` when watching) so **`lim xcode rbe install`** picks the same log. The SDK gains **`inspectBuildCompletion`**, typed **`RbeBepError`**, and stricter **BLAKE3 / non-SHA256** detection in bytestream URIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd349e53e00b5510c1f17057132e962ea39d23b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->