### PR TITLE
ui: distinguish terminated instances from connection drops

### DIFF
--- a/packages/ui/src/components/remote-control.css
+++ b/packages/ui/src/components/remote-control.css
@@ -97,3 +97,35 @@
   outline: 2px solid #2563eb;
   outline-offset: 2px;
 }
+
+.rc-terminated {
+  position: absolute;
+  z-index: 50;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  max-width: 240px;
+  padding: 12px 18px;
+  border-radius: 16px;
+  text-align: center;
+  font: inherit;
+  background: rgba(255, 255, 255, 0.92);
+  color: #111827;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.rc-terminated-title {
+  font: inherit;
+  font-weight: 600;
+}
+
+.rc-terminated-message {
+  font: inherit;
+  font-size: 0.8125rem;
+  line-height: 1.3;
+  color: #6b7280;
+}

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -60,6 +60,19 @@ interface RemoteControlProps {
   autoReconnect?: boolean;
 
   /**
+   * Fires once when the component concludes the instance is permanently
+   * gone rather than suffering a recoverable connection blip.
+   *
+   * After a drop, the component probes the instance endpoint over HTTP;
+   * a 404 means the instance no longer exists (terminated/deleted). When
+   * that happens the component stops reconnecting and renders a built-in
+   * "terminated" message in place of the "Retry" button, and invokes this
+   * callback so the host can react (navigate away, surface its own UI,
+   * etc.). It is not called for ordinary network drops.
+   */
+  onTerminated?: () => void;
+
+  /**
    * Enable the inspect overlay. When set, the component starts polling the
    * accessibility tree and draws boxes over each element on top of the
    * video stream.
@@ -254,6 +267,9 @@ const MAX_CONNECTION_ATTEMPTS = 3;
 const CONNECTION_RETRY_DELAY_MS = 1000;
 const CONNECTION_SUCCESS_TIMEOUT_MS = 15000;
 const ICE_DISCONNECTED_GRACE_MS = 3000;
+// Upper bound for the one-shot HTTP probe that disambiguates a terminated
+// instance (endpoint 404s) from a transient connection drop.
+const TERMINATION_PROBE_TIMEOUT_MS = 4000;
 
 const isAndroidTabletVideo = (width: number, height: number): boolean =>
   (width === ANDROID_TABLET_VIDEO_WIDTH && height === ANDROID_TABLET_VIDEO_HEIGHT) ||
@@ -332,6 +348,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       openUrl,
       showFrame = true,
       autoReconnect = false,
+      onTerminated,
       inspectMode,
       onAxSnapshotChange,
       onInspectSelectionChange,
@@ -346,6 +363,13 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     const frameRef = useRef<HTMLImageElement>(null);
     const [videoLoaded, setVideoLoaded] = useState(false);
     const [retryExhausted, setRetryExhausted] = useState(false);
+    // Set once we've concluded the instance is permanently gone (its
+    // endpoint 404s after a drop), as opposed to a recoverable blip. When
+    // set, reconnection stops and a terminated message replaces "Retry".
+    const [terminated, setTerminated] = useState(false);
+    const terminatedRef = useRef(false);
+    // Guards against firing overlapping termination probes.
+    const terminationProbeInFlightRef = useRef(false);
     const [isLandscape, setIsLandscape] = useState(false);
     const [useAndroidTabletFrame, setUseAndroidTabletFrame] = useState(false);
     const [videoStyle, setVideoStyle] = useState<React.CSSProperties>({});
@@ -463,6 +487,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     onInspectSelectionChangeRef.current = onInspectSelectionChange;
     const onAxStatusChangeRef = useRef(onAxStatusChange);
     onAxStatusChangeRef.current = onAxStatusChange;
+    const onTerminatedRef = useRef(onTerminated);
+    onTerminatedRef.current = onTerminated;
 
     const inspectActive = inspectMode === true || inspectMode === 'hover-only';
     const inspectModeResolved: InspectMode = inspectMode === 'hover-only' ? 'hover-only' : 'select';
@@ -1485,10 +1511,91 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       }
     };
 
+    // Probe the instance endpoint over HTTP to tell a permanent termination
+    // apart from a recoverable connection drop. The router serves the same
+    // path the WebSocket uses and returns 404 once the instance is gone
+    // (deleted / terminated), while a live instance returns something else.
+    //
+    // Only an authoritative, freshly-fetched 404 counts as terminated. A
+    // network outage, a non-404 status, or a CORS-blocked (unreadable)
+    // response all resolve to `false` so we keep the normal retry/reconnect
+    // behavior and never mistake a connectivity problem for a termination.
+    const probeTerminated = async (): Promise<boolean> => {
+      // The browser knows it has no network — this is a connectivity drop,
+      // not a termination. Don't probe (and don't risk a cached 404).
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        return false;
+      }
+      let probeUrl: string;
+      try {
+        const parsed = new URL(url);
+        parsed.protocol =
+          parsed.protocol === 'wss:' ? 'https:'
+          : parsed.protocol === 'ws:' ? 'http:'
+          : parsed.protocol;
+        parsed.searchParams.set('token', token);
+        probeUrl = parsed.toString();
+      } catch {
+        return false;
+      }
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), TERMINATION_PROBE_TIMEOUT_MS);
+      try {
+        // `no-store` so a prior response can't be served from the HTTP cache
+        // (e.g. a stale 404 returned while offline would look like a
+        // termination); the probe must always reach the live router.
+        const res = await fetch(probeUrl, { method: 'GET', cache: 'no-store', signal: controller.signal });
+        return res.status === 404;
+      } catch {
+        return false;
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    };
+
+    const markTerminated = () => {
+      if (terminatedRef.current) return;
+      terminatedRef.current = true;
+      setTerminated(true);
+      setRetryExhausted(false);
+      // Invalidate any in-flight/scheduled attempt and stop all activity so
+      // we don't keep hammering an endpoint that will never come back.
+      connectionGenerationRef.current += 1;
+      clearScheduledRetry();
+      clearConnectionSuccessTimeout();
+      clearIceDisconnectedGrace();
+      teardownConnection();
+      updateStatus('Instance terminated');
+      safeInvoke('onTerminated', onTerminatedRef.current);
+    };
+
+    // Run a one-shot termination check in reaction to a drop. Event-driven
+    // (no polling), deduped while one is already in flight, and a no-op once
+    // we've concluded the instance is gone.
+    const checkTerminated = () => {
+      if (terminatedRef.current || terminationProbeInFlightRef.current) return;
+      terminationProbeInFlightRef.current = true;
+      void probeTerminated().then((isTerminated) => {
+        terminationProbeInFlightRef.current = false;
+        if (isTerminated) {
+          markTerminated();
+        }
+      });
+    };
+
     const scheduleRetry = (reason: string, generation: number) => {
+      if (terminatedRef.current) {
+        return;
+      }
       if (generation !== connectionGenerationRef.current) {
         return;
       }
+
+      // A drop just happened. Find out whether the instance is gone for good
+      // (404) rather than a recoverable blip; if so the probe stops retries
+      // and surfaces the terminated message. Meanwhile the normal retry path
+      // below proceeds and is short-circuited once the verdict lands.
+      checkTerminated();
 
       if (controlChannelOpenedRef.current) {
         if (!autoReconnectRef.current) {
@@ -1525,6 +1632,9 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     };
 
     const startAttempt = async (attemptNumber = 0) => {
+      // Never reconnect to an instance we've concluded is gone. `start()`
+      // clears this when a deliberate fresh connection is requested.
+      if (terminatedRef.current) return;
       const generation = connectionGenerationRef.current + 1;
       connectionGenerationRef.current = generation;
       connectionAttemptRef.current = attemptNumber;
@@ -2041,6 +2151,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     };
 
     const start = () => {
+      // A fresh connection (mount, prop change, manual retry, reconnect())
+      // clears any prior terminated verdict so we re-evaluate from scratch.
+      terminatedRef.current = false;
+      setTerminated(false);
       void startAttempt(0);
     };
 
@@ -2567,11 +2681,19 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
             }}
           />
         )}
-        {retryExhausted && (
-          <button type="button" className="rc-retry-button" onClick={handleManualRetry}>
-            Retry
-          </button>
-        )}
+        {terminated ?
+          <div className="rc-terminated" role="status">
+            <div className="rc-terminated-title">Instance terminated</div>
+            <div className="rc-terminated-message">
+              This instance no longer exists and can&apos;t be reconnected.
+            </div>
+          </div>
+        : retryExhausted && (
+            <button type="button" className="rc-retry-button" onClick={handleManualRetry}>
+              Retry
+            </button>
+          )
+        }
       </div>
     );
   },


### PR DESCRIPTION
On a connection drop, RemoteControl probes the instance endpoint over HTTP. An authoritative 404 means the instance is gone, so it stops reconnecting and shows a built-in "Instance terminated" message in place of the Retry button, and fires the new optional onTerminated callback.

Network outages are never mistaken for termination: the probe bails when navigator.onLine is false and uses cache: no-store so a stale 404 can't be served from the HTTP cache while offline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebRTC reconnect behavior and adds an HTTP probe on every connection failure; mis-routed 404s could stop retries early, though the implementation deliberately avoids treating offline or cached responses as termination.
> 
> **Overview**
> **RemoteControl** now treats a dead instance differently from a flaky connection. After a drop, it issues a one-shot HTTP GET to the same path as the WebSocket (with token); only a fresh **404** is treated as permanent termination.
> 
> When terminated, reconnects and scheduled retries stop, the **Retry** button is replaced by a built-in **Instance terminated** message (new `.rc-terminated` styles), and the optional **`onTerminated`** callback runs once. **`start()`** / manual retry clears the terminated state so a new session can be attempted.
> 
> The probe skips work when **`navigator.onLine`** is false, uses **`cache: 'no-store'`**, and treats network errors and non-404 responses as recoverable so outages are not classified as termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7ed9e90d2bd952ea92ffeb0a8d3b880840aa46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->