### PR TITLE
feat(xcode): getRecentRbeBuilds for polling build-end discovery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
   type RbeUploadResult,
   type RbeActiveBuild,
   type RbeBuildEnd,
+  type RbeBuildSummary,
   type Tunnel,
   RbeUnsupportedError,
   deriveRbeTunnelUrl,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -224,8 +224,9 @@ export type RbeActiveBuild = {
   invocationId: string;
   /** RUNNING while in flight; terminal statuses appear only on the build-end event. */
   status: 'RUNNING' | (string & {});
-  /** The bazel target pattern(s) of the invocation, when known. */
-  pattern?: string[];
+  /** The bazel target pattern(s) of the invocation; null when the build has
+   *  not reported one yet (the wire always carries the key). */
+  pattern?: string[] | null;
 };
 
 /** The terminal summary of a Bazel invocation, from the build stream's end event. */
@@ -233,6 +234,17 @@ export type RbeBuildEnd = {
   invocationId: string;
   status: 'SUCCEEDED' | 'FAILED' | 'CANCELLED' | 'INCOMPLETE' | (string & {});
   error?: string;
+};
+
+/** A Bazel invocation from the instance's bounded recent view: in flight or
+ *  recently finished with its terminal status. */
+export type RbeBuildSummary = {
+  invocationId: string;
+  status: 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELLED' | 'INCOMPLETE' | (string & {});
+  /** The bazel target pattern(s) of the invocation; null when the build never
+   *  reported one (e.g. its event stream dropped early). */
+  pattern?: string[] | null;
+  error?: string | null;
 };
 
 export type XcodeClient = {
@@ -301,6 +313,16 @@ export type XcodeClient = {
    * to discover new builds (e.g. to auto-upload on build end).
    */
   getActiveRbeBuilds: () => Promise<RbeActiveBuild[]>;
+
+  /**
+   * List the instance's recent Bazel invocations: in flight plus a bounded
+   * number of recently finished ones with their terminal status. Poll this to
+   * react to build ends (live streams are removed the moment a build ends, so
+   * the recent view is the reliable discovery surface). Retention is scoped
+   * to the RBE session: stopping the stack clears it. Durable history lives
+   * in the build records.
+   */
+  getRecentRbeBuilds: () => Promise<RbeBuildSummary[]>;
 
   /**
    * Wait for a Bazel invocation to finish and return its terminal summary.
@@ -757,6 +779,18 @@ export class XcodeInstances extends GeneratedXcodeInstances {
         // readRbeResponse: a 404 here means a limbuild that predates this
         // route, not a vanished instance (same trap as the other /rbe routes).
         return readRbeResponse<RbeActiveBuild[]>(res, 'GET /rbe/builds/active');
+      },
+
+      async getRecentRbeBuilds(): Promise<RbeBuildSummary[]> {
+        const res = await nodeProxyTransport.fetch(`${apiUrl}/rbe/builds/recent`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        // readRbeResponse: a 404 here means a limbuild that predates this
+        // route, not a vanished instance (same trap as the other /rbe routes).
+        return readRbeResponse<RbeBuildSummary[]>(res, 'GET /rbe/builds/recent');
       },
 
       waitForRbeBuildEnd(invocationId: string, opts?: { signal?: AbortSignal }): Promise<RbeBuildEnd> {

--- a/tests/xcode-client-rbe.test.ts
+++ b/tests/xcode-client-rbe.test.ts
@@ -34,6 +34,34 @@ describe('xcode client RBE helpers', () => {
     ]);
   });
 
+  test('getRecentRbeBuilds returns terminal and running entries; 404 maps to RbeUnsupportedError', async () => {
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) =>
+      String(input).endsWith('/rbe/builds/recent') ?
+        new Response(
+          JSON.stringify([
+            { invocationId: 'inv-1', status: 'RUNNING' },
+            { invocationId: 'inv-0', status: 'SUCCEEDED', pattern: ['//App'] },
+            // The Go wire always carries the pattern key, null when never reported.
+            { invocationId: 'inv-2', status: 'INCOMPLETE', pattern: null },
+          ]),
+          { status: 200 },
+        )
+      : (() => {
+          throw new Error(`unexpected request: ${input}`);
+        })(),
+    );
+    const xcode = await rbeClient();
+    await expect(xcode.getRecentRbeBuilds()).resolves.toEqual([
+      { invocationId: 'inv-1', status: 'RUNNING' },
+      { invocationId: 'inv-0', status: 'SUCCEEDED', pattern: ['//App'] },
+      { invocationId: 'inv-2', status: 'INCOMPLETE', pattern: null },
+    ]);
+
+    // A daemon predating the route must not read as a vanished instance.
+    nodeProxyTransport.fetch = jest.fn(async () => new Response('404 page not found\n', { status: 404 }));
+    await expect(xcode.getRecentRbeBuilds()).rejects.toBeInstanceOf(RbeUnsupportedError);
+  });
+
   test('startRbe maps a /rbe 404 to RbeUnsupportedError, not NotFoundError', async () => {
     nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) =>
       String(input).endsWith('/rbe') ?


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive client API and types mirroring existing `getActiveRbeBuilds`; no auth or data-path changes.
> 
> **Overview**
> Adds **`getRecentRbeBuilds()`** on the Xcode client so callers can poll **`GET /rbe/builds/recent`** and see in-flight builds plus a bounded set of recently finished invocations with terminal status, optional **`error`**, and target **`pattern`**.
> 
> Introduces **`RbeBuildSummary`** and exports it from the public API. **`RbeActiveBuild.pattern`** is typed as **`string[] | null`** to match the Go wire (key always present, null when not reported yet). The new route uses the same **`readRbeResponse`** behavior as other `/rbe` helpers (404 → **`RbeUnsupportedError`**). Tests cover parsed responses and 404 mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8bfb6260e236f2c387e7a0fcc2781c6b4687ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->