### PR TITLE
Thread asset TTL through getOrUpload helper and CLI

### DIFF
--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -64,6 +64,10 @@ export default class AndroidCreate extends BaseCommand {
         'Local app file to upload and install automatically after creation. Repeat for multiple files.',
       multiple: true,
     }),
+    'asset-ttl': Flags.string({
+      description:
+        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. Defaults to no expiry.',
+    }),
   };
 
   async run(): Promise<void> {
@@ -78,7 +82,11 @@ export default class AndroidCreate extends BaseCommand {
           const resolved = path.resolve(filePath);
           const name = path.basename(resolved);
           this.info(`Uploading ${name}...`);
-          const asset = await this.client.assets.getOrUpload({ path: resolved, name });
+          const asset = await this.client.assets.getOrUpload({
+            path: resolved,
+            name,
+            ttl: flags['asset-ttl'],
+          });
           assetNames.push(asset.name);
         }
         this.info(`Successfully uploaded ${flags.install.length} file(s)`);

--- a/packages/cli/src/commands/android/install-app.ts
+++ b/packages/cli/src/commands/android/install-app.ts
@@ -31,6 +31,10 @@ export default class AndroidInstallApp extends BaseCommand {
       description:
         'Android instance ID to install the app on. Defaults to the last created Android instance.',
     }),
+    'asset-ttl': Flags.string({
+      description:
+        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+    }),
   };
 
   async run(): Promise<void> {
@@ -54,7 +58,7 @@ export default class AndroidInstallApp extends BaseCommand {
         }
         const name = path.basename(filePath);
         this.info(`Uploading ${name}...`);
-        const asset = await this.client.assets.getOrUpload({ path: filePath, name });
+        const asset = await this.client.assets.getOrUpload({ path: filePath, name, ttl: flags['asset-ttl'] });
         downloadUrl = asset.signedDownloadUrl;
       }
 

--- a/packages/cli/src/commands/asset/list.ts
+++ b/packages/cli/src/commands/asset/list.ts
@@ -53,8 +53,8 @@ export default class AssetList extends BaseCommand {
           this.outputJson(asset);
           return;
         }
-        const headers = ['ID', 'Name', 'MD5'];
-        const row = [asset.id, asset.name, asset.md5 || ''];
+        const headers = ['ID', 'Name', 'MD5', 'Expires At'];
+        const row = [asset.id, asset.name, asset.md5 || '', asset.expiresAt || ''];
         if (flags['download-url']) {
           headers.push('Download URL');
           row.push(asset.signedDownloadUrl || '');
@@ -76,12 +76,12 @@ export default class AssetList extends BaseCommand {
       if (flags['name-prefix']) params.namePrefixFilter = flags['name-prefix'];
 
       const assets = await this.client.assets.list(params as any);
-      const headers = ['ID', 'Name', 'MD5'];
+      const headers = ['ID', 'Name', 'MD5', 'Expires At'];
       if (flags['download-url']) headers.push('Download URL');
       if (flags['upload-url']) headers.push('Upload URL');
 
       const rows = (assets as any[]).map((a: any) => {
-        const row = [a.id, a.name, a.md5 || ''];
+        const row = [a.id, a.name, a.md5 || '', a.expiresAt || ''];
         if (flags['download-url']) row.push(a.signedDownloadUrl || '');
         if (flags['upload-url']) row.push(a.signedUploadUrl || '');
         return row;

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -10,6 +10,7 @@ export default class AssetPush extends BaseCommand {
   static examples = [
     '<%= config.bin %> asset push ./app.apk',
     '<%= config.bin %> asset push ./app.ipa -n my-app',
+    '<%= config.bin %> asset push ./app.ipa --ttl 24h',
   ];
 
   static args = {
@@ -19,6 +20,9 @@ export default class AssetPush extends BaseCommand {
   static flags = {
     ...BaseCommand.baseFlags,
     name: Flags.string({ char: 'n', description: 'Asset name to store. Defaults to the source filename.' }),
+    ttl: Flags.string({
+      description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+    }),
   };
 
   async run(): Promise<void> {
@@ -37,9 +41,13 @@ export default class AssetPush extends BaseCommand {
       const asset = await this.client.assets.getOrUpload({
         path: filePath,
         name: assetName,
+        ttl: flags.ttl,
       });
 
       this.output(`ID: ${asset.id}`);
+      if (asset.expiresAt) {
+        this.output(`Expires At: ${asset.expiresAt}`);
+      }
     });
   }
 }

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -64,6 +64,10 @@ export default class IosCreate extends BaseCommand {
         'Local app file to upload and install automatically after creation. Repeat for multiple files.',
       multiple: true,
     }),
+    'asset-ttl': Flags.string({
+      description:
+        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. Defaults to no expiry.',
+    }),
     xcode: Flags.boolean({
       description: 'Enable an attached Xcode sandbox for build and sync workflows',
       default: false,
@@ -99,7 +103,11 @@ export default class IosCreate extends BaseCommand {
           const resolved = path.resolve(filePath);
           const name = path.basename(resolved);
           this.info(`Uploading ${name}...`);
-          const asset = await this.client.assets.getOrUpload({ path: resolved, name });
+          const asset = await this.client.assets.getOrUpload({
+            path: resolved,
+            name,
+            ttl: flags['asset-ttl'],
+          });
           assetNames.push(asset.name);
         }
         this.info(`Successfully uploaded ${flags.install.length} file(s)`);

--- a/packages/cli/src/commands/ios/install-app.ts
+++ b/packages/cli/src/commands/ios/install-app.ts
@@ -40,6 +40,10 @@ export default class IosInstallApp extends BaseCommand {
       description: 'Launch behavior after installation. Omit to install without launching.',
       options: ['ForegroundIfRunning', 'RelaunchIfRunning'],
     }),
+    'asset-ttl': Flags.string({
+      description:
+        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+    }),
   };
 
   async run(): Promise<void> {
@@ -63,7 +67,7 @@ export default class IosInstallApp extends BaseCommand {
         }
         const name = path.basename(filePath);
         this.info(`Uploading ${name}...`);
-        const asset = await this.client.assets.getOrUpload({ path: filePath, name });
+        const asset = await this.client.assets.getOrUpload({ path: filePath, name, ttl: flags['asset-ttl'] });
         downloadUrl = asset.signedDownloadUrl;
       }
 

--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -16,6 +16,13 @@ export interface AssetGetOrUploadParams {
    * The name for the asset. Defaults to the name of the file given in the filePath parameter.
    */
   name?: string;
+
+  /**
+   * Optional time-to-live as a Go duration string (e.g. "24h"). When set, the asset is deleted
+   * this long after now; minimum is 1m. Omit for no expiry. On re-upload of an existing asset,
+   * a value updates the expiry while omitting it leaves the current expiry unchanged.
+   */
+  ttl?: string;
 }
 
 export interface AssetGetOrUploadResponse {
@@ -23,6 +30,7 @@ export interface AssetGetOrUploadResponse {
   name: string;
   signedDownloadUrl: string;
   md5: string;
+  expiresAt?: string;
 }
 
 export class Assets extends GeneratedAssets {
@@ -33,6 +41,7 @@ export class Assets extends GeneratedAssets {
     const creationResponse = await this.getOrCreate(
       {
         name: body.name ?? basename(body.path),
+        ...(body.ttl && { ttl: body.ttl }),
       },
       options,
     );
@@ -44,6 +53,7 @@ export class Assets extends GeneratedAssets {
         name: creationResponse.name,
         signedDownloadUrl: creationResponse.signedDownloadUrl,
         md5: creationResponse.md5,
+        ...(creationResponse.expiresAt && { expiresAt: creationResponse.expiresAt }),
       };
     }
     const uploadResponse = await nodeProxyTransport.fetch(creationResponse.signedUploadUrl, {
@@ -62,6 +72,7 @@ export class Assets extends GeneratedAssets {
       name: creationResponse.name,
       signedDownloadUrl: creationResponse.signedDownloadUrl,
       md5,
+      ...(creationResponse.expiresAt && { expiresAt: creationResponse.expiresAt }),
     };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive CLI/SDK options and display fields; no changes to auth or instance lifecycle beyond passing TTL to existing asset APIs.
> 
> **Overview**
> Adds optional **asset expiration** when uploading files: callers can set a Go-style duration so uploaded assets are deleted automatically after that period (default remains no expiry).
> 
> The SDK **`assets.getOrUpload`** helper now accepts optional `ttl`, forwards it to **`getOrCreate`**, and surfaces **`expiresAt`** on the response when the API provides it.
> 
> CLI coverage: **`asset push --ttl`**, **`asset list`** tables include an **Expires At** column, and **`--asset-ttl`** on Android/iOS **`create`** (only for `--install` uploads) and **`install-app`** (local file path uploads only—not remote URLs or `--install-asset`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c40ecd6ffe5d6e7508de17a09770cda68397f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->