### PR TITLE
ios: add encryption key support for keychain

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "^0.33.5",
+        "@limrun/api": "^0.36.1",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.33.5.tgz",
-      "integrity": "sha512-qHY7DkCJ3m/JhJOWfVjTynwwRf5TkE2feTKVAGSWPsDMTEBZAjmhQ4r1YsIYcb05ve9tli4eKoT/qlbw4ryWBw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.36.1.tgz",
+      "integrity": "sha512-NzAO51TNxUdoOSCILo/fHHAHlVUQD9i+jpV05w2Xs2+YsFfyXQz3vkVtomRi+V3tAsic30/xIeRINDE5gUPtLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "eventsource-client": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.33.5",
+    "@limrun/api": "^0.36.1",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -111,6 +111,18 @@ export default class IosCreate extends BaseCommand {
       this.error('Use --encryption-key or --encryption-key-stdin only with --keychain or --keychain-url.');
     }
 
+    let keychainEncryptionKey: string | undefined;
+    if (hasKeychainInitialAssets) {
+      try {
+        keychainEncryptionKey = await resolveKeychainEncryptionKey({
+          encryptionKey: flags['encryption-key'],
+          encryptionKeyStdin: flags['encryption-key-stdin'],
+        });
+      } catch (error) {
+        this.error((error as Error).message);
+      }
+    }
+
     await this.withAuth(async () => {
       const attachTarget = flags.attach ? await this.resolveXcodeTarget(args.xcodeId) : undefined;
       if (attachTarget && attachTarget.type !== 'xcode') {
@@ -150,15 +162,7 @@ export default class IosCreate extends BaseCommand {
         }));
       }
       if (hasKeychainInitialAssets) {
-        let encryptionKey: string;
-        try {
-          encryptionKey = await resolveKeychainEncryptionKey({
-            encryptionKey: flags['encryption-key'],
-            encryptionKeyStdin: flags['encryption-key-stdin'],
-          });
-        } catch (error) {
-          this.error((error as Error).message);
-        }
+        const encryptionKey = keychainEncryptionKey!;
         if (!params.spec) params.spec = {};
         params.spec!.initialAssets = [
           ...(params.spec!.initialAssets || []),

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -6,6 +6,7 @@ import { registerCreatedInstance } from '../../lib/config';
 import { xcodeSandboxIdFromUrl } from '../../lib/xcode-sandbox';
 import { formatSimulatorAttachResult, simulatorAttachJson } from '../../lib/simulator-attach';
 import { formatDurationMs } from '../../lib/duration';
+import { resolveKeychainEncryptionKey } from '../../lib/keychain-encryption-key';
 import { type SimulatorAttachResult } from '@limrun/api';
 import { type IosInstanceCreateParams } from '@limrun/api/resources/ios-instances';
 
@@ -18,6 +19,8 @@ export default class IosCreate extends BaseCommand {
     '<%= config.bin %> ios create',
     '<%= config.bin %> ios create --rm --model ipad',
     '<%= config.bin %> ios create --region us-west --install-asset my-app.ipa',
+    '<%= config.bin %> ios create --keychain keychain/state.tar.gz --encryption-key-stdin < keychain.key',
+    '<%= config.bin %> ios create --keychain-url https://example.t3.storage.dev/... --encryption-key <key>',
     '<%= config.bin %> ios create --install ./MyApp.ipa',
     '<%= config.bin %> ios create --attach <xcode-instance-ID>',
   ];
@@ -59,6 +62,22 @@ export default class IosCreate extends BaseCommand {
       description: 'Existing asset name to install onto the instance after creation',
       multiple: true,
     }),
+    keychain: Flags.string({
+      description: 'Existing encrypted Keychain asset name to import after creation.',
+      multiple: true,
+    }),
+    'keychain-url': Flags.string({
+      description: 'Presigned encrypted Keychain asset URL to import after creation.',
+      multiple: true,
+    }),
+    'encryption-key': Flags.string({
+      description: 'Base64/base64url 32-byte decryption key for --keychain/--keychain-url.',
+    }),
+    'encryption-key-stdin': Flags.boolean({
+      description:
+        'Read the base64/base64url 32-byte decryption key for --keychain/--keychain-url from stdin.',
+      default: false,
+    }),
     install: Flags.string({
       description:
         'Local app file to upload and install automatically after creation. Repeat for multiple files.',
@@ -86,6 +105,10 @@ export default class IosCreate extends BaseCommand {
     }
     if (args.xcodeId && !flags.attach) {
       this.error('Xcode target argument requires --attach.');
+    }
+    const hasKeychainInitialAssets = Boolean(flags.keychain?.length || flags['keychain-url']?.length);
+    if (!hasKeychainInitialAssets && (flags['encryption-key'] || flags['encryption-key-stdin'])) {
+      this.error('Use --encryption-key or --encryption-key-stdin only with --keychain or --keychain-url.');
     }
 
     await this.withAuth(async () => {
@@ -125,6 +148,33 @@ export default class IosCreate extends BaseCommand {
           source: 'AssetName' as const,
           assetName: name,
         }));
+      }
+      if (hasKeychainInitialAssets) {
+        let encryptionKey: string;
+        try {
+          encryptionKey = await resolveKeychainEncryptionKey({
+            encryptionKey: flags['encryption-key'],
+            encryptionKeyStdin: flags['encryption-key-stdin'],
+          });
+        } catch (error) {
+          this.error((error as Error).message);
+        }
+        if (!params.spec) params.spec = {};
+        params.spec!.initialAssets = [
+          ...(params.spec!.initialAssets || []),
+          ...(flags.keychain || []).map((name) => ({
+            kind: 'Keychain' as const,
+            source: 'AssetName' as const,
+            assetName: name,
+            encryptionKey,
+          })),
+          ...(flags['keychain-url'] || []).map((url) => ({
+            kind: 'Keychain' as const,
+            source: 'URL' as const,
+            url,
+            encryptionKey,
+          })),
+        ];
       }
 
       if (flags.region) params.spec!.region = flags.region;

--- a/packages/cli/src/commands/ios/keychain/export.ts
+++ b/packages/cli/src/commands/ios/keychain/export.ts
@@ -1,6 +1,7 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command';
 import { getIosInstanceClient } from '../../../lib/instance-client-factory';
+import { resolveKeychainEncryptionKey } from '../../../lib/keychain-encryption-key';
 
 export default class IosKeychainExport extends BaseCommand {
   static summary = 'Export iOS keychain state to asset storage';
@@ -9,6 +10,8 @@ export default class IosKeychainExport extends BaseCommand {
   static examples = [
     '<%= config.bin %> ios keychain export keychain/state.tar.gz',
     '<%= config.bin %> ios keychain export keychain/state.tar.gz --ttl 24h --json',
+    '<%= config.bin %> ios keychain generate-key > keychain.key',
+    '<%= config.bin %> ios keychain export keychain/state.tar.gz --encryption-key-stdin < keychain.key',
   ];
 
   static args = {
@@ -30,18 +33,34 @@ export default class IosKeychainExport extends BaseCommand {
     ttl: Flags.string({
       description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
     }),
+    'encryption-key': Flags.string({
+      description: 'Base64/base64url 32-byte encryption key for the exported keychain archive.',
+    }),
+    'encryption-key-stdin': Flags.boolean({
+      description: 'Read the base64/base64url 32-byte encryption key from stdin.',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(IosKeychainExport);
     this.setParsedFlags(flags);
 
-    await this.withAuth(async () => {
-      const assetName = args.asset_name ?? flags['asset-name'];
-      if (!assetName) {
-        this.error('Provide a keychain asset name, e.g. `lim ios keychain export keychain/state.tar.gz`.');
-      }
+    const assetName = args.asset_name ?? flags['asset-name'];
+    if (!assetName) {
+      this.error('Provide a keychain asset name, e.g. `lim ios keychain export keychain/state.tar.gz`.');
+    }
+    let encryptionKey: string;
+    try {
+      encryptionKey = await resolveKeychainEncryptionKey({
+        encryptionKey: flags['encryption-key'],
+        encryptionKeyStdin: flags['encryption-key-stdin'],
+      });
+    } catch (error) {
+      this.error((error as Error).message);
+    }
 
+    await this.withAuth(async () => {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const asset = await this.client.assets.getOrCreate({
         name: assetName,
@@ -52,7 +71,7 @@ export default class IosKeychainExport extends BaseCommand {
 
       const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
       try {
-        await client.exportKeychain({ url: asset.signedUploadUrl });
+        await client.exportKeychain({ url: asset.signedUploadUrl, encryptionKey });
       } finally {
         disconnect();
       }

--- a/packages/cli/src/commands/ios/keychain/generate-key.ts
+++ b/packages/cli/src/commands/ios/keychain/generate-key.ts
@@ -1,0 +1,19 @@
+import { BaseCommand } from '../../../base-command';
+import { generateKeychainEncryptionKey } from '../../../lib/keychain-encryption-key';
+
+export default class IosKeychainGenerateKey extends BaseCommand {
+  static summary = 'Generate an iOS keychain encryption key';
+  static description =
+    'Print a new 32-byte base64 key for encrypted iOS keychain export and import. Store it securely and pass it to export/import on stdin.';
+  static examples = ['<%= config.bin %> ios keychain generate-key > keychain.key'];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosKeychainGenerateKey);
+    this.setParsedFlags(flags);
+    this.output(generateKeychainEncryptionKey());
+  }
+}

--- a/packages/cli/src/commands/ios/keychain/import.ts
+++ b/packages/cli/src/commands/ios/keychain/import.ts
@@ -1,6 +1,7 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command';
 import { getIosInstanceClient } from '../../../lib/instance-client-factory';
+import { resolveKeychainEncryptionKey } from '../../../lib/keychain-encryption-key';
 
 type KeychainAsset = {
   id: string;
@@ -18,6 +19,7 @@ export default class IosKeychainImport extends BaseCommand {
     '<%= config.bin %> ios keychain import keychain/state.tar.gz --id <instance-ID>',
     '<%= config.bin %> ios keychain import --asset-id <asset-ID>',
     '<%= config.bin %> ios keychain import --url https://example.t3.storage.dev/... --json',
+    '<%= config.bin %> ios keychain import keychain/state.tar.gz --encryption-key-stdin < keychain.key',
   ];
 
   static args = {
@@ -35,20 +37,36 @@ export default class IosKeychainImport extends BaseCommand {
     'asset-id': Flags.string({
       description: 'Keychain asset ID to import instead of resolving the positional asset name.',
     }),
+    'encryption-key': Flags.string({
+      description: 'Base64/base64url 32-byte decryption key for the keychain archive.',
+    }),
+    'encryption-key-stdin': Flags.boolean({
+      description: 'Read the base64/base64url 32-byte decryption key from stdin.',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(IosKeychainImport);
     this.setParsedFlags(flags);
 
+    let encryptionKey: string;
+    try {
+      encryptionKey = await resolveKeychainEncryptionKey({
+        encryptionKey: flags['encryption-key'],
+        encryptionKeyStdin: flags['encryption-key-stdin'],
+      });
+    } catch (error) {
+      this.error((error as Error).message);
+    }
+
     await this.withAuth(async () => {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const url =
         flags.url ?? (await this.resolveKeychainAssetDownloadUrl(args.asset_name, flags['asset-id']));
-
       const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
       try {
-        const result = await client.importKeychain({ url });
+        const result = await client.importKeychain({ url, encryptionKey });
         if (flags.json) {
           this.outputJson(result);
           return;

--- a/packages/cli/src/lib/keychain-encryption-key.ts
+++ b/packages/cli/src/lib/keychain-encryption-key.ts
@@ -1,0 +1,56 @@
+import { randomBytes } from 'crypto';
+
+export function generateKeychainEncryptionKey(): string {
+  return randomBytes(32).toString('base64');
+}
+
+export async function resolveKeychainEncryptionKey(options: {
+  encryptionKey?: string;
+  encryptionKeyStdin?: boolean;
+}): Promise<string> {
+  if (options.encryptionKey && options.encryptionKeyStdin) {
+    throw new Error('Use either --encryption-key or --encryption-key-stdin, not both.');
+  }
+  if (options.encryptionKey) {
+    const key = options.encryptionKey.trim();
+    validateKeychainEncryptionKey(key);
+    return key;
+  }
+  if (options.encryptionKeyStdin) {
+    return readKeychainEncryptionKeyFromStdin();
+  }
+  throw new Error('Provide --encryption-key or --encryption-key-stdin.');
+}
+
+export async function readKeychainEncryptionKeyFromStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new Error('Provide a 32-byte base64 key on stdin.');
+  }
+
+  const chunks: string[] = [];
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+
+  const key = chunks.join('').trim();
+  validateKeychainEncryptionKey(key);
+  return key;
+}
+
+export function validateKeychainEncryptionKey(key: string): void {
+  if (!key) {
+    throw new Error('Keychain encryption key is empty.');
+  }
+  if (!/^[A-Za-z0-9+/_=-]+$/.test(key)) {
+    throw new Error('Keychain encryption key must be base64 or base64url.');
+  }
+
+  let normalized = key.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = (4 - (normalized.length % 4)) % 4;
+  normalized += '='.repeat(padding);
+  const decoded = Buffer.from(normalized, 'base64');
+  if (decoded.length !== 32) {
+    throw new Error('Keychain encryption key must decode to exactly 32 bytes.');
+  }
+}

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -561,12 +561,12 @@ export type InstanceClient = {
   /**
    * Export the simulator keychain and upload it to a presigned asset-storage URL.
    */
-  exportKeychain: (options: { url: string }) => Promise<void>;
+  exportKeychain: (options: { url: string; encryptionKey: string }) => Promise<void>;
 
   /**
    * Download keychain state from a presigned asset-storage URL and apply it.
    */
-  importKeychain: (options: { url: string }) => Promise<KeychainImportResult>;
+  importKeychain: (options: { url: string; encryptionKey: string }) => Promise<KeychainImportResult>;
 
   /**
    * Set the device orientation
@@ -1422,7 +1422,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
     const redactRequestForDebug = (request: Record<string, unknown>): Record<string, unknown> => {
       if (request['type'] !== 'launchApp') {
-        return request;
+        return 'encryptionKey' in request ? { ...request, encryptionKey: '[REDACTED]' } : request;
       }
 
       const runtime = request['runtime'] as LaunchAppRuntime | undefined;
@@ -1850,14 +1850,22 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       );
     };
 
-    const exportKeychain = async (keychainOptions: { url: string }): Promise<void> => {
-      await sendRequest<void>('exportKeychain', { url: keychainOptions.url }, undefined, 120_000);
+    const exportKeychain = async (keychainOptions: { url: string; encryptionKey: string }): Promise<void> => {
+      await sendRequest<void>(
+        'exportKeychain',
+        { url: keychainOptions.url, encryptionKey: keychainOptions.encryptionKey },
+        undefined,
+        120_000,
+      );
     };
 
-    const importKeychain = async (keychainOptions: { url: string }): Promise<KeychainImportResult> => {
+    const importKeychain = async (keychainOptions: {
+      url: string;
+      encryptionKey: string;
+    }): Promise<KeychainImportResult> => {
       return sendRequest<KeychainImportResult>(
         'importKeychain',
-        { url: keychainOptions.url },
+        { url: keychainOptions.url, encryptionKey: keychainOptions.encryptionKey },
         undefined,
         120_000,
       );

--- a/src/resources/ios-instances.ts
+++ b/src/resources/ios-instances.ts
@@ -217,6 +217,12 @@ export namespace IosInstanceCreateParams {
       assetName?: string;
 
       /**
+       * Base64/base64url-encoded 32-byte key used to decrypt Keychain assets.
+       * Required when kind is Keychain.
+       */
+      encryptionKey?: string;
+
+      /**
        * Launch mode specifies how to launch the app after installation. If not given,
        * the app won't be launched.
        */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches simulator keychain handling and requires encryption keys on export/import/create paths; incorrect keys or missed CLI/SDK updates will break existing keychain automation.
> 
> **Overview**
> **Encrypted iOS keychain workflows** are now end-to-end: keychain archives are encrypted on export and decrypted on import, and the same key can be applied when creating a simulator from stored keychain assets.
> 
> The SDK and CLI **require** a base64/base64url 32-byte `encryptionKey` on `exportKeychain` / `importKeychain` (breaking change for callers that omitted it). Instance create accepts optional `--keychain` / `--keychain-url` initial assets with `--encryption-key` or `--encryption-key-stdin`. Shared CLI logic validates keys and reads them from stdin; **`lim ios keychain generate-key`** prints a new key.
> 
> `InitialAsset` for Keychain kinds documents optional `encryptionKey` for the create API. Debug logging **redacts** `encryptionKey` in outbound requests. The CLI dependency on `@limrun/api` is bumped to **^0.36.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0aa9d62acef34917c16d655c5fbf9273512b2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->