### PR TITLE
cli: show termination reason in get commands

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "^0.37.2",
+        "@limrun/api": "^0.38.0",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.37.2.tgz",
-      "integrity": "sha512-I1W6VtcvZHle+kePfGY1YmzgK+PfcBpPjCn05qaujbikYKUC/ZdVFknearOe1Gj92hVBTAX6OsqdKQuxAfKRKQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.38.0.tgz",
+      "integrity": "sha512-60MADFTeyhc/lti5FYQ6NOgFFEQo3YnfZMBETy7G+p4CKvJGE8Yy4fd+BVR1OUNE9POaKxPgRLRZ5VxOVQIjXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "eventsource-client": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.37.2",
+    "@limrun/api": "^0.38.0",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/android/get.ts
+++ b/packages/cli/src/commands/android/get.ts
@@ -31,6 +31,8 @@ export default class AndroidGet extends BaseCommand {
         this.output(`Name: ${instance.metadata.displayName || ''}`);
         this.output(`Region: ${instance.spec.region}`);
         this.output(`State: ${instance.status.state}`);
+        if (instance.status.terminationReason)
+          this.output(`Termination Reason: ${instance.status.terminationReason}`);
         this.output(`Console URL: ${this.consoleStreamUrl(instance.metadata.id)}`);
         if (instance.status.apiUrl) this.output(`API URL: ${instance.status.apiUrl}`);
         if (instance.status.adbWebSocketUrl)

--- a/packages/cli/src/commands/ios/get.ts
+++ b/packages/cli/src/commands/ios/get.ts
@@ -31,6 +31,8 @@ export default class IosGet extends BaseCommand {
         this.output(`Name: ${instance.metadata.displayName || ''}`);
         this.output(`Region: ${instance.spec.region}`);
         this.output(`State: ${instance.status.state}`);
+        if (instance.status.terminationReason)
+          this.output(`Termination Reason: ${instance.status.terminationReason}`);
         this.output(`Console URL: ${this.consoleStreamUrl(instance.metadata.id)}`);
         if (instance.status.apiUrl) this.output(`API URL: ${instance.status.apiUrl}`);
         if (instance.status.sandbox?.xcode?.url) {

--- a/packages/cli/src/commands/xcode/get.ts
+++ b/packages/cli/src/commands/xcode/get.ts
@@ -35,6 +35,8 @@ export default class XcodeGet extends BaseCommand {
           this.output(`Name: ${instance.metadata.displayName || ''}`);
           this.output(`Region: ${instance.spec.region}`);
           this.output(`State: ${instance.status.state}`);
+          if (instance.status.terminationReason)
+            this.output(`Termination Reason: ${instance.status.terminationReason}`);
           this.output(`Console URL: ${this.consoleStreamUrl(instance.metadata.id)}`);
           if (instance.status.sandbox?.xcode?.url) {
             this.output(`Xcode Sandbox URL: ${instance.status.sandbox.xcode.url}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small display-only CLI changes plus a dependency minor bump; no auth or instance lifecycle logic changes.
> 
> **Overview**
> Bumps **`@limrun/api`** to **^0.38.0** so the CLI can read **`terminationReason`** on instance status.
> 
> For human-readable output (not `--json`), **`android get`**, **`ios get`**, and **`xcode get`** (iOS-with-sandbox path) now print **Termination Reason** when that field is present, right after **State**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa1df25504bf2b0a3fac4250487b15ca6af3c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->