### PR TITLE
auth: use the new auth machinery with backend

### DIFF
--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -133,7 +133,7 @@ export abstract class BaseCommand extends Command {
       if (err instanceof AuthenticationError) {
         const config = readConfig();
         this.info('Session expired. Logging in...');
-        await login(config.consoleEndpoint, VERSION);
+        await login(config.apiEndpoint, config.consoleEndpoint, VERSION);
         this.info('You are logged in now.');
         // Reset client so it picks up the new key
         this._client = undefined;

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -135,7 +135,6 @@ export abstract class BaseCommand extends Command {
         this.info('Session expired. Logging in...');
         await login(config.apiEndpoint, config.consoleEndpoint, VERSION, {
           log: (message) => this.info(message),
-          promptBeforeOpen: !this.shouldSuppressInfo(),
         });
         this.info('You are logged in now.');
         // Reset client so it picks up the new key

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -133,7 +133,10 @@ export abstract class BaseCommand extends Command {
       if (err instanceof AuthenticationError) {
         const config = readConfig();
         this.info('Session expired. Logging in...');
-        await login(config.apiEndpoint, config.consoleEndpoint, VERSION);
+        await login(config.apiEndpoint, config.consoleEndpoint, VERSION, {
+          log: (message) => this.info(message),
+          promptBeforeOpen: !this.shouldSuppressInfo(),
+        });
         this.info('You are logged in now.');
         // Reset client so it picks up the new key
         this._client = undefined;

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -16,7 +16,7 @@ export default class Login extends BaseCommand {
     this.setParsedFlags(flags);
     const config = readConfig();
     this.log('Opening browser to log in...');
-    await login(config.consoleEndpoint, VERSION);
+    await login(config.apiEndpoint, config.consoleEndpoint, VERSION);
     this.log('You are logged in now.');
   }
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -3,20 +3,25 @@ import { readConfig } from '../lib/config';
 import { login } from '../lib/auth';
 
 const VERSION = require('../../package.json').version;
+const loginFlags = { ...BaseCommand.baseFlags };
+delete (loginFlags as Partial<typeof loginFlags>).json;
 
 export default class Login extends BaseCommand {
   static summary = 'Log in to Limrun';
   static description =
     'Open your browser to authenticate with Limrun and store the resulting API key locally for future CLI commands.';
   static examples = ['<%= config.bin %> login'];
-  static flags = { ...BaseCommand.baseFlags };
+  static flags = loginFlags;
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Login);
     this.setParsedFlags(flags);
     const config = readConfig();
-    this.log('Opening browser to log in...');
-    await login(config.apiEndpoint, config.consoleEndpoint, VERSION);
-    this.log('You are logged in now.');
+    this.info('Opening browser to log in...');
+    await login(config.apiEndpoint, config.consoleEndpoint, VERSION, {
+      log: (message) => this.info(message),
+      promptBeforeOpen: !this.shouldSuppressInfo(),
+    });
+    this.info('You are logged in now.');
   }
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -17,11 +17,10 @@ export default class Login extends BaseCommand {
     const { flags } = await this.parse(Login);
     this.setParsedFlags(flags);
     const config = readConfig();
-    this.info('Opening browser to log in...');
+    this.info('Authenticating with Limrun...');
     await login(config.apiEndpoint, config.consoleEndpoint, VERSION, {
       log: (message) => this.info(message),
-      promptBeforeOpen: !this.shouldSuppressInfo(),
     });
-    this.info('You are logged in now.');
+    this.info('Authentication successful.');
   }
 }

--- a/packages/cli/src/commands/set-api-key.ts
+++ b/packages/cli/src/commands/set-api-key.ts
@@ -1,0 +1,31 @@
+import { Args } from '@oclif/core';
+import { BaseCommand } from '../base-command';
+import { CONFIG_KEYS, writeConfig } from '../lib/config';
+
+const setApiKeyFlags = {
+  quiet: BaseCommand.baseFlags.quiet,
+};
+
+export default class SetApiKey extends BaseCommand {
+  static summary = 'Set the stored Limrun API key';
+  static description = 'Store an API key locally, equivalent to completing `lim login` manually.';
+  static examples = ['<%= config.bin %> set-api-key lim_...'];
+  static flags = setApiKeyFlags;
+  static args = {
+    apiKey: Args.string({
+      description: 'API key to store for future CLI commands.',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(SetApiKey);
+    this.setParsedFlags(flags);
+    const apiKey = args.apiKey.trim();
+    if (!apiKey) {
+      this.error('API key cannot be empty.');
+    }
+    writeConfig({ [CONFIG_KEYS.apiKey]: apiKey });
+    this.info('API key saved.');
+  }
+}

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -166,7 +166,9 @@ async function pollForToken(
     if (err instanceof LoginTimeoutError) {
       throw err;
     }
-    throw new RetryableLoginError(`Failed while waiting for CLI login approval: ${err instanceof Error ? err.message : String(err)}`);
+    throw new RetryableLoginError(
+      `Failed while waiting for CLI login approval: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
   if (response.status === 202) {
     return null;
@@ -213,7 +215,9 @@ async function fetchWithDeadline(
 }
 
 function loginTimeoutError(): LoginTimeoutError {
-  return new LoginTimeoutError('Login timed out waiting for browser authorization. Run `lim login` again to retry.');
+  return new LoginTimeoutError(
+    'Login timed out waiting for browser authorization. Run `lim login` again to retry.',
+  );
 }
 
 async function responseMessage(response: Response): Promise<string> {

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -1,20 +1,31 @@
-import http from 'http';
-import type { Socket } from 'net';
+import os from 'os';
 import { writeConfig, CONFIG_KEYS } from './config';
 
-const CALLBACK_PORT = 32412;
-const CALLBACK_HOST = 'localhost';
-const CALLBACK_PATH = '/authn/callback';
 const LOGIN_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
 
 interface LoginOptions {
+  apiEndpoint: string;
   consoleEndpoint: string;
   version: string;
-  callbackHost?: string;
-  callbackPort?: number;
   configWriter?: typeof writeConfig;
   opener?: (url: string) => Promise<unknown> | unknown;
+  fetcher?: typeof fetch;
+  hostname?: string;
   timeoutMs?: number;
+}
+
+interface CreateSessionResponse {
+  sessionId: string;
+  secret: string;
+  phrase: string;
+  verificationUrl: string;
+  expiresAt: string;
+  pollIntervalSeconds?: number;
+}
+
+interface CollectTokenResponse {
+  apiKey?: string;
+  message?: string;
 }
 
 async function openLoginUrl(url: string): Promise<void> {
@@ -25,115 +36,107 @@ async function openLoginUrl(url: string): Promise<void> {
   await open(url);
 }
 
-export async function login(consoleEndpoint: string, version: string): Promise<void> {
-  return loginWithOptions({ consoleEndpoint, version });
+export async function login(apiEndpoint: string, consoleEndpoint: string, version: string): Promise<void> {
+  return loginWithOptions({ apiEndpoint, consoleEndpoint, version });
 }
 
 export async function loginWithOptions(options: LoginOptions): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const { consoleEndpoint, version } = options;
-    const callbackHost = options.callbackHost ?? CALLBACK_HOST;
-    const callbackPort = options.callbackPort ?? CALLBACK_PORT;
-    const configWriter = options.configWriter ?? writeConfig;
-    const sockets = new Set<Socket>();
-    let settled = false;
-    let callbackTimeout: ReturnType<typeof setTimeout> | undefined;
+  const {
+    apiEndpoint,
+    consoleEndpoint,
+    version,
+    configWriter = writeConfig,
+    fetcher = fetch,
+    hostname = os.hostname(),
+  } = options;
 
-    const closeServer = () => {
-      if (server.listening) {
-        server.close();
-      }
-      server.closeIdleConnections?.();
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-    };
+  const session = await createSession(fetcher, apiEndpoint, consoleEndpoint, hostname, version);
+  console.log(`Confirm this phrase in your browser: ${session.phrase}`);
+  console.log(`Open this URL to log in:\n${session.verificationUrl}`);
 
-    const settle = (err?: Error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (callbackTimeout) {
-        clearTimeout(callbackTimeout);
-      }
-      closeServer();
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve();
-    };
-
-    const server = http.createServer((req, res) => {
-      // CORS preflight
-      if (req.method === 'OPTIONS') {
-        res.writeHead(200, {
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Methods': 'GET, OPTIONS',
-          'Access-Control-Allow-Headers': '*',
-          'Access-Control-Max-Age': '86400',
-          'Access-Control-Allow-Private-Network': 'true',
-          Connection: 'close',
-        });
-        res.end();
-        return;
-      }
-
-      const url = new URL(req.url || '/', `http://${callbackHost}:${callbackPort}`);
-      if (url.pathname !== CALLBACK_PATH) {
-        res.writeHead(404);
-        res.end('Not found');
-        return;
-      }
-
-      res.setHeader('Access-Control-Allow-Origin', '*');
-
-      const apiKey = url.searchParams.get(CONFIG_KEYS.apiKey);
-      if (!apiKey) {
-        res.writeHead(400, { Connection: 'close' });
-        res.end('missing api-key', () => {
-          settle(new Error('Login callback received without api-key'));
-        });
-        return;
-      }
-
-      try {
-        configWriter({ [CONFIG_KEYS.apiKey]: apiKey });
-      } catch (err) {
-        res.writeHead(500, { Connection: 'close' });
-        res.end('failed to save api-key', () => {
-          settle(err instanceof Error ? err : new Error(String(err)));
-        });
-        return;
-      }
-      res.writeHead(200, { Connection: 'close' });
-      res.end('OK', () => {
-        settle();
-      });
-    });
-
-    server.on('connection', (socket) => {
-      sockets.add(socket);
-      socket.on('close', () => {
-        sockets.delete(socket);
-      });
-    });
-
-    server.listen(callbackPort, callbackHost, () => {
-      const loginUrl = new URL('/authn/login', consoleEndpoint);
-      loginUrl.searchParams.set('user-agent', `lim/${version}`);
-      Promise.resolve((options.opener ?? openLoginUrl)(loginUrl.toString())).catch(() => {
-        console.log(`Open this URL in your browser to log in:\n${loginUrl.toString()}`);
-      });
-    });
-
-    callbackTimeout = setTimeout(() => {
-      settle(new Error('Login timed out waiting for browser authorization. Run `lim login` again to retry.'));
-    }, options.timeoutMs ?? LOGIN_CALLBACK_TIMEOUT_MS);
-
-    server.on('error', (err) => {
-      settle(new Error(`Failed to start login server on ${callbackHost}:${callbackPort}: ${err.message}`));
-    });
+  Promise.resolve((options.opener ?? openLoginUrl)(session.verificationUrl)).catch(() => {
+    // The URL is already printed above, so a failed opener does not block login.
   });
+
+  const deadline = Date.now() + (options.timeoutMs ?? LOGIN_CALLBACK_TIMEOUT_MS);
+  const pollIntervalMs = Math.max(1, session.pollIntervalSeconds ?? 2) * 1000;
+  for (;;) {
+    if (Date.now() >= deadline) {
+      throw new Error('Login timed out waiting for browser authorization. Run `lim login` again to retry.');
+    }
+
+    const token = await pollForToken(fetcher, apiEndpoint, session);
+    if (token) {
+      configWriter({ [CONFIG_KEYS.apiKey]: token });
+      return;
+    }
+
+    await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
+  }
+}
+
+async function createSession(
+  fetcher: typeof fetch,
+  apiEndpoint: string,
+  consoleEndpoint: string,
+  hostname: string,
+  version: string,
+): Promise<CreateSessionResponse> {
+  const response = await fetcher(new URL('/authn/cli/sessions', apiEndpoint), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ hostname, cliVersion: version }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to start CLI login session: ${await responseMessage(response)}`);
+  }
+  const session = (await response.json()) as CreateSessionResponse;
+  if (!session.sessionId || !session.secret || !session.phrase) {
+    throw new Error('Backend returned an invalid CLI login session.');
+  }
+  if (!session.verificationUrl) {
+    const verificationUrl = new URL('/authn/cli', consoleEndpoint);
+    verificationUrl.searchParams.set('session', session.sessionId);
+    session.verificationUrl = verificationUrl.toString();
+  }
+  return session;
+}
+
+async function pollForToken(
+  fetcher: typeof fetch,
+  apiEndpoint: string,
+  session: CreateSessionResponse,
+): Promise<string | null> {
+  const url = new URL(`/authn/cli/sessions/${encodeURIComponent(session.sessionId)}/token`, apiEndpoint);
+  url.searchParams.set('secret', session.secret);
+  const response = await fetcher(url);
+  if (response.status === 202) {
+    return null;
+  }
+  if (response.status === 410) {
+    throw new Error('CLI login session expired. Run `lim login` again to retry.');
+  }
+  if (!response.ok) {
+    throw new Error(`Failed while waiting for CLI login approval: ${await responseMessage(response)}`);
+  }
+  const body = (await response.json()) as CollectTokenResponse;
+  if (!body.apiKey) {
+    throw new Error('Backend approved the CLI login session without returning an API key.');
+  }
+  return body.apiKey;
+}
+
+async function responseMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as CollectTokenResponse;
+    return body.message || `${response.status} ${response.statusText}`;
+  } catch {
+    return `${response.status} ${response.statusText}`;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -1,6 +1,6 @@
+import { execFileSync } from 'child_process';
 import os from 'os';
 import process from 'process';
-import readline from 'readline/promises';
 import { writeConfig, CONFIG_KEYS } from './config';
 
 const LOGIN_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
@@ -10,7 +10,6 @@ interface LoginOptions {
   consoleEndpoint: string;
   version: string;
   log?: (message: string) => void;
-  promptBeforeOpen?: boolean;
   configWriter?: typeof writeConfig;
   opener?: (url: string) => Promise<unknown> | unknown;
   fetcher?: typeof fetch;
@@ -61,19 +60,21 @@ export async function loginWithOptions(options: LoginOptions): Promise<void> {
     version,
     configWriter = writeConfig,
     fetcher = fetch,
-    hostname = os.hostname(),
+    hostname = computerName(),
     log = console.log,
-  promptBeforeOpen = true,
   } = options;
 
   const deadline = Date.now() + (options.timeoutMs ?? LOGIN_CALLBACK_TIMEOUT_MS);
   const session = await createSession(fetcher, apiEndpoint, consoleEndpoint, hostname, version, deadline);
-  log(`Confirm this phrase in your browser: ${session.phrase}`);
-  log(`Open this URL to log in:\n${session.verificationUrl}`);
+  log(`\nConfirm this phrase in your browser: ${session.phrase}`);
+  log(`Opening this URL to log in: ${session.verificationUrl}\n\n`);
 
-  Promise.resolve(openBrowser(session.verificationUrl, options.opener ?? openLoginUrl, promptBeforeOpen, log)).catch(() => {
+  try {
+    await (options.opener ?? openLoginUrl)(session.verificationUrl);
+  } catch {
     // The URL is already printed above, so a failed opener does not block login.
-  });
+  }
+  log('Waiting for you to confirm in browser...');
 
   const pollIntervalMs = Math.max(1, session.pollIntervalSeconds ?? 2) * 1000;
   for (;;) {
@@ -100,22 +101,24 @@ export async function loginWithOptions(options: LoginOptions): Promise<void> {
   }
 }
 
-async function openBrowser(
-  url: string,
-  opener: (url: string) => Promise<unknown> | unknown,
-  promptBeforeOpen: boolean,
-  log: (message: string) => void,
-): Promise<void> {
-  if (promptBeforeOpen && process.stdin.isTTY && process.stdout.isTTY) {
-    log('Press Enter to open it in your browser.');
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+function computerName(): string {
+  if (process.platform === 'darwin') {
     try {
-      await rl.question('');
-    } finally {
-      rl.close();
+      const name = execFileSync('scutil', ['--get', 'ComputerName'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (name) {
+        return name;
+      }
+    } catch {
+      // Fall through to generic OS names.
     }
   }
-  await opener(url);
+  if (process.platform === 'win32' && process.env['COMPUTERNAME']) {
+    return process.env['COMPUTERNAME'];
+  }
+  return os.hostname();
 }
 
 async function createSession(

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -1,4 +1,6 @@
 import os from 'os';
+import process from 'process';
+import readline from 'readline/promises';
 import { writeConfig, CONFIG_KEYS } from './config';
 
 const LOGIN_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
@@ -7,6 +9,8 @@ interface LoginOptions {
   apiEndpoint: string;
   consoleEndpoint: string;
   version: string;
+  log?: (message: string) => void;
+  promptBeforeOpen?: boolean;
   configWriter?: typeof writeConfig;
   opener?: (url: string) => Promise<unknown> | unknown;
   fetcher?: typeof fetch;
@@ -28,6 +32,11 @@ interface CollectTokenResponse {
   message?: string;
 }
 
+type LoginRuntimeOptions = Omit<LoginOptions, 'apiEndpoint' | 'consoleEndpoint' | 'version'>;
+
+class RetryableLoginError extends Error {}
+class LoginTimeoutError extends Error {}
+
 async function openLoginUrl(url: string): Promise<void> {
   const importEsm = new Function('specifier', 'return import(specifier)') as (
     specifier: string,
@@ -36,8 +45,13 @@ async function openLoginUrl(url: string): Promise<void> {
   await open(url);
 }
 
-export async function login(apiEndpoint: string, consoleEndpoint: string, version: string): Promise<void> {
-  return loginWithOptions({ apiEndpoint, consoleEndpoint, version });
+export async function login(
+  apiEndpoint: string,
+  consoleEndpoint: string,
+  version: string,
+  options: LoginRuntimeOptions = {},
+): Promise<void> {
+  return loginWithOptions({ ...options, apiEndpoint, consoleEndpoint, version });
 }
 
 export async function loginWithOptions(options: LoginOptions): Promise<void> {
@@ -48,24 +62,35 @@ export async function loginWithOptions(options: LoginOptions): Promise<void> {
     configWriter = writeConfig,
     fetcher = fetch,
     hostname = os.hostname(),
+    log = console.log,
+  promptBeforeOpen = true,
   } = options;
 
-  const session = await createSession(fetcher, apiEndpoint, consoleEndpoint, hostname, version);
-  console.log(`Confirm this phrase in your browser: ${session.phrase}`);
-  console.log(`Open this URL to log in:\n${session.verificationUrl}`);
+  const deadline = Date.now() + (options.timeoutMs ?? LOGIN_CALLBACK_TIMEOUT_MS);
+  const session = await createSession(fetcher, apiEndpoint, consoleEndpoint, hostname, version, deadline);
+  log(`Confirm this phrase in your browser: ${session.phrase}`);
+  log(`Open this URL to log in:\n${session.verificationUrl}`);
 
-  Promise.resolve((options.opener ?? openLoginUrl)(session.verificationUrl)).catch(() => {
+  Promise.resolve(openBrowser(session.verificationUrl, options.opener ?? openLoginUrl, promptBeforeOpen, log)).catch(() => {
     // The URL is already printed above, so a failed opener does not block login.
   });
 
-  const deadline = Date.now() + (options.timeoutMs ?? LOGIN_CALLBACK_TIMEOUT_MS);
   const pollIntervalMs = Math.max(1, session.pollIntervalSeconds ?? 2) * 1000;
   for (;;) {
     if (Date.now() >= deadline) {
-      throw new Error('Login timed out waiting for browser authorization. Run `lim login` again to retry.');
+      throw loginTimeoutError();
     }
 
-    const token = await pollForToken(fetcher, apiEndpoint, session);
+    let token: string | null;
+    try {
+      token = await pollForToken(fetcher, apiEndpoint, session, deadline);
+    } catch (err) {
+      if (!(err instanceof RetryableLoginError) || Date.now() >= deadline) {
+        throw err;
+      }
+      await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
+      continue;
+    }
     if (token) {
       configWriter({ [CONFIG_KEYS.apiKey]: token });
       return;
@@ -75,14 +100,33 @@ export async function loginWithOptions(options: LoginOptions): Promise<void> {
   }
 }
 
+async function openBrowser(
+  url: string,
+  opener: (url: string) => Promise<unknown> | unknown,
+  promptBeforeOpen: boolean,
+  log: (message: string) => void,
+): Promise<void> {
+  if (promptBeforeOpen && process.stdin.isTTY && process.stdout.isTTY) {
+    log('Press Enter to open it in your browser.');
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      await rl.question('');
+    } finally {
+      rl.close();
+    }
+  }
+  await opener(url);
+}
+
 async function createSession(
   fetcher: typeof fetch,
   apiEndpoint: string,
   consoleEndpoint: string,
   hostname: string,
   version: string,
+  deadline: number,
 ): Promise<CreateSessionResponse> {
-  const response = await fetcher(new URL('/authn/cli/sessions', apiEndpoint), {
+  const response = await fetchWithDeadline(fetcher, new URL('/authn/cli/sessions', apiEndpoint), deadline, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -108,10 +152,19 @@ async function pollForToken(
   fetcher: typeof fetch,
   apiEndpoint: string,
   session: CreateSessionResponse,
+  deadline: number,
 ): Promise<string | null> {
   const url = new URL(`/authn/cli/sessions/${encodeURIComponent(session.sessionId)}/token`, apiEndpoint);
   url.searchParams.set('secret', session.secret);
-  const response = await fetcher(url);
+  let response: Response;
+  try {
+    response = await fetchWithDeadline(fetcher, url, deadline);
+  } catch (err) {
+    if (err instanceof LoginTimeoutError) {
+      throw err;
+    }
+    throw new RetryableLoginError(`Failed while waiting for CLI login approval: ${err instanceof Error ? err.message : String(err)}`);
+  }
   if (response.status === 202) {
     return null;
   }
@@ -119,13 +172,45 @@ async function pollForToken(
     throw new Error('CLI login session expired. Run `lim login` again to retry.');
   }
   if (!response.ok) {
-    throw new Error(`Failed while waiting for CLI login approval: ${await responseMessage(response)}`);
+    const message = `Failed while waiting for CLI login approval: ${await responseMessage(response)}`;
+    if (response.status === 408 || response.status === 429 || response.status >= 500) {
+      throw new RetryableLoginError(message);
+    }
+    throw new Error(message);
   }
   const body = (await response.json()) as CollectTokenResponse;
   if (!body.apiKey) {
     throw new Error('Backend approved the CLI login session without returning an API key.');
   }
   return body.apiKey;
+}
+
+async function fetchWithDeadline(
+  fetcher: typeof fetch,
+  input: URL,
+  deadline: number,
+  init: RequestInit = {},
+): Promise<Response> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    throw loginTimeoutError();
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), remaining);
+  try {
+    return await fetcher(input, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (controller.signal.aborted) {
+      throw loginTimeoutError();
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function loginTimeoutError(): LoginTimeoutError {
+  return new LoginTimeoutError('Login timed out waiting for browser authorization. Run `lim login` again to retry.');
 }
 
 async function responseMessage(response: Response): Promise<string> {

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -81,7 +81,9 @@ export async function ensureLoggedIn({ version, apiKey, log }: EnsureLoggedInOpt
   }
   log?.('Opening browser for Limrun login...');
   const { login } = await import('./auth');
-  await login(config.apiEndpoint, config.consoleEndpoint, version, log ? { log } : { promptBeforeOpen: false });
+  await login(config.apiEndpoint, config.consoleEndpoint, version, {
+    ...(log ? { log } : {}),
+  });
   log?.('Logged in to Limrun.');
 }
 

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -81,7 +81,7 @@ export async function ensureLoggedIn({ version, apiKey, log }: EnsureLoggedInOpt
   }
   log?.('Opening browser for Limrun login...');
   const { login } = await import('./auth');
-  await login(config.consoleEndpoint, version);
+  await login(config.apiEndpoint, config.consoleEndpoint, version);
   log?.('Logged in to Limrun.');
 }
 

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -81,7 +81,7 @@ export async function ensureLoggedIn({ version, apiKey, log }: EnsureLoggedInOpt
   }
   log?.('Opening browser for Limrun login...');
   const { login } = await import('./auth');
-  await login(config.apiEndpoint, config.consoleEndpoint, version);
+  await login(config.apiEndpoint, config.consoleEndpoint, version, log ? { log } : { promptBeforeOpen: false });
   log?.('Logged in to Limrun.');
 }
 

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -138,7 +138,7 @@ describe('lim login rendezvous session', () => {
         configWriter: () => {},
         opener: () => undefined,
         log: () => {},
-          timeoutMs: 10,
+        timeoutMs: 10,
       }),
     ).rejects.toThrow('Login timed out waiting for browser authorization');
   });
@@ -165,7 +165,7 @@ describe('lim login rendezvous session', () => {
         },
         opener: () => undefined,
         log: () => {},
-          timeoutMs: 1_000,
+        timeoutMs: 1_000,
       }),
     ).rejects.toThrow('disk full');
   });
@@ -195,7 +195,7 @@ describe('lim login rendezvous session', () => {
 
     expect(logs).toEqual([
       '\nConfirm this phrase in your browser: cosmic-otter-band',
-      `Opening this URL to log in: ${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test`,
+      `Opening this URL to log in: ${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test\n\n`,
       'Waiting for you to confirm in browser...',
     ]);
   });
@@ -229,7 +229,9 @@ describe('lim login rendezvous session', () => {
       timeoutMs: 1_000,
     });
 
-    await expect(Promise.race([loginPromise.then(() => 'done'), Promise.resolve('pending')])).resolves.toBe('pending');
+    await expect(Promise.race([loginPromise.then(() => 'done'), Promise.resolve('pending')])).resolves.toBe(
+      'pending',
+    );
     expect(configWrites).toEqual([]);
 
     finishOpen();
@@ -253,7 +255,7 @@ describe('lim login rendezvous session', () => {
         configWriter: () => {},
         opener: () => undefined,
         log: () => {},
-          timeoutMs: 10,
+        timeoutMs: 10,
       }),
     ).rejects.toThrow('Login timed out waiting for browser authorization');
   });

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -72,7 +72,6 @@ describe('lim login rendezvous session', () => {
         openedUrls.push(url);
       },
       log: () => {},
-      promptBeforeOpen: false,
       timeoutMs: 1_000,
     });
 
@@ -113,7 +112,6 @@ describe('lim login rendezvous session', () => {
         openedUrls.push(url);
       },
       log: () => {},
-      promptBeforeOpen: false,
       timeoutMs: 1_000,
     });
 
@@ -140,8 +138,7 @@ describe('lim login rendezvous session', () => {
         configWriter: () => {},
         opener: () => undefined,
         log: () => {},
-        promptBeforeOpen: false,
-        timeoutMs: 10,
+          timeoutMs: 10,
       }),
     ).rejects.toThrow('Login timed out waiting for browser authorization');
   });
@@ -168,8 +165,7 @@ describe('lim login rendezvous session', () => {
         },
         opener: () => undefined,
         log: () => {},
-        promptBeforeOpen: false,
-        timeoutMs: 1_000,
+          timeoutMs: 1_000,
       }),
     ).rejects.toThrow('disk full');
   });
@@ -194,14 +190,51 @@ describe('lim login rendezvous session', () => {
       configWriter: () => {},
       opener: () => undefined,
       log: (message) => logs.push(message),
-      promptBeforeOpen: false,
       timeoutMs: 1_000,
     });
 
     expect(logs).toEqual([
-      'Confirm this phrase in your browser: cosmic-otter-band',
-      `Open this URL to log in:\n${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test`,
+      '\nConfirm this phrase in your browser: cosmic-otter-band',
+      `Opening this URL to log in: ${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test`,
+      'Waiting for you to confirm in browser...',
     ]);
+  });
+
+  test('waits for browser opening before completing login', async () => {
+    const configWrites: Array<Partial<Record<string, string>>> = [];
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+    let finishOpen!: () => void;
+    const openerFinished = new Promise<void>((resolve) => {
+      finishOpen = resolve;
+    });
+
+    const fetcher: typeof fetch = async (input) => {
+      const url = requestUrl(input);
+      if (url.pathname === '/authn/cli/sessions') {
+        return sessionResponse();
+      }
+      return jsonResponse({ apiKey: 'lim_test_key' });
+    };
+
+    const loginPromise = loginWithOptions({
+      apiEndpoint: API_ENDPOINT,
+      consoleEndpoint: CONSOLE_ENDPOINT,
+      version: 'test',
+      fetcher,
+      configWriter: (partial) => {
+        configWrites.push(partial);
+      },
+      opener: () => openerFinished,
+      log: () => {},
+      timeoutMs: 1_000,
+    });
+
+    await expect(Promise.race([loginPromise.then(() => 'done'), Promise.resolve('pending')])).resolves.toBe('pending');
+    expect(configWrites).toEqual([]);
+
+    finishOpen();
+    await loginPromise;
+    expect(configWrites).toEqual([{ 'api-key': 'lim_test_key' }]);
   });
 
   test('aborts a hung session creation at the login deadline', async () => {
@@ -220,8 +253,7 @@ describe('lim login rendezvous session', () => {
         configWriter: () => {},
         opener: () => undefined,
         log: () => {},
-        promptBeforeOpen: false,
-        timeoutMs: 10,
+          timeoutMs: 10,
       }),
     ).rejects.toThrow('Login timed out waiting for browser authorization');
   });
@@ -256,7 +288,6 @@ describe('lim login rendezvous session', () => {
       },
       opener: () => undefined,
       log: () => {},
-      promptBeforeOpen: false,
       timeoutMs: 3_000,
     });
 

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -1,162 +1,266 @@
-import http from 'http';
-import net from 'net';
-
+const API_ENDPOINT = 'https://api.example.test';
 const CONSOLE_ENDPOINT = 'https://console.example.test';
 
-function getAvailablePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.listen(0, 'localhost', () => {
-      const address = server.address();
-      if (typeof address !== 'object' || !address) {
-        server.close();
-        reject(new Error('Failed to allocate test port'));
-        return;
-      }
-      const { port } = address;
-      server.close(() => resolve(port));
-    });
-    server.on('error', reject);
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
   });
 }
 
-function request(
-  port: number,
-  options: {
-    agent?: http.Agent;
-    headers?: http.OutgoingHttpHeaders;
-    method?: string;
-    path: string;
-  },
-): Promise<{ body: string; headers: http.IncomingHttpHeaders; statusCode: number | undefined }> {
-  return new Promise((resolve, reject) => {
-    const req = http.request(
-      {
-        agent: options.agent,
-        headers: options.headers,
-        host: 'localhost',
-        method: options.method ?? 'GET',
-        path: options.path,
-        port,
-      },
-      (res) => {
-        let body = '';
-        res.setEncoding('utf8');
-        res.on('data', (chunk) => {
-          body += chunk;
-        });
-        res.on('end', () => {
-          resolve({ body, headers: res.headers, statusCode: res.statusCode });
-        });
-      },
-    );
-    req.on('error', reject);
-    req.end();
-  });
+function requestUrl(input: string | URL | Request): URL {
+  if (input instanceof URL) {
+    return input;
+  }
+  if (typeof input === 'string') {
+    return new URL(input);
+  }
+  return new URL(input.url);
 }
 
-describe('lim login callback server', () => {
-  test('writes the api key and resolves promptly after a keep-alive callback', async () => {
-    const port = await getAvailablePort();
-    const agent = new http.Agent({ keepAlive: true });
+function sessionResponse(overrides: Partial<Record<string, unknown>> = {}): Response {
+  return jsonResponse(
+    {
+      sessionId: 'clisess_test',
+      secret: 'secret_test',
+      phrase: 'cosmic-otter-band',
+      verificationUrl: `${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test`,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      pollIntervalSeconds: 1,
+      ...overrides,
+    },
+    { status: 201 },
+  );
+}
+
+describe('lim login rendezvous session', () => {
+  test('creates a session, opens the approval URL, polls, and writes the api key', async () => {
     const configWrites: Array<Partial<Record<string, string>>> = [];
-    let hangingSocket: net.Socket | undefined;
-    let hangingSocketClosed: Promise<void> = Promise.resolve();
+    const openedUrls: string[] = [];
+    const requests: Array<{ body: string | undefined; method: string; url: string }> = [];
     const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
 
-    try {
-      const loginPromise = loginWithOptions({
-        consoleEndpoint: CONSOLE_ENDPOINT,
-        version: 'test',
-        callbackPort: port,
-        configWriter: (partial) => {
-          configWrites.push(partial);
-        },
-        opener: () => {
-          hangingSocket = net.createConnection({ host: 'localhost', port });
-          hangingSocketClosed = new Promise((resolve) => {
-            hangingSocket?.on('close', () => resolve());
-          });
-          void request(port, { agent, path: '/authn/callback?api-key=lim_test_key' }).catch(() => {});
-        },
-        timeoutMs: 1_000,
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = requestUrl(input);
+      requests.push({
+        body: typeof init?.body === 'string' ? init.body : undefined,
+        method: init?.method ?? 'GET',
+        url: url.toString(),
       });
-
-      const timeout = new Promise((resolve) => setTimeout(() => resolve('timeout'), 500));
-      await expect(Promise.race([loginPromise.then(() => 'resolved'), timeout])).resolves.toBe('resolved');
-      await expect(Promise.race([hangingSocketClosed.then(() => 'closed'), timeout])).resolves.toBe('closed');
-      expect(configWrites).toEqual([{ 'api-key': 'lim_test_key' }]);
-    } finally {
-      agent.destroy();
-      hangingSocket?.destroy();
-    }
-  });
-
-  test('allows browser private-network preflight before callback delivery', async () => {
-    const port = await getAvailablePort();
-    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
-    let preflightHeaders: http.IncomingHttpHeaders | undefined;
+      if (url.pathname === '/authn/cli/sessions') {
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        return sessionResponse();
+      }
+      if (url.pathname === '/authn/cli/sessions/clisess_test/token') {
+        expect(url.searchParams.get('secret')).toBe('secret_test');
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        return jsonResponse({ apiKey: 'lim_test_key' });
+      }
+      return jsonResponse({ message: 'not found' }, { status: 404 });
+    };
 
     await loginWithOptions({
+      apiEndpoint: API_ENDPOINT,
       consoleEndpoint: CONSOLE_ENDPOINT,
       version: 'test',
-      callbackPort: port,
-      configWriter: () => {},
-      opener: () => {
-        void (async () => {
-          const preflight = await request(port, {
-            headers: {
-              Origin: 'https://console.limrun.com',
-              'Access-Control-Request-Method': 'GET',
-              'Access-Control-Request-Private-Network': 'true',
-            },
-            method: 'OPTIONS',
-            path: '/authn/callback?api-key=lim_test_key',
-          });
-          preflightHeaders = preflight.headers;
-          await request(port, { path: '/authn/callback?api-key=lim_test_key' });
-        })().catch(() => {});
+      hostname: 'test-host',
+      fetcher,
+      configWriter: (partial) => {
+        configWrites.push(partial);
       },
+      opener: (url) => {
+        openedUrls.push(url);
+      },
+      log: () => {},
+      promptBeforeOpen: false,
       timeoutMs: 1_000,
     });
 
-    expect(preflightHeaders?.['access-control-allow-private-network']).toBe('true');
-    expect(preflightHeaders?.connection).toBe('close');
+    expect(configWrites).toEqual([{ 'api-key': 'lim_test_key' }]);
+    expect(openedUrls).toEqual([`${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test`]);
+    expect(requests).toEqual([
+      {
+        body: JSON.stringify({ hostname: 'test-host', cliVersion: 'test' }),
+        method: 'POST',
+        url: `${API_ENDPOINT}/authn/cli/sessions`,
+      },
+      {
+        method: 'GET',
+        url: `${API_ENDPOINT}/authn/cli/sessions/clisess_test/token?secret=secret_test`,
+      },
+    ]);
   });
 
-  test('rejects when the browser never calls back', async () => {
-    const port = await getAvailablePort();
+  test('falls back to console endpoint when the backend omits verificationUrl', async () => {
+    const openedUrls: string[] = [];
     const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+
+    const fetcher: typeof fetch = async (input) => {
+      const url = requestUrl(input);
+      if (url.pathname === '/authn/cli/sessions') {
+        return sessionResponse({ verificationUrl: '' });
+      }
+      return jsonResponse({ apiKey: 'lim_test_key' });
+    };
+
+    await loginWithOptions({
+      apiEndpoint: API_ENDPOINT,
+      consoleEndpoint: CONSOLE_ENDPOINT,
+      version: 'test',
+      fetcher,
+      configWriter: () => {},
+      opener: (url) => {
+        openedUrls.push(url);
+      },
+      log: () => {},
+      promptBeforeOpen: false,
+      timeoutMs: 1_000,
+    });
+
+    expect(openedUrls).toEqual([`${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test`]);
+  });
+
+  test('rejects when the browser never approves the session', async () => {
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+
+    const fetcher: typeof fetch = async (input) => {
+      const url = requestUrl(input);
+      if (url.pathname === '/authn/cli/sessions') {
+        return sessionResponse();
+      }
+      return jsonResponse({ status: 'pending' }, { status: 202 });
+    };
 
     await expect(
       loginWithOptions({
+        apiEndpoint: API_ENDPOINT,
         consoleEndpoint: CONSOLE_ENDPOINT,
         version: 'test',
-        callbackPort: port,
+        fetcher,
         configWriter: () => {},
         opener: () => undefined,
+        log: () => {},
+        promptBeforeOpen: false,
         timeoutMs: 10,
       }),
     ).rejects.toThrow('Login timed out waiting for browser authorization');
   });
 
   test('rejects cleanly when saving the api key fails', async () => {
-    const port = await getAvailablePort();
     const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+
+    const fetcher: typeof fetch = async (input) => {
+      const url = requestUrl(input);
+      if (url.pathname === '/authn/cli/sessions') {
+        return sessionResponse();
+      }
+      return jsonResponse({ apiKey: 'lim_test_key' });
+    };
 
     await expect(
       loginWithOptions({
+        apiEndpoint: API_ENDPOINT,
         consoleEndpoint: CONSOLE_ENDPOINT,
         version: 'test',
-        callbackPort: port,
+        fetcher,
         configWriter: () => {
           throw new Error('disk full');
         },
-        opener: () => {
-          void request(port, { path: '/authn/callback?api-key=lim_test_key' }).catch(() => {});
-        },
+        opener: () => undefined,
+        log: () => {},
+        promptBeforeOpen: false,
         timeoutMs: 1_000,
       }),
     ).rejects.toThrow('disk full');
+  });
+
+  test('sends phrase and URL through the provided logger only', async () => {
+    const logs: string[] = [];
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+
+    const fetcher: typeof fetch = async (input) => {
+      const url = requestUrl(input);
+      if (url.pathname === '/authn/cli/sessions') {
+        return sessionResponse();
+      }
+      return jsonResponse({ apiKey: 'lim_test_key' });
+    };
+
+    await loginWithOptions({
+      apiEndpoint: API_ENDPOINT,
+      consoleEndpoint: CONSOLE_ENDPOINT,
+      version: 'test',
+      fetcher,
+      configWriter: () => {},
+      opener: () => undefined,
+      log: (message) => logs.push(message),
+      promptBeforeOpen: false,
+      timeoutMs: 1_000,
+    });
+
+    expect(logs).toEqual([
+      'Confirm this phrase in your browser: cosmic-otter-band',
+      `Open this URL to log in:\n${CONSOLE_ENDPOINT}/authn/cli?session=clisess_test`,
+    ]);
+  });
+
+  test('aborts a hung session creation at the login deadline', async () => {
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+    const fetcher: typeof fetch = (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+
+    await expect(
+      loginWithOptions({
+        apiEndpoint: API_ENDPOINT,
+        consoleEndpoint: CONSOLE_ENDPOINT,
+        version: 'test',
+        fetcher,
+        configWriter: () => {},
+        opener: () => undefined,
+        log: () => {},
+        promptBeforeOpen: false,
+        timeoutMs: 10,
+      }),
+    ).rejects.toThrow('Login timed out waiting for browser authorization');
+  });
+
+  test('retries transient polling failures until approval', async () => {
+    const { loginWithOptions } = await import('../packages/cli/src/lib/auth');
+    const configWrites: Array<Partial<Record<string, string>>> = [];
+    let pollCount = 0;
+
+    const fetcher: typeof fetch = async (input) => {
+      const url = requestUrl(input);
+      if (url.pathname === '/authn/cli/sessions') {
+        return sessionResponse({ pollIntervalSeconds: 0 });
+      }
+      pollCount += 1;
+      if (pollCount === 1) {
+        throw new Error('temporary network failure');
+      }
+      if (pollCount === 2) {
+        return jsonResponse({ message: 'try again' }, { status: 503 });
+      }
+      return jsonResponse({ apiKey: 'lim_test_key' });
+    };
+
+    await loginWithOptions({
+      apiEndpoint: API_ENDPOINT,
+      consoleEndpoint: CONSOLE_ENDPOINT,
+      version: 'test',
+      fetcher,
+      configWriter: (partial) => {
+        configWrites.push(partial);
+      },
+      opener: () => undefined,
+      log: () => {},
+      promptBeforeOpen: false,
+      timeoutMs: 3_000,
+    });
+
+    expect(pollCount).toBe(3);
+    expect(configWrites).toEqual([{ 'api-key': 'lim_test_key' }]);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> This is a breaking change to how CLI credentials are obtained and stored; all login paths must stay aligned with the new backend authn API.
> 
> **Overview**
> **CLI login** no longer runs a localhost HTTP callback. It **POSTs** to `/authn/cli/sessions` on the API (with hostname and CLI version), shows a **confirmation phrase** and opens the console **verification URL**, then **polls** `/authn/cli/sessions/:id/token` until the API key is returned or the session times out. Transient poll errors (network, 429, 5xx) are retried; 202 means still pending.
> 
> `lim login`, session refresh in `withAuth`, and onboarding `ensureLoggedIn` all pass **`apiEndpoint`** plus an injectable **`log`** hook. **`lim set-api-key`** is new for storing a key locally without the browser flow.
> 
> Tests were rewritten around the rendezvous/poll flow instead of the old callback server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9751bc78a192af054d61105b06bdc6add3ce30ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->