### PR TITLE
feat(xcode): RBE build-watch primitives for auto-upload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ export {
   type RbeInstallResult,
   type RbeUploadOptions,
   type RbeUploadResult,
+  type RbeActiveBuild,
+  type RbeBuildEnd,
   type Tunnel,
   RbeUnsupportedError,
   deriveRbeTunnelUrl,

--- a/src/internal/sse-fetch.ts
+++ b/src/internal/sse-fetch.ts
@@ -1,0 +1,20 @@
+import type { Fetch } from './builtin-types';
+
+/**
+ * Wraps a fetch for use with eventsource-client, which swallows a REJECTED
+ * fetch (connection refused, instance gone) into a silent reconnect loop
+ * without ever calling onDisconnect. The wrapper reports the rejection so the
+ * caller can settle its promise instead of hanging while the client
+ * reconnect-loops. exec-client has the same latent hazard and should adopt
+ * this when touched next.
+ */
+export function sseFetch(fetchImpl: Fetch, onRejected: (err: unknown) => void): Fetch {
+  return async (input, init) => {
+    try {
+      return await fetchImpl(input, init);
+    } catch (err) {
+      onRejected(err);
+      throw err;
+    }
+  };
+}

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -17,6 +17,8 @@ import { LimrunError } from '../core/error';
 import { validateBuildSettings } from '../build-settings';
 import { startTcpTunnel, type Tunnel } from '../tunnel';
 import { isTransientError, retryTransient } from '../rbe-session';
+import { sseFetch } from '../internal/sse-fetch';
+import { createEventSource } from 'eventsource-client';
 
 export type { Tunnel } from '../tunnel';
 
@@ -217,6 +219,22 @@ export type RbeUploadResult = {
   signedDownloadUrl?: string;
 };
 
+/** An in-flight Bazel invocation on the instance's RBE stack. */
+export type RbeActiveBuild = {
+  invocationId: string;
+  /** RUNNING while in flight; terminal statuses appear only on the build-end event. */
+  status: 'RUNNING' | (string & {});
+  /** The bazel target pattern(s) of the invocation, when known. */
+  pattern?: string[];
+};
+
+/** The terminal summary of a Bazel invocation, from the build stream's end event. */
+export type RbeBuildEnd = {
+  invocationId: string;
+  status: 'SUCCEEDED' | 'FAILED' | 'CANCELLED' | 'INCOMPLETE' | (string & {});
+  error?: string;
+};
+
 export type XcodeClient = {
   /**
    * Sync source code to the xcode instance. In watch mode, keeps syncing on changes.
@@ -277,6 +295,24 @@ export type XcodeClient = {
    * brief no-build window right after bazel exits is retried automatically.
    */
   uploadLatestRbeBuild: (opts: RbeUploadOptions) => Promise<RbeUploadResult>;
+
+  /**
+   * List the Bazel invocations currently building on the RBE stack. Poll this
+   * to discover new builds (e.g. to auto-upload on build end).
+   */
+  getActiveRbeBuilds: () => Promise<RbeActiveBuild[]>;
+
+  /**
+   * Wait for a Bazel invocation to finish and return its terminal summary.
+   * Subscribes to the invocation's build event stream (which replays from the
+   * start, so subscribing any time before the build ends is safe) and resolves
+   * on the terminal event. Rejects when the stream drops or cannot be reached,
+   * typically because the build already ended and its live stream was removed,
+   * and on abort via the optional signal. There is no internal retry; the
+   * caller owns that policy (re-subscribe while the invocation is still listed
+   * active, else treat the outcome as unknown).
+   */
+  waitForRbeBuildEnd: (invocationId: string, opts?: { signal?: AbortSignal }) => Promise<RbeBuildEnd>;
 
   /**
    * Create a new iOS simulator instance and attach it to this xcode instance.
@@ -709,6 +745,83 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           (isDirectInstanceHttpError(err, 400) && /no successful RBE app build/i.test(err.body));
         const result = await retryTransient(post, { retryOn });
         return { ...result, ...(signedDownloadUrl && { signedDownloadUrl }) };
+      },
+
+      async getActiveRbeBuilds(): Promise<RbeActiveBuild[]> {
+        const res = await nodeProxyTransport.fetch(`${apiUrl}/rbe/builds/active`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        // readRbeResponse: a 404 here means a limbuild that predates this
+        // route, not a vanished instance (same trap as the other /rbe routes).
+        return readRbeResponse<RbeActiveBuild[]>(res, 'GET /rbe/builds/active');
+      },
+
+      waitForRbeBuildEnd(invocationId: string, opts?: { signal?: AbortSignal }): Promise<RbeBuildEnd> {
+        return new Promise<RbeBuildEnd>((resolve, reject) => {
+          if (opts?.signal?.aborted) {
+            reject(new Error(`waiting for build ${invocationId} was aborted`));
+            return;
+          }
+          // Both settle paths close the source: eventsource-client
+          // auto-reconnects otherwise, which would retry-loop against the
+          // stream once the daemon removes it.
+          let settled = false;
+          const cleanup = () => {
+            eventSource.close();
+            opts?.signal?.removeEventListener('abort', onAbort);
+          };
+          const settleResolve = (end: RbeBuildEnd) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            resolve(end);
+          };
+          const settleReject = (err: Error) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            reject(err);
+          };
+          const onAbort = () => settleReject(new Error(`waiting for build ${invocationId} was aborted`));
+          const eventSource = createEventSource({
+            url: `${apiUrl}/exec/${invocationId}/events`,
+            fetch: sseFetch(nodeProxyTransport.fetch, (err) =>
+              settleReject(
+                new Error(
+                  `build event stream for ${invocationId} is unreachable: ${
+                    err instanceof Error ? err.message : err
+                  }`,
+                ),
+              ),
+            ),
+            headers: { Authorization: `Bearer ${token}` },
+            onMessage: (message) => {
+              if (message.event !== 'end') {
+                return; // meta and log frames
+              }
+              let end: RbeBuildEnd;
+              try {
+                end = JSON.parse(message.data) as RbeBuildEnd;
+              } catch (err) {
+                settleReject(new Error(`invalid build end event for ${invocationId}: ${err}`));
+                return;
+              }
+              settleResolve(end);
+            },
+            onDisconnect: () => {
+              settleReject(
+                new Error(
+                  `build event stream for ${invocationId} ended without a terminal event ` +
+                    '(the build may have finished and its live stream been removed)',
+                ),
+              );
+            },
+          });
+          opts?.signal?.addEventListener('abort', onAbort, { once: true });
+        });
       },
     };
   }

--- a/tests/xcode-client-rbe.test.ts
+++ b/tests/xcode-client-rbe.test.ts
@@ -5,18 +5,34 @@ import type { RequestInfo } from '../src/internal/builtin-types';
 
 const originalFetch = nodeProxyTransport.fetch;
 
-describe('xcode client RBE helpers', () => {
-  afterEach(() => {
-    nodeProxyTransport.fetch = originalFetch;
-  });
+afterEach(() => {
+  nodeProxyTransport.fetch = originalFetch;
+});
 
-  async function rbeClient() {
-    const client = new Limrun({ apiKey: 'key' });
-    return client.xcodeInstances.createClient({
-      apiUrl: 'https://eu-nl1-m14-lim8.example.test/v1/sandbox_euna_abc/xcode',
-      token: 'xcode-token',
-    });
-  }
+async function rbeClient() {
+  const client = new Limrun({ apiKey: 'key' });
+  return client.xcodeInstances.createClient({
+    apiUrl: 'https://eu-nl1-m14-lim8.example.test/v1/sandbox_euna_abc/xcode',
+    token: 'xcode-token',
+  });
+}
+
+describe('xcode client RBE helpers', () => {
+  test('getActiveRbeBuilds returns the parsed invocation list', async () => {
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) =>
+      String(input).endsWith('/rbe/builds/active') ?
+        new Response(JSON.stringify([{ invocationId: 'inv-1', status: 'RUNNING', pattern: ['//App'] }]), {
+          status: 200,
+        })
+      : (() => {
+          throw new Error(`unexpected request: ${input}`);
+        })(),
+    );
+    const xcode = await rbeClient();
+    await expect(xcode.getActiveRbeBuilds()).resolves.toEqual([
+      { invocationId: 'inv-1', status: 'RUNNING', pattern: ['//App'] },
+    ]);
+  });
 
   test('startRbe maps a /rbe 404 to RbeUnsupportedError, not NotFoundError', async () => {
     nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) =>
@@ -74,6 +90,89 @@ describe('xcode client RBE helpers', () => {
       frontendPort: 8980,
       xcodeVersion: '26.4.0.17E192',
     });
+  });
+});
+
+describe('waitForRbeBuildEnd', () => {
+  /** A one-shot SSE response streaming the given frames, then closing. The
+   *  `retry: 1` prologue drops eventsource-client's reconnect delay from its
+   *  2s default to ~1ms, so the no-reconnect assertions below actually bite
+   *  within their short observation windows. */
+  function sseResponse(frames: string[]): Response {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('retry: 1\n\n'));
+        for (const frame of frames) {
+          controller.enqueue(new TextEncoder().encode(frame));
+        }
+        controller.close();
+      },
+    });
+    return new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  }
+
+  test('resolves with the summary from the end frame, ignoring meta and log frames', async () => {
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) => {
+      if (!String(input).endsWith('/exec/inv-1/events')) {
+        throw new Error(`unexpected request: ${input}`);
+      }
+      return sseResponse([
+        'event: meta\ndata: {"invocationId":"inv-1","status":"RUNNING"}\n\n',
+        'event: stdout\ndata: Analyzing...\n\n',
+        'event: end\ndata: {"invocationId":"inv-1","status":"SUCCEEDED"}\n\n',
+      ]);
+    });
+    const xcode = await rbeClient();
+    await expect(xcode.waitForRbeBuildEnd('inv-1')).resolves.toEqual({
+      invocationId: 'inv-1',
+      status: 'SUCCEEDED',
+    });
+  });
+
+  test('rejects when the stream closes without an end frame (no reconnect loop)', async () => {
+    const fetchMock = jest.fn(async () =>
+      sseResponse(['event: meta\ndata: {"invocationId":"inv-2","status":"RUNNING"}\n\n']),
+    );
+    nodeProxyTransport.fetch = fetchMock;
+    const xcode = await rbeClient();
+    await expect(xcode.waitForRbeBuildEnd('inv-2')).rejects.toThrow(/without a terminal event/);
+    // The promise must close the source rather than let eventsource-client
+    // auto-reconnect against a stream the daemon has already removed (the
+    // fixture's retry: 1 makes a leaked reconnect land within this window).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects instead of hanging when the stream is unreachable', async () => {
+    // eventsource-client swallows a rejected fetch into a silent reconnect
+    // loop (onDisconnect never fires); the wrapper must surface it.
+    const fetchMock = jest.fn(async () => {
+      throw new Error('connect ECONNREFUSED');
+    });
+    nodeProxyTransport.fetch = fetchMock;
+    const xcode = await rbeClient();
+    await expect(xcode.waitForRbeBuildEnd('inv-3')).rejects.toThrow(/unreachable.*ECONNREFUSED/);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects on abort and stops the stream', async () => {
+    // A never-ending stream (no close) so only the abort can settle it.
+    nodeProxyTransport.fetch = jest.fn(
+      async () =>
+        new Response(new ReadableStream<Uint8Array>({ start: () => {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+    );
+    const xcode = await rbeClient();
+    const controller = new AbortController();
+    const wait = xcode.waitForRbeBuildEnd('inv-4', { signal: controller.signal });
+    controller.abort();
+    await expect(wait).rejects.toThrow(/aborted/);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New network/SSE lifecycle behavior can reject or hang callers if misused; changes are additive SDK surface on RBE/Xcode paths but event-stream edge cases are easy to get wrong without the documented caller-owned retry policy.
> 
> **Overview**
> Adds **RBE build-watch** APIs on `XcodeClient` so callers can discover in-flight Bazel invocations and wait for a terminal outcome—intended for flows like **auto-upload when a remote build finishes**.
> 
> **`getActiveRbeBuilds`** polls `GET /rbe/builds/active` and returns `RbeActiveBuild[]` (invocation id, status, optional target patterns), using the same RBE 404 → `RbeUnsupportedError` handling as other `/rbe` routes.
> 
> **`waitForRbeBuildEnd`** subscribes to `GET /exec/{invocationId}/events` via `eventsource-client`, resolves on an `end` SSE frame (`RbeBuildEnd`), and rejects on abort (`AbortSignal`), unreachable fetch, disconnect without `end`, or bad JSON. The promise **closes the EventSource** on settle so the client does not reconnect against removed streams; retry policy is left to the caller.
> 
> A new **`sseFetch`** wrapper surfaces fetch rejections that `eventsource-client` would otherwise swallow into a silent reconnect loop (noted for future `exec-client` adoption). **`RbeActiveBuild`** and **`RbeBuildEnd`** are exported from the public package entry. Tests cover active-build listing and SSE success, early close, connection failure, and abort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a4fcd06fcf9eb2c108c44c8503c236acdf04698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->