### PR TITLE
cli: strip rules_apple no-remote tags in generated RBE config

### DIFF
--- a/packages/cli/src/lib/rbe-workspace.ts
+++ b/packages/cli/src/lib/rbe-workspace.ts
@@ -313,6 +313,19 @@ xcode_config(
  *   actions to the mac RBE pool. On a mac it is HARMFUL: it makes bazel run
  *   exec-config actions on the local host instead of the remote worker, which
  *   then demand a local Xcode.
+ * - `--modify_execution_info=.*=-no-remote,.*=-no-remote-exec` strips the
+ *   `no-remote`/`no-remote-exec` execution-info tags rules_apple sets on
+ *   bundling/linking/signing actions (in-code on device builds, and via its
+ *   recommended `+no-remote` bazelrc that real iOS repos carry). Under
+ *   --config=limrun every action runs remotely, so any such tag leaves the
+ *   action with no usable strategy ("cannot be executed with any of the
+ *   available strategies: [remote]") and the build fails. That is the exact
+ *   breakage a Linux client (no local Xcode) hits. This is the execution-info
+ *   analog of the --strategy=...=remote overrides above; stripping globally is
+ *   safe because removing a tag an action never had is a no-op.
+ * - A `user.limrun.bazelrc` at the workspace root is try-imported last as a user
+ *   override hook, so callers can extend or override the generated config
+ *   without editing this file or passing flags on the command line.
  */
 export function renderLimrunBazelrc(
   port: number,
@@ -331,12 +344,18 @@ build:limrun --spawn_strategy=remote
 build:limrun --noremote_local_fallback
 build:limrun --strategy=SwiftCompile=remote
 build:limrun --strategy=Genrule=remote
+build:limrun --modify_execution_info=.*=-no-remote,.*=-no-remote-exec
 build:limrun --xcode_version_config=//.limrun:remote_xcode_config
 build:limrun --xcode_version=${shortVersion(versionKey)}
 build:limrun --ios_multi_cpus=sim_arm64
 build:limrun --remote_download_outputs=minimal
 build:limrun --build_event_json_file=${bepPath}
 ${execPlatform}build:limrun --action_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# A user.limrun.bazelrc at the workspace root is try-imported last, so it can
+# extend or override anything above without editing this generated file or
+# passing flags on the command line. A missing file is silently skipped.
+try-import %workspace%/user.limrun.bazelrc
 `;
 }
 

--- a/tests/cli-rbe-workspace.test.ts
+++ b/tests/cli-rbe-workspace.test.ts
@@ -209,7 +209,9 @@ describe('rbe workspace generation', () => {
 
   test('renderLimrunBazelrc scopes every flag under the limrun config', () => {
     const rc = renderLimrunBazelrc(9123, '26.4.0.17E192', true, '/ws/.limrun/bep.json');
-    const flagLines = rc.split('\n').filter((l) => l && !l.startsWith('#'));
+    // Every flag is config-scoped; the trailing user-override try-import is a
+    // directive, not a flag, so it is excluded from this check.
+    const flagLines = rc.split('\n').filter((l) => l && !l.startsWith('#') && !l.startsWith('try-import '));
     expect(flagLines.length).toBeGreaterThan(0);
     for (const line of flagLines) {
       expect(line).toMatch(/^build:limrun /);
@@ -241,6 +243,26 @@ describe('rbe workspace generation', () => {
     expect(rc).toContain('--strategy=Genrule=remote');
     // sysctl (hw.logicalcpu) lives in /usr/sbin.
     expect(rc).toContain('--action_env=PATH=/usr/bin:/bin:/usr/sbin:/sbin');
+  });
+
+  test('renderLimrunBazelrc strips rules_apple no-remote tags so every action can run remotely', () => {
+    // Under --config=limrun everything runs remotely; rules_apple's no-remote /
+    // no-remote-exec tags would otherwise leave bundling/linking/signing with no
+    // usable strategy. Stripped on both client kinds (the config forces remote
+    // for mac too).
+    for (const isMac of [true, false]) {
+      const rc = renderLimrunBazelrc(9123, '26.4.0.17E192', isMac, '/ws/.limrun/bep.json');
+      expect(rc).toContain('--modify_execution_info=.*=-no-remote,.*=-no-remote-exec');
+    }
+  });
+
+  test('renderLimrunBazelrc try-imports a user override file last so overrides win', () => {
+    const rc = renderLimrunBazelrc(9123, '26.4.0.17E192', true, '/ws/.limrun/bep.json');
+    expect(rc).toContain('try-import %workspace%/user.limrun.bazelrc');
+    const lines = rc.split('\n');
+    const lastFlag = lines.map((l) => l.startsWith('build:limrun')).lastIndexOf(true);
+    const userImport = lines.findIndex((l) => l.startsWith('try-import %workspace%/user.limrun.bazelrc'));
+    expect(userImport).toBeGreaterThan(lastFlag);
   });
 
   test('renderLimrunBazelrc keeps outputs in CAS and emits BEP for the install verb', () => {
@@ -280,11 +302,15 @@ describe('rbe workspace generation', () => {
       expect(fs.readFileSync(path.join(dir, '.limrun', '.gitignore'), 'utf8')).toBe('*\n');
       expect(fs.readFileSync(path.join(dir, '.bazelrc'), 'utf8')).toContain(TRY_IMPORT_LINE);
       expect(result.bazelrcUpdated).toBe(true);
-      // BEP path is the ABSOLUTE workspace path, not %workspace% (which Bazel
-      // does not expand in flag values — it would create a junk %workspace%/ dir).
+      // BEP path is the ABSOLUTE workspace path, not %workspace%. Bazel does not
+      // expand %workspace% in flag values, so it must not appear in any flag line
+      // (it is valid only in the trailing user-override try-import directive).
       const rc = fs.readFileSync(result.bazelrcFragment, 'utf8');
       expect(rc).toContain(`--build_event_json_file=${path.join(dir, '.limrun', 'bep.json')}`);
-      expect(rc).not.toContain('%workspace%');
+      for (const line of rc.split('\n').filter((l) => l.startsWith('build:limrun'))) {
+        expect(line).not.toContain('%workspace%');
+      }
+      expect(rc).toContain('try-import %workspace%/user.limrun.bazelrc');
     });
 
     test('writeRbeWorkspaceFiles honors a custom bep path and creates its parent dir', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only the CLI-generated Bazel rc fragment and tests; behavior is scoped to `--config=limrun` and documented as safe when tags are absent.
> 
> **Overview**
> Fixes **Linux (and other non-local-Xcode) RBE builds** that fail when `rules_apple` marks bundling/linking/signing with `no-remote` / `no-remote-exec`. The generated `build:limrun` fragment now adds **`--modify_execution_info=.*=-no-remote,.*=-no-remote-exec`** so those tags are stripped and every action can use the remote strategy under full remote spawn.
> 
> Also appends **`try-import %workspace%/user.limrun.bazelrc`** after all `build:limrun` lines so repos can override or extend the generated config without editing `.limrun/bazelrc`. Tests cover the new flag (mac and non-mac clients), import ordering, and that `%workspace%` appears only in the try-import—not in flag values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c62f00b9dac54f70566510869f9a84caa830aea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->