### PR TITLE
lim xcode rbe: skip post-create validation get to fix read-after-create 404

### DIFF
--- a/packages/cli/src/commands/xcode/rbe.ts
+++ b/packages/cli/src/commands/xcode/rbe.ts
@@ -213,9 +213,13 @@ export default class XcodeRbe extends BaseCommand {
 
         // resolveXcodeClient validates an iOS-backed target via iosInstances.get,
         // but a cached standalone Xcode target is trusted without a round-trip.
-        // Validate it so a deleted instance throws NotFoundError here (→ withAuth
-        // clears the cache and recreates) rather than a misleading /rbe 404.
-        if (typeof target !== 'string' && target.type === 'xcode') {
+        // Validate it so a stale "last instance" pointer or a deleted instance throws
+        // NotFoundError here (→ withAuth clears the cache and recreates) rather than a
+        // misleading /rbe 404. Skip an instance we created this run: create({wait:true})
+        // already proved it exists, and get() reads the central read-model that the region
+        // populates asynchronously, so validating it here would race that lag and tear down
+        // a live session for nothing.
+        if (typeof target !== 'string' && target.type === 'xcode' && !this.wasCreatedThisRun(instanceId)) {
           await this.client.xcodeInstances.get(instanceId);
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow change to RBE startup validation only; reuses existing `wasCreatedThisRun` tracking with no auth or API contract changes.
> 
> **Overview**
> **`lim xcode rbe`** still calls **`xcodeInstances.get`** for cached standalone Xcode targets so stale or deleted instances fail early with **NotFoundError** instead of a confusing **`/rbe` 404**.
> 
> The change **skips that `get` when the instance was auto-created in the same invocation** (`wasCreatedThisRun`). **`create({ wait: true })`** already confirms the instance exists; an immediate **`get`** can hit the central read-model before the region catches up and falsely 404, which would trigger cache clear/recreate and kill a healthy new session.
> 
> Comments now spell out that race and the stale last-instance case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1094f871736dcf7fe0241fc522e683755e9a985a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->