### PR TITLE
ios: add support for ipa files for sync-app functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "proxy-from-env": "^2.1.0",
     "undici": "7.24.7",
     "ws": "^8.18.3",
-    "xdelta3-wasm": "^1.0.0"
+    "xdelta3-wasm": "^1.0.0",
+    "yauzl": "^3.4.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.0",
@@ -48,6 +49,7 @@
     "@types/node": "^20.17.6",
     "@types/proxy-from-env": "^1.0.4",
     "@types/ws": "^8.18.1",
+    "@types/yauzl": "^3.4.0",
     "@typescript-eslint/eslint-plugin": "8.31.1",
     "@typescript-eslint/parser": "8.31.1",
     "dotenv": "^17.4.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/ui",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "publishConfig": {
     "access": "public"
   },

--- a/src/app-archive.ts
+++ b/src/app-archive.ts
@@ -326,7 +326,7 @@ export function watchAppArchive(opts: {
   };
 
   const watcher = fs.watch(parentDir, (_eventType, filename) => {
-    if (!filename || filename.toString() === archiveBase) {
+    if (filename?.toString() === archiveBase) {
       schedule();
     }
   });

--- a/src/app-archive.ts
+++ b/src/app-archive.ts
@@ -144,24 +144,6 @@ function discoverPayloadApp(entries: yauzl.Entry[], archivePath: string): string
   return appName;
 }
 
-async function copyExtractedAppIntoStableRoot(stagingAppPath: string, appPath: string): Promise<void> {
-  await ensureDirectoryNotSymlink(appPath);
-  const existing = await fs.promises.readdir(appPath).catch((err: NodeJS.ErrnoException) => {
-    if (err.code === 'ENOENT') return [];
-    throw err;
-  });
-  await Promise.all(
-    existing.map((name) => fs.promises.rm(path.join(appPath, name), { recursive: true, force: true })),
-  );
-  await fs.promises.cp(stagingAppPath, appPath, {
-    recursive: true,
-    force: true,
-    errorOnExist: false,
-    dereference: false,
-    verbatimSymlinks: true,
-  });
-}
-
 async function extractEntry(
   zip: yauzl.ZipFile,
   entry: yauzl.Entry,
@@ -200,7 +182,6 @@ export async function extractAppArchiveToStablePath(archivePath: string): Promis
   const resolvedArchivePath = path.resolve(archivePath);
   const appPath = stableAppPath(resolvedArchivePath);
   const stableRoot = path.dirname(appPath);
-  const stagingRoot = path.join(stableRoot, `.staging-${process.pid}-${Date.now()}`);
 
   await ensureDirectoryNotSymlink(stableRoot);
   const zip = await openZip(resolvedArchivePath);
@@ -208,8 +189,8 @@ export async function extractAppArchiveToStablePath(archivePath: string): Promis
     const entries = await readEntries(zip);
     const appName = discoverPayloadApp(entries, resolvedArchivePath);
     const payloadPrefix = `Payload/${appName}/`;
-    const stagingAppPath = path.join(stagingRoot, path.basename(appPath));
-    await fs.promises.rm(stagingRoot, { recursive: true, force: true });
+    await fs.promises.rm(appPath, { recursive: true, force: true });
+    await ensureDirectoryNotSymlink(appPath);
 
     for (const entry of entries) {
       const name = toZipPath(entry.fileName);
@@ -218,14 +199,14 @@ export async function extractAppArchiveToStablePath(archivePath: string): Promis
       }
       const rel = name === `Payload/${appName}` ? '' : name.slice(payloadPrefix.length);
       if (rel === '') {
-        await fs.promises.mkdir(stagingAppPath, { recursive: true });
+        await fs.promises.mkdir(appPath, { recursive: true });
         continue;
       }
       if (isUnsafeZipPath(rel)) {
         throw new Error(`ZIP entry has an unsafe app-relative path: ${entry.fileName}`);
       }
-      const target = path.join(stagingAppPath, rel.split('/').join(path.sep));
-      const stagingAppResolved = path.resolve(stagingAppPath);
+      const target = path.join(appPath, rel.split('/').join(path.sep));
+      const stagingAppResolved = path.resolve(appPath);
       const targetResolved = path.resolve(target);
       if (
         targetResolved !== stagingAppResolved &&
@@ -233,10 +214,9 @@ export async function extractAppArchiveToStablePath(archivePath: string): Promis
       ) {
         throw new Error(`ZIP entry escapes app bundle: ${entry.fileName}`);
       }
-      await extractEntry(zip, entry, target, stagingAppPath);
+      await extractEntry(zip, entry, target, appPath);
     }
 
-    await copyExtractedAppIntoStableRoot(stagingAppPath, appPath);
     return {
       appPath,
       cacheIdentityPath: resolvedArchivePath,
@@ -245,7 +225,6 @@ export async function extractAppArchiveToStablePath(archivePath: string): Promis
     };
   } finally {
     zip.close();
-    await fs.promises.rm(stagingRoot, { recursive: true, force: true });
   }
 }
 
@@ -291,7 +270,11 @@ async function waitForStableArchiveFile(archivePath: string, shouldStop: () => b
   return false;
 }
 
-export function watchAppArchive(opts: { archivePath: string; log?: LogFn }): ArchiveWatcher {
+export function watchAppArchive(opts: {
+  archivePath: string;
+  log?: LogFn;
+  onExtracted?: () => void | Promise<void>;
+}): ArchiveWatcher {
   const archivePath = path.resolve(opts.archivePath);
   const log = opts.log ?? noopLogger;
   const parentDir = path.dirname(archivePath);
@@ -318,6 +301,7 @@ export function watchAppArchive(opts: { archivePath: string; log?: LogFn }): Arc
       }
       await extractAppArchiveToStablePath(archivePath);
       log('debug', `re-extracted ZIP/IPA archive: ${archivePath}`);
+      await opts.onExtracted?.();
     } catch (err) {
       log(
         'error',

--- a/src/app-archive.ts
+++ b/src/app-archive.ts
@@ -1,0 +1,324 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+import * as yauzl from 'yauzl';
+
+type LogFn = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
+
+export type PreparedAppBundle = {
+  appPath: string;
+  cacheIdentityPath: string;
+  isArchive: boolean;
+  archivePath?: string;
+};
+
+export type ArchiveWatcher = {
+  close: () => void;
+};
+
+const noopLogger: LogFn = () => {};
+
+function stableArchiveRoot(archivePath: string): string {
+  const resolved = path.resolve(archivePath);
+  const hash = crypto.createHash('sha1').update(resolved).digest('hex').slice(0, 12);
+  const base = path
+    .basename(resolved, path.extname(resolved))
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const safeBase = base === '' ? 'app' : base;
+  return path.join(os.tmpdir(), `limrun-sync-app-${safeBase}-${hash}`);
+}
+
+function stableAppPath(archivePath: string): string {
+  return path.join(stableArchiveRoot(archivePath), 'Extracted.app');
+}
+
+function toZipPath(name: string): string {
+  return name.replace(/\\/g, '/');
+}
+
+function isUnsafeZipPath(name: string): boolean {
+  if (name.includes('\0')) return true;
+  if (path.posix.isAbsolute(name)) return true;
+  return name.split('/').some((part) => part === '..');
+}
+
+function entryMode(entry: yauzl.Entry): number {
+  return (entry.externalFileAttributes >>> 16) & 0xffff;
+}
+
+function isSymlinkEntry(entry: yauzl.Entry): boolean {
+  return (entryMode(entry) & 0o170000) === 0o120000;
+}
+
+function isDirectoryEntry(entry: yauzl.Entry): boolean {
+  return entry.fileName.endsWith('/');
+}
+
+function entryPerm(entry: yauzl.Entry, fallback: number): number {
+  return entryMode(entry) & 0o7777 || fallback;
+}
+
+async function openZip(archivePath: string): Promise<yauzl.ZipFile> {
+  try {
+    return await yauzl.openPromise(archivePath, {
+      autoClose: false,
+      lazyEntries: true,
+      strictFileNames: true,
+      validateEntrySizes: true,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? `: ${err.message}` : '';
+    throw new Error(
+      `The path is not a valid app bundle directory or ZIP/IPA archive: ${archivePath}${message}`,
+    );
+  }
+}
+
+async function readEntries(zip: yauzl.ZipFile): Promise<yauzl.Entry[]> {
+  const entries: yauzl.Entry[] = [];
+  for await (const entry of zip.eachEntry()) {
+    entries.push(entry);
+  }
+  return entries;
+}
+
+async function ensureDirectoryNotSymlink(dir: string): Promise<void> {
+  const stat = await fs.promises.lstat(dir).catch((err: NodeJS.ErrnoException) => {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  });
+  if (stat && (!stat.isDirectory() || stat.isSymbolicLink())) {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+  await fs.promises.mkdir(dir, { recursive: true });
+}
+
+function discoverPayloadApp(entries: yauzl.Entry[], archivePath: string): string {
+  const appNames = new Set<string>();
+  const appsWithInfoPlist = new Set<string>();
+
+  for (const entry of entries) {
+    const name = toZipPath(entry.fileName);
+    if (isUnsafeZipPath(name)) {
+      throw new Error(`ZIP entry has an unsafe path: ${entry.fileName}`);
+    }
+    if (isDirectoryEntry(entry)) {
+      continue;
+    }
+    const rest = name.startsWith('Payload/') ? name.slice('Payload/'.length) : '';
+    if (rest === '') {
+      continue;
+    }
+    const [appName, ...parts] = rest.split('/');
+    if (!appName?.endsWith('.app')) {
+      continue;
+    }
+    appNames.add(appName);
+    if (parts.join('/') === 'Info.plist') {
+      appsWithInfoPlist.add(appName);
+    }
+  }
+
+  if (appNames.size === 0) {
+    throw new Error(`ZIP/IPA archive contains no Payload/*.app bundle: ${archivePath}`);
+  }
+  if (appNames.size > 1) {
+    throw new Error(
+      `ZIP/IPA archive contains more than one Payload/*.app bundle (${[...appNames].join(
+        ', ',
+      )}); expected exactly one`,
+    );
+  }
+
+  const appName = [...appNames][0]!;
+  if (!appsWithInfoPlist.has(appName)) {
+    throw new Error(`ZIP/IPA archive app bundle is missing Info.plist: Payload/${appName}/Info.plist`);
+  }
+  return appName;
+}
+
+async function copyExtractedAppIntoStableRoot(stagingAppPath: string, appPath: string): Promise<void> {
+  await ensureDirectoryNotSymlink(appPath);
+  const existing = await fs.promises.readdir(appPath).catch((err: NodeJS.ErrnoException) => {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  });
+  await Promise.all(
+    existing.map((name) => fs.promises.rm(path.join(appPath, name), { recursive: true, force: true })),
+  );
+  await fs.promises.cp(stagingAppPath, appPath, {
+    recursive: true,
+    force: true,
+    errorOnExist: false,
+    dereference: false,
+    verbatimSymlinks: true,
+  });
+}
+
+async function extractEntry(
+  zip: yauzl.ZipFile,
+  entry: yauzl.Entry,
+  target: string,
+  appRoot: string,
+): Promise<void> {
+  if (isDirectoryEntry(entry)) {
+    await fs.promises.mkdir(target, { recursive: true, mode: entryPerm(entry, 0o755) });
+    return;
+  }
+
+  await fs.promises.mkdir(path.dirname(target), { recursive: true });
+  if (isSymlinkEntry(entry)) {
+    const stream = await zip.openReadStreamPromise(entry);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const linkTarget = Buffer.concat(chunks).toString('utf8');
+    const resolved = path.resolve(path.dirname(target), linkTarget);
+    const appRootResolved = path.resolve(appRoot);
+    if (resolved !== appRootResolved && !resolved.startsWith(appRootResolved + path.sep)) {
+      throw new Error(`ZIP/IPA symlink escapes app bundle: ${entry.fileName} -> ${linkTarget}`);
+    }
+    await fs.promises.rm(target, { force: true });
+    await fs.promises.symlink(linkTarget, target);
+    return;
+  }
+
+  const stream = await zip.openReadStreamPromise(entry);
+  await pipeline(stream, fs.createWriteStream(target, { mode: entryPerm(entry, 0o644) }));
+  await fs.promises.chmod(target, entryPerm(entry, 0o644));
+}
+
+export async function extractAppArchiveToStablePath(archivePath: string): Promise<PreparedAppBundle> {
+  const resolvedArchivePath = path.resolve(archivePath);
+  const appPath = stableAppPath(resolvedArchivePath);
+  const stableRoot = path.dirname(appPath);
+  const stagingRoot = path.join(stableRoot, `.staging-${process.pid}-${Date.now()}`);
+
+  await ensureDirectoryNotSymlink(stableRoot);
+  const zip = await openZip(resolvedArchivePath);
+  try {
+    const entries = await readEntries(zip);
+    const appName = discoverPayloadApp(entries, resolvedArchivePath);
+    const payloadPrefix = `Payload/${appName}/`;
+    const stagingAppPath = path.join(stagingRoot, path.basename(appPath));
+    await fs.promises.rm(stagingRoot, { recursive: true, force: true });
+
+    for (const entry of entries) {
+      const name = toZipPath(entry.fileName);
+      if (name !== `Payload/${appName}` && !name.startsWith(payloadPrefix)) {
+        continue;
+      }
+      const rel = name === `Payload/${appName}` ? '' : name.slice(payloadPrefix.length);
+      if (rel === '') {
+        await fs.promises.mkdir(stagingAppPath, { recursive: true });
+        continue;
+      }
+      if (isUnsafeZipPath(rel)) {
+        throw new Error(`ZIP entry has an unsafe app-relative path: ${entry.fileName}`);
+      }
+      const target = path.join(stagingAppPath, rel.split('/').join(path.sep));
+      const stagingAppResolved = path.resolve(stagingAppPath);
+      const targetResolved = path.resolve(target);
+      if (
+        targetResolved !== stagingAppResolved &&
+        !targetResolved.startsWith(stagingAppResolved + path.sep)
+      ) {
+        throw new Error(`ZIP entry escapes app bundle: ${entry.fileName}`);
+      }
+      await extractEntry(zip, entry, target, stagingAppPath);
+    }
+
+    await copyExtractedAppIntoStableRoot(stagingAppPath, appPath);
+    return {
+      appPath,
+      cacheIdentityPath: resolvedArchivePath,
+      isArchive: true,
+      archivePath: resolvedArchivePath,
+    };
+  } finally {
+    zip.close();
+    await fs.promises.rm(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+export async function prepareAppBundlePath(inputPath: string): Promise<PreparedAppBundle> {
+  const resolvedPath = path.resolve(inputPath);
+  const stat = await fs.promises.stat(resolvedPath);
+  if (stat.isDirectory()) {
+    return {
+      appPath: resolvedPath,
+      cacheIdentityPath: resolvedPath,
+      isArchive: false,
+    };
+  }
+  if (!stat.isFile()) {
+    throw new Error(`The path is neither an app bundle directory nor a ZIP/IPA archive: ${inputPath}`);
+  }
+  return await extractAppArchiveToStablePath(resolvedPath);
+}
+
+export function watchAppArchive(opts: { archivePath: string; log?: LogFn }): ArchiveWatcher {
+  const archivePath = path.resolve(opts.archivePath);
+  const log = opts.log ?? noopLogger;
+  const parentDir = path.dirname(archivePath);
+  const archiveBase = path.basename(archivePath);
+  let timer: NodeJS.Timeout | undefined;
+  let inFlight = false;
+  let queued = false;
+  let closed = false;
+
+  const run = async () => {
+    if (closed) return;
+    if (inFlight) {
+      queued = true;
+      return;
+    }
+    inFlight = true;
+    try {
+      await extractAppArchiveToStablePath(archivePath);
+      log('debug', `re-extracted ZIP/IPA archive: ${archivePath}`);
+    } catch (err) {
+      log(
+        'error',
+        `failed to re-extract ZIP/IPA archive ${archivePath}: ${err instanceof Error ? err.message : err}`,
+      );
+    } finally {
+      inFlight = false;
+      if (queued) {
+        queued = false;
+        void run();
+      }
+    }
+  };
+
+  const schedule = () => {
+    if (closed) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      void run();
+    }, 500);
+  };
+
+  const watcher = fs.watch(parentDir, (_eventType, filename) => {
+    if (!filename || filename.toString() === archiveBase) {
+      schedule();
+    }
+  });
+  log('debug', `watchAppArchive: ${archivePath}`);
+
+  return {
+    close: () => {
+      closed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      watcher.close();
+    },
+  };
+}

--- a/src/app-archive.ts
+++ b/src/app-archive.ts
@@ -20,6 +20,10 @@ export type ArchiveWatcher = {
 
 const noopLogger: LogFn = () => {};
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function stableArchiveRoot(archivePath: string): string {
   const resolved = path.resolve(archivePath);
   const hash = crypto.createHash('sha1').update(resolved).digest('hex').slice(0, 12);
@@ -261,6 +265,32 @@ export async function prepareAppBundlePath(inputPath: string): Promise<PreparedA
   return await extractAppArchiveToStablePath(resolvedPath);
 }
 
+async function waitForStableArchiveFile(archivePath: string, shouldStop: () => boolean): Promise<boolean> {
+  const deadline = Date.now() + 10_000;
+  let previous: { size: number; mtimeMs: number } | undefined;
+
+  while (!shouldStop() && Date.now() < deadline) {
+    const stat = await fs.promises.stat(archivePath).catch((err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') return null;
+      throw err;
+    });
+
+    if (stat?.isFile()) {
+      const current = { size: stat.size, mtimeMs: stat.mtimeMs };
+      if (previous && previous.size === current.size && previous.mtimeMs === current.mtimeMs) {
+        return true;
+      }
+      previous = current;
+    } else {
+      previous = undefined;
+    }
+
+    await sleep(100);
+  }
+
+  return false;
+}
+
 export function watchAppArchive(opts: { archivePath: string; log?: LogFn }): ArchiveWatcher {
   const archivePath = path.resolve(opts.archivePath);
   const log = opts.log ?? noopLogger;
@@ -279,6 +309,13 @@ export function watchAppArchive(opts: { archivePath: string; log?: LogFn }): Arc
     }
     inFlight = true;
     try {
+      const ready = await waitForStableArchiveFile(archivePath, () => closed);
+      if (!ready) {
+        if (!closed) {
+          log('warn', `ZIP/IPA archive did not become readable after change: ${archivePath}`);
+        }
+        return;
+      }
       await extractAppArchiveToStablePath(archivePath);
       log('debug', `re-extracted ZIP/IPA archive: ${archivePath}`);
     } catch (err) {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -1916,6 +1916,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       const hash = crypto.createHash('sha1').update(resolvedPath).digest('hex').slice(0, 8);
       const cacheKey = `limsync-cache-${folderName}-${hash}`;
       const basisCacheDir = opts?.basisCacheDir ?? path.join(os.tmpdir(), cacheKey);
+      const shouldWatch = opts?.watch ?? true;
       const syncLog: FolderSyncOptions['log'] = (level, msg) => {
         switch (level) {
           case 'debug':
@@ -1945,19 +1946,23 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         install: opts?.install ?? true,
         maxPatchBytes: opts?.maxPatchBytes ?? 4 * 1024 * 1024,
         launchMode: opts?.launchMode ?? 'ForegroundIfRunning',
-        watch: opts?.watch ?? true,
+        watch: preparedApp.isArchive ? false : shouldWatch,
       };
       const result = await syncFolder(appBundlePath, folderSyncOpts);
-      if (!preparedApp.isArchive || !preparedApp.archivePath || !folderSyncOpts.watch) {
+      if (!preparedApp.isArchive || !preparedApp.archivePath || !shouldWatch) {
         return result;
       }
-      const archiveWatcher = watchAppArchive({ archivePath: preparedApp.archivePath, log: syncLog });
-      const stopWatching = result.stopWatching;
+      const archiveWatcher = watchAppArchive({
+        archivePath: preparedApp.archivePath,
+        log: syncLog,
+        onExtracted: async () => {
+          await syncFolder(appBundlePath, folderSyncOpts);
+        },
+      });
       return {
         ...result,
         stopWatching: () => {
           archiveWatcher.close();
-          stopWatching?.();
         },
       };
     };

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'events';
 import { assertPort, isNonRetryableError, startReverseTcpTunnel, type ReverseTunnel } from './tunnel';
 import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './folder-sync';
 import { createIgnoreFn } from './folder-sync-ignore';
+import { prepareAppBundlePath, watchAppArchive } from './app-archive';
 import { downloadFileToLocalPath } from './internal/download-file';
 import { nodeProxyTransport } from './internal/proxy-transport';
 import { startHttpProxy as startLocalHttpProxy } from './http-proxy';
@@ -1900,7 +1901,9 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         watch?: boolean;
       },
     ): Promise<SyncFolderResult> => {
-      const infoPlistPath = path.join(localAppBundlePath, 'Info.plist');
+      const preparedApp = await prepareAppBundlePath(localAppBundlePath);
+      const appBundlePath = preparedApp.appPath;
+      const infoPlistPath = path.join(appBundlePath, 'Info.plist');
       const infoPlistStat = await fs.promises.stat(infoPlistPath).catch(() => null);
       if (!infoPlistStat?.isFile()) {
         throw new Error(`The folder is not a valid app bundle: missing Info.plist at ${infoPlistPath}`);
@@ -1908,7 +1911,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       if (!cachedDeviceInfo) {
         throw new Error('Device info not available yet; wait for client connection to be established.');
       }
-      const resolvedPath = path.resolve(localAppBundlePath);
+      const resolvedPath = path.resolve(preparedApp.cacheIdentityPath);
       const folderName = path.basename(resolvedPath);
       const hash = crypto.createHash('sha1').update(resolvedPath).digest('hex').slice(0, 8);
       const cacheKey = `limsync-cache-${folderName}-${hash}`;
@@ -1936,7 +1939,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         apiUrl: options.apiUrl,
         token: options.token,
         udid: cacheKey,
-        ignoreFn: await createIgnoreFn(localAppBundlePath, { basisCacheDir, log: syncLog }),
+        ignoreFn: await createIgnoreFn(appBundlePath, { basisCacheDir, log: syncLog }),
         basisCacheDir,
         log: syncLog,
         install: opts?.install ?? true,
@@ -1944,7 +1947,19 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         launchMode: opts?.launchMode ?? 'ForegroundIfRunning',
         watch: opts?.watch ?? true,
       };
-      return await syncFolder(localAppBundlePath, folderSyncOpts);
+      const result = await syncFolder(appBundlePath, folderSyncOpts);
+      if (!preparedApp.isArchive || !preparedApp.archivePath || !folderSyncOpts.watch) {
+        return result;
+      }
+      const archiveWatcher = watchAppArchive({ archivePath: preparedApp.archivePath, log: syncLog });
+      const stopWatching = result.stopWatching;
+      return {
+        ...result,
+        stopWatching: () => {
+          archiveWatcher.close();
+          stopWatching?.();
+        },
+      };
     };
 
     const lsof = (): Promise<LsofEntry[]> => {

--- a/tests/app-archive.test.ts
+++ b/tests/app-archive.test.ts
@@ -159,8 +159,9 @@ describe('app archive preparation', () => {
     const ipaPath = path.join(work, 'WatchMe.ipa');
     writeIpa(ipaPath, 'WatchMe.app', { 'Info.plist': 'first' });
     const prepared = await extractAppArchiveToStablePath(ipaPath);
+    const onExtracted = jest.fn();
 
-    const watcher = watchAppArchive({ archivePath: ipaPath });
+    const watcher = watchAppArchive({ archivePath: ipaPath, onExtracted });
     fs.rmSync(ipaPath);
     onChange?.('rename', path.basename(ipaPath));
     await new Promise((resolve) => setTimeout(resolve, 650));
@@ -168,6 +169,7 @@ describe('app archive preparation', () => {
     await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(fs.readFileSync(path.join(prepared.appPath, 'Info.plist'), 'utf8')).toBe('second');
+    expect(onExtracted).toHaveBeenCalledTimes(1);
     watcher.close();
     watchSpy.mockRestore();
   });

--- a/tests/app-archive.test.ts
+++ b/tests/app-archive.test.ts
@@ -148,4 +148,27 @@ describe('app archive preparation', () => {
     expect(close).toHaveBeenCalled();
     watchSpy.mockRestore();
   });
+
+  test('archive watcher waits for a deleted archive to reappear before extracting', async () => {
+    let onChange: ((eventType: string, filename: string) => void) | undefined;
+    const watchSpy = jest.spyOn(fs, 'watch').mockImplementation((_path, listener) => {
+      onChange = listener as (eventType: string, filename: string) => void;
+      return { close: jest.fn() } as unknown as fs.FSWatcher;
+    });
+    const work = tempDir();
+    const ipaPath = path.join(work, 'WatchMe.ipa');
+    writeIpa(ipaPath, 'WatchMe.app', { 'Info.plist': 'first' });
+    const prepared = await extractAppArchiveToStablePath(ipaPath);
+
+    const watcher = watchAppArchive({ archivePath: ipaPath });
+    fs.rmSync(ipaPath);
+    onChange?.('rename', path.basename(ipaPath));
+    await new Promise((resolve) => setTimeout(resolve, 650));
+    writeIpa(ipaPath, 'WatchMe.app', { 'Info.plist': 'second' });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(fs.readFileSync(path.join(prepared.appPath, 'Info.plist'), 'utf8')).toBe('second');
+    watcher.close();
+    watchSpy.mockRestore();
+  });
 });

--- a/tests/app-archive.test.ts
+++ b/tests/app-archive.test.ts
@@ -1,0 +1,151 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { extractAppArchiveToStablePath, prepareAppBundlePath, watchAppArchive } from '../src/app-archive';
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-app-archive-test-'));
+}
+
+function writeIpa(ipaPath: string, appName: string, files: Record<string, string>): void {
+  const root = tempDir();
+  const appDir = path.join(root, 'Payload', appName);
+  fs.mkdirSync(appDir, { recursive: true });
+  for (const [relPath, content] of Object.entries(files)) {
+    const filePath = path.join(appDir, relPath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+  fs.rmSync(ipaPath, { force: true });
+  execFileSync('zip', ['-qry', ipaPath, 'Payload'], { cwd: root });
+}
+
+function writeZip(root: string, zipPath: string, args: string[]): void {
+  fs.rmSync(zipPath, { force: true });
+  execFileSync('zip', ['-qry', zipPath, ...args], { cwd: root });
+}
+
+describe('app archive preparation', () => {
+  test('returns app directories unchanged', async () => {
+    const appDir = path.join(tempDir(), 'Example.app');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(path.join(appDir, 'Info.plist'), 'plist');
+
+    await expect(prepareAppBundlePath(appDir)).resolves.toMatchObject({
+      appPath: appDir,
+      cacheIdentityPath: appDir,
+      isArchive: false,
+    });
+  });
+
+  test('extracts an IPA to a stable app path derived from the archive path', async () => {
+    const work = tempDir();
+    const ipaPath = path.join(work, 'TargetName.ipa');
+    writeIpa(ipaPath, 'BundleName.app', {
+      'Info.plist': 'plist',
+      'Resources/data.txt': 'first',
+    });
+
+    const first = await extractAppArchiveToStablePath(ipaPath);
+    const second = await extractAppArchiveToStablePath(ipaPath);
+
+    expect(first.appPath).toBe(second.appPath);
+    expect(path.basename(first.appPath)).toBe('Extracted.app');
+    expect(first.cacheIdentityPath).toBe(path.resolve(ipaPath));
+    expect(fs.readFileSync(path.join(first.appPath, 'Info.plist'), 'utf8')).toBe('plist');
+    expect(fs.readFileSync(path.join(first.appPath, 'Resources', 'data.txt'), 'utf8')).toBe('first');
+  });
+
+  test('re-extracting removes files that disappeared from the archive', async () => {
+    const work = tempDir();
+    const ipaPath = path.join(work, 'Changing.ipa');
+    writeIpa(ipaPath, 'Changing.app', {
+      'Info.plist': 'plist',
+      'stale.txt': 'remove me',
+    });
+    const first = await extractAppArchiveToStablePath(ipaPath);
+    expect(fs.existsSync(path.join(first.appPath, 'stale.txt'))).toBe(true);
+
+    writeIpa(ipaPath, 'Changing.app', {
+      'Info.plist': 'plist',
+      'fresh.txt': 'new',
+    });
+    const second = await extractAppArchiveToStablePath(ipaPath);
+
+    expect(second.appPath).toBe(first.appPath);
+    expect(fs.existsSync(path.join(second.appPath, 'stale.txt'))).toBe(false);
+    expect(fs.readFileSync(path.join(second.appPath, 'fresh.txt'), 'utf8')).toBe('new');
+  });
+
+  test('rejects non-zip files', async () => {
+    const filePath = path.join(tempDir(), 'not-an-app.txt');
+    fs.writeFileSync(filePath, 'hello');
+
+    await expect(prepareAppBundlePath(filePath)).rejects.toThrow(
+      /not a valid app bundle directory or ZIP\/IPA archive/,
+    );
+  });
+
+  test('rejects zips with no Payload app bundle', async () => {
+    const work = tempDir();
+    fs.writeFileSync(path.join(work, 'file.txt'), 'hello');
+    const zipPath = path.join(work, 'bad.ipa');
+    writeZip(work, zipPath, ['file.txt']);
+
+    await expect(extractAppArchiveToStablePath(zipPath)).rejects.toThrow(
+      /contains no Payload\/\*\.app bundle/,
+    );
+  });
+
+  test('rejects zips with multiple Payload app bundles', async () => {
+    const work = tempDir();
+    fs.mkdirSync(path.join(work, 'Payload', 'One.app'), { recursive: true });
+    fs.mkdirSync(path.join(work, 'Payload', 'Two.app'), { recursive: true });
+    fs.writeFileSync(path.join(work, 'Payload', 'One.app', 'Info.plist'), 'one');
+    fs.writeFileSync(path.join(work, 'Payload', 'Two.app', 'Info.plist'), 'two');
+    const zipPath = path.join(work, 'bad.ipa');
+    writeZip(work, zipPath, ['Payload']);
+
+    await expect(extractAppArchiveToStablePath(zipPath)).rejects.toThrow(
+      /more than one Payload\/\*\.app bundle/,
+    );
+  });
+
+  test('rejects zip-slip entries', async () => {
+    const work = tempDir();
+    fs.mkdirSync(path.join(work, 'inside'), { recursive: true });
+    fs.writeFileSync(path.join(work, 'outside.txt'), 'escape');
+    const zipPath = path.join(work, 'evil.ipa');
+    writeZip(path.join(work, 'inside'), zipPath, ['../outside.txt']);
+
+    await expect(extractAppArchiveToStablePath(zipPath)).rejects.toThrow(/unsafe path|invalid relative path/);
+  });
+
+  test('rejects symlinks that escape the extracted app bundle', async () => {
+    const work = tempDir();
+    const appDir = path.join(work, 'Payload', 'Evil.app');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(path.join(appDir, 'Info.plist'), 'plist');
+    fs.symlinkSync('../../outside.txt', path.join(appDir, 'escape'));
+    const zipPath = path.join(work, 'evil.ipa');
+    fs.rmSync(zipPath, { force: true });
+    execFileSync('zip', ['-qry', '-y', zipPath, 'Payload'], { cwd: work });
+
+    await expect(extractAppArchiveToStablePath(zipPath)).rejects.toThrow(/symlink escapes app bundle/);
+  });
+
+  test('archive watcher can be closed', () => {
+    const close = jest.fn();
+    const watchSpy = jest.spyOn(fs, 'watch').mockImplementation(() => ({ close }) as unknown as fs.FSWatcher);
+    const archivePath = path.join(tempDir(), 'WatchMe.ipa');
+    fs.writeFileSync(archivePath, 'not used by this test');
+
+    const watcher = watchAppArchive({ archivePath });
+    watcher.close();
+
+    expect(watchSpy).toHaveBeenCalledWith(path.dirname(archivePath), expect.any(Function));
+    expect(close).toHaveBeenCalled();
+    watchSpy.mockRestore();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,6 +970,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-3.4.0.tgz#93de17db1589472d30b4e106c5e7711bcf32a5e9"
+  integrity sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@8.31.1":
   version "8.31.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz#62f1befe59647524994e89de4516d8dcba7a850a"
@@ -2911,6 +2918,11 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -3544,6 +3556,13 @@ yargs@^17.3.1, yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yauzl@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.4.0.tgz#88b2a21455f37ca7dccf2eeb33bacb4392322719"
+  integrity sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
+  dependencies:
+    pend "~1.2.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
We have differential patching for `.app` folders produced by xcode but Bazel produces `.ipa` files even if it's a simulator build, so we add support here to handle that case as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem extraction and watch path touches sync/install behavior; mitigated by validation tests and path-traversal checks, but archive handling is inherently sensitive.
> 
> **Overview**
> **`syncApp` now accepts a `.ipa`/ZIP path** (e.g. Bazel simulator builds), not only an on-disk `.app` directory.
> 
> A new **`app-archive`** layer uses **`yauzl`** to extract exactly one `Payload/*.app` (with `Info.plist`) into a **stable temp path** keyed by the archive file. **Zip-slip and escaping symlinks** are rejected; re-extract **wipes** the staging bundle so removed files do not linger.
> 
> **`syncApp`** runs folder sync against the extracted bundle but keys the **basis cache** off the **archive path** when applicable. **Directory watching** stays on `.app` folders; for archives it **watches the IPA**, waits until the file is stable, **re-extracts**, then **re-syncs**. **`stopWatching`** closes the archive watcher when watch is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f6baadc1f992fbcbe83e12bfff060ec1d5d934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->