### PR TITLE
ios: implement the callback with logs for app crashes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,9 @@
       "asset": {
         "description": "Upload, download, list, inspect, and delete files that can be used by iOS & Android as pre-installed apps: push, pull, list, delete"
       },
+      "assets": {
+        "description": "Upload, download, list, inspect, and delete files that can be used by iOS & Android as pre-installed apps: push, pull, list, delete"
+      },
       "session": {
         "description": "Manage persistent background sessions for device interaction: start, status, stop. Sessions are used to execute commands on remote devices without the need to reconnect to the device after each command."
       },

--- a/packages/cli/src/commands/asset/delete.ts
+++ b/packages/cli/src/commands/asset/delete.ts
@@ -4,6 +4,7 @@ import { BaseCommand } from '../../base-command';
 export default class AssetDelete extends BaseCommand {
   static summary = 'Delete an asset';
   static description = 'Delete an uploaded asset by ID.';
+  static aliases = ['assets:delete'];
   static examples = ['<%= config.bin %> asset delete <ID>', '<%= config.bin %> asset delete asset_abc123'];
 
   static args = {

--- a/packages/cli/src/commands/asset/list.ts
+++ b/packages/cli/src/commands/asset/list.ts
@@ -5,6 +5,7 @@ export default class AssetList extends BaseCommand {
   static summary = 'List assets or get a specific one';
   static description =
     'List uploaded assets in your account or fetch a single asset by ID. You can optionally include signed download or upload URLs when preparing follow-up automation steps.';
+  static aliases = ['assets:list'];
   static examples = [
     '<%= config.bin %> asset list',
     '<%= config.bin %> asset list <ID>',

--- a/packages/cli/src/commands/asset/pull.ts
+++ b/packages/cli/src/commands/asset/pull.ts
@@ -7,6 +7,7 @@ export default class AssetPull extends BaseCommand {
   static summary = 'Download an asset file';
   static description =
     'Download an asset by ID or by name into a local directory. For reliable automation, prefer an asset ID or ensure the name resolves to exactly one asset.';
+  static aliases = ['assets:pull'];
   static examples = [
     '<%= config.bin %> asset pull <ID>',
     '<%= config.bin %> asset pull my-app.apk',

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -7,6 +7,7 @@ export default class AssetPush extends BaseCommand {
   static summary = 'Upload an asset file';
   static description =
     'Upload a local file to Limrun asset storage so it can be installed on instances or reused by later commands. The asset name defaults to the filename unless you provide `-n`.';
+  static aliases = ['assets:push'];
   static examples = [
     '<%= config.bin %> asset push ./app.apk',
     '<%= config.bin %> asset push ./app.ipa -n my-app',

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -274,8 +274,8 @@ export type LaunchAppShutdownCallback = (exitCode: number, logs: string[]) => Pr
 
 type LaunchAppShutdownOptions = {
   /**
-   * Called once when the launched app process exits. The SDK fetches the
-   * server-reported app log tail before invoking this callback.
+   * Called when the launched app exits. The logs array contains one entry per
+   * stdout/stderr line produced by that execution, as reported by limulator.
    */
   onShutdown?: LaunchAppShutdownCallback;
 };
@@ -946,7 +946,6 @@ type SimctlRequest = {
 type ServerResponse = {
   type: string;
   id: string;
-  execId?: string;
   error?: string;
   // Response-specific fields
   base64?: string;
@@ -971,6 +970,8 @@ type ServerResponse = {
   exitCode?: number;
   // Log tail fields
   logs?: string;
+  // App shutdown fields
+  execId?: string;
   logLineCount?: number;
   // App log streaming fields
   lines?: string[];
@@ -1306,7 +1307,12 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
   // Simctl uses streaming, so it needs separate handling
   const simctlExecutions: Map<string, SimctlExecution> = new Map();
-  const appShutdownCallbacks: Map<string, LaunchAppShutdownCallback> = new Map();
+
+  // Server notifications are keyed by notification type and that type's
+  // identifier field. They intentionally survive transient WebSocket reconnects
+  // and are one-shot once a matching notification is processed.
+  type ServerNotificationHandler = (message: ServerResponse) => Promise<void>;
+  const serverNotifications: Map<string, Map<string, ServerNotificationHandler>> = new Map();
 
   const xcrunShimCleanups: Array<() => Promise<void>> = [];
   const httpProxyCleanups: Array<() => Promise<void>> = [];
@@ -1352,7 +1358,6 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
     simctlExecutions.forEach((execution) => execution._handleError(new Error(reason)));
     simctlExecutions.clear();
-    appShutdownCallbacks.clear();
   };
 
   const cleanupConnection = (): void => {
@@ -1389,6 +1394,52 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
     cleanupClientResources();
   };
 
+  const registerServerNotification = (
+    type: string,
+    notificationId: string,
+    handler: ServerNotificationHandler,
+  ): void => {
+    const handlers = serverNotifications.get(type) ?? new Map<string, ServerNotificationHandler>();
+    handlers.set(notificationId, handler);
+    serverNotifications.set(type, handlers);
+  };
+
+  const takeServerNotification = (
+    type: string,
+    notificationId: string,
+  ): ServerNotificationHandler | undefined => {
+    const handlers = serverNotifications.get(type);
+    if (!handlers) {
+      return undefined;
+    }
+
+    const handler = handlers.get(notificationId);
+    if (!handler) {
+      return undefined;
+    }
+
+    handlers.delete(notificationId);
+    if (handlers.size === 0) {
+      serverNotifications.delete(type);
+    }
+    return handler;
+  };
+
+  const deleteServerNotification = (type: string, notificationId: string): void => {
+    const handlers = serverNotifications.get(type);
+    if (!handlers) {
+      return;
+    }
+    handlers.delete(notificationId);
+    if (handlers.size === 0) {
+      serverNotifications.delete(type);
+    }
+  };
+
+  const clearServerNotifications = (): void => {
+    serverNotifications.clear();
+  };
+
   let pingInterval: NodeJS.Timeout | undefined;
   const keepAliveSessionId =
     Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
@@ -1406,12 +1457,14 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       if (isNonRetryableError(lastError ?? '')) {
         logger.error(`Skipping reconnection (non-retryable error): ${lastError}`);
         updateConnectionState('disconnected');
+        clearServerNotifications();
         return;
       }
 
       if (reconnectAttempts >= maxReconnectAttempts) {
         logger.error(`Max reconnection attempts (${maxReconnectAttempts}) reached. Giving up.`);
         updateConnectionState('disconnected');
+        clearServerNotifications();
         return;
       }
 
@@ -1486,6 +1539,45 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       });
     };
 
+    const splitAppLogTail = (logs: string): string[] => {
+      if (logs.length === 0) {
+        return [];
+      }
+      return logs.split(/\r?\n/);
+    };
+
+    const handleAppShutdown = (message: ServerResponse): boolean => {
+      if (message.type !== 'appShutdown') {
+        return false;
+      }
+
+      const { execId, bundleId, exitCode, logLineCount } = message;
+      if (
+        typeof execId !== 'string' ||
+        typeof bundleId !== 'string' ||
+        typeof exitCode !== 'number' ||
+        !Number.isInteger(exitCode) ||
+        typeof logLineCount !== 'number' ||
+        !Number.isInteger(logLineCount) ||
+        logLineCount < 0
+      ) {
+        logger.warn('Received malformed appShutdown message:', message);
+        return true;
+      }
+
+      const notification = takeServerNotification('appShutdown', execId);
+      if (!notification) {
+        logger.debug(`Received appShutdown for unknown or already handled execId: ${execId}`);
+        return true;
+      }
+
+      void notification(message).catch((error) => {
+        logger.error(`Error processing appShutdown notification for execId ${execId}:`, error);
+      });
+
+      return true;
+    };
+
     // Response handlers - transform raw responses to typed results
     const responseHandlers: Record<string, (msg: ServerResponse) => unknown> = {
       screenshotResult: (msg) => ({
@@ -1544,45 +1636,6 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       }),
     };
 
-    const splitAppLogTail = (logs: string): string[] => {
-      if (logs.length === 0) {
-        return [];
-      }
-      return logs.split('\n');
-    };
-
-    const handleAppShutdown = (message: ServerResponse): void => {
-      const execId = message.execId;
-      if (!execId) {
-        logger.warn('Received appShutdown without execId');
-        return;
-      }
-
-      const callback = appShutdownCallbacks.get(execId);
-      if (!callback) {
-        logger.debug(`Received appShutdown for unknown execId: ${execId}`);
-        return;
-      }
-      appShutdownCallbacks.delete(execId);
-
-      const bundleId = message.bundleId;
-      const exitCode = message.exitCode;
-      const logLineCount = message.logLineCount;
-      if (!bundleId || exitCode === undefined || logLineCount === undefined) {
-        logger.warn(`Received incomplete appShutdown for execId: ${execId}`);
-        return;
-      }
-
-      void (async () => {
-        try {
-          const tail = await appLogTail(bundleId, logLineCount);
-          await callback(exitCode, splitAppLogTail(tail));
-        } catch (err) {
-          logger.error('Error in app shutdown callback:', err);
-        }
-      })();
-    };
-
     const setupWebSocket = (): void => {
       cleanupConnection();
       updateConnectionState('connecting');
@@ -1599,8 +1652,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
           return;
         }
 
-        if (message.type === 'appShutdown') {
-          handleAppShutdown(message);
+        if (handleAppShutdown(message)) {
           return;
         }
 
@@ -1697,6 +1749,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
           cleanup();
           updateConnectionState('disconnected');
           failPendingRequests('Non-retryable error');
+          clearServerNotifications();
           logger.debug('Non-retryable error. Closing connection.');
         }
       });
@@ -1859,9 +1912,38 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         );
       }
       const mode = launchOptions.runtime ? 'RelaunchIfRunning' : launchOptions.mode;
-      const execId = launchOptions.onShutdown ? generateId() : undefined;
-      if (execId && launchOptions.onShutdown) {
-        appShutdownCallbacks.set(execId, launchOptions.onShutdown);
+      const onShutdown = launchOptions.onShutdown;
+      const execId = onShutdown ? generateId() : undefined;
+      if (execId && onShutdown) {
+        registerServerNotification('appShutdown', execId, async (message) => {
+          const { bundleId, exitCode, logLineCount } = message;
+          if (
+            typeof bundleId !== 'string' ||
+            typeof exitCode !== 'number' ||
+            !Number.isInteger(exitCode) ||
+            typeof logLineCount !== 'number' ||
+            !Number.isInteger(logLineCount) ||
+            logLineCount < 0
+          ) {
+            logger.warn(`Received malformed appShutdown payload for execId ${execId}:`, message);
+            return;
+          }
+
+          let logs: string[] = [];
+          try {
+            logs = splitAppLogTail(
+              await sendRequest<string>('appLogTail', { bundleId, lines: logLineCount }),
+            );
+          } catch (error) {
+            logger.error(`Failed to fetch app logs for shutdown execId ${execId}:`, error);
+          }
+
+          try {
+            await onShutdown(exitCode, logs);
+          } catch (error) {
+            logger.error(`Error in onShutdown callback for execId ${execId}:`, error);
+          }
+        });
       }
       return sendRequest<void>('launchApp', {
         bundleId,
@@ -1870,7 +1952,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         execId,
       }).catch((error) => {
         if (execId) {
-          appShutdownCallbacks.delete(execId);
+          deleteServerNotification('appShutdown', execId);
         }
         throw error;
       });
@@ -2337,6 +2419,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       cleanup();
       updateConnectionState('disconnected');
       failPendingRequests('Intentional disconnect');
+      clearServerNotifications();
       logger.debug('Intentionally disconnected from WebSocket.');
     };
 

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -270,7 +270,17 @@ export type DetoxLaunchRuntime = {
 
 export type LaunchAppRuntime = DetoxLaunchRuntime;
 
-type StandardLaunchAppOptions = {
+export type LaunchAppShutdownCallback = (exitCode: number, logs: string[]) => Promise<void>;
+
+type LaunchAppShutdownOptions = {
+  /**
+   * Called once when the launched app process exits. The SDK fetches the
+   * server-reported app log tail before invoking this callback.
+   */
+  onShutdown?: LaunchAppShutdownCallback;
+};
+
+type StandardLaunchAppOptions = LaunchAppShutdownOptions & {
   /**
    * Launch behavior when the app may already be running.
    * Defaults to `ForegroundIfRunning` server-side.
@@ -279,7 +289,7 @@ type StandardLaunchAppOptions = {
   runtime?: undefined;
 };
 
-type RuntimeLaunchAppOptions = {
+type RuntimeLaunchAppOptions = LaunchAppShutdownOptions & {
   /** Runtime launches must relaunch so runtime injection is applied. */
   mode?: Extract<LaunchAppMode, 'RelaunchIfRunning'>;
   /** Optional app runtime to attach during launch. */
@@ -936,6 +946,7 @@ type SimctlRequest = {
 type ServerResponse = {
   type: string;
   id: string;
+  execId?: string;
   error?: string;
   // Response-specific fields
   base64?: string;
@@ -960,6 +971,7 @@ type ServerResponse = {
   exitCode?: number;
   // Log tail fields
   logs?: string;
+  logLineCount?: number;
   // App log streaming fields
   lines?: string[];
   // performActions batch result fields
@@ -1294,6 +1306,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
   // Simctl uses streaming, so it needs separate handling
   const simctlExecutions: Map<string, SimctlExecution> = new Map();
+  const appShutdownCallbacks: Map<string, LaunchAppShutdownCallback> = new Map();
 
   const xcrunShimCleanups: Array<() => Promise<void>> = [];
   const httpProxyCleanups: Array<() => Promise<void>> = [];
@@ -1339,6 +1352,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
     simctlExecutions.forEach((execution) => execution._handleError(new Error(reason)));
     simctlExecutions.clear();
+    appShutdownCallbacks.clear();
   };
 
   const cleanupConnection = (): void => {
@@ -1427,6 +1441,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       return {
         type: request['type'],
         id: request['id'],
+        execId: request['execId'],
         bundleId: request['bundleId'],
         mode: request['mode'],
         runtime: runtime ? { kind: runtime.kind, version: runtime.version } : undefined,
@@ -1529,6 +1544,45 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       }),
     };
 
+    const splitAppLogTail = (logs: string): string[] => {
+      if (logs.length === 0) {
+        return [];
+      }
+      return logs.split('\n');
+    };
+
+    const handleAppShutdown = (message: ServerResponse): void => {
+      const execId = message.execId;
+      if (!execId) {
+        logger.warn('Received appShutdown without execId');
+        return;
+      }
+
+      const callback = appShutdownCallbacks.get(execId);
+      if (!callback) {
+        logger.debug(`Received appShutdown for unknown execId: ${execId}`);
+        return;
+      }
+      appShutdownCallbacks.delete(execId);
+
+      const bundleId = message.bundleId;
+      const exitCode = message.exitCode;
+      const logLineCount = message.logLineCount;
+      if (!bundleId || exitCode === undefined || logLineCount === undefined) {
+        logger.warn(`Received incomplete appShutdown for execId: ${execId}`);
+        return;
+      }
+
+      void (async () => {
+        try {
+          const tail = await appLogTail(bundleId, logLineCount);
+          await callback(exitCode, splitAppLogTail(tail));
+        } catch (err) {
+          logger.error('Error in app shutdown callback:', err);
+        }
+      })();
+    };
+
     const setupWebSocket = (): void => {
       cleanupConnection();
       updateConnectionState('connecting');
@@ -1542,6 +1596,11 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
           message = JSON.parse(data.toString());
         } catch (e) {
           logger.error({ data, error: e }, 'Failed to parse JSON message');
+          return;
+        }
+
+        if (message.type === 'appShutdown') {
+          handleAppShutdown(message);
           return;
         }
 
@@ -1800,10 +1859,20 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         );
       }
       const mode = launchOptions.runtime ? 'RelaunchIfRunning' : launchOptions.mode;
+      const execId = launchOptions.onShutdown ? generateId() : undefined;
+      if (execId && launchOptions.onShutdown) {
+        appShutdownCallbacks.set(execId, launchOptions.onShutdown);
+      }
       return sendRequest<void>('launchApp', {
         bundleId,
         mode,
         runtime: launchOptions.runtime,
+        execId,
+      }).catch((error) => {
+        if (execId) {
+          appShutdownCallbacks.delete(execId);
+        }
+        throw error;
       });
     };
 

--- a/tests/ios-launch-app.test.ts
+++ b/tests/ios-launch-app.test.ts
@@ -1,9 +1,11 @@
 import type { LaunchAppOptions } from '../src/ios-client';
 
 const sentMessages: Record<string, unknown>[] = [];
+const mockSockets: Array<{ emit: (event: string, ...args: unknown[]) => boolean }> = [];
 
 jest.mock('ws', () => {
   const { EventEmitter } = require('events');
+  type EmittingSocket = { emit: (event: string, ...args: unknown[]) => boolean };
 
   class MockWebSocket extends EventEmitter {
     static CONNECTING = 0;
@@ -13,6 +15,7 @@ jest.mock('ws', () => {
 
     constructor() {
       super();
+      mockSockets.push(this as unknown as EmittingSocket);
       process.nextTick(() => this['emit']('open'));
     }
 
@@ -40,6 +43,20 @@ jest.mock('ws', () => {
         process.nextTick(() => {
           this['emit']('message', Buffer.from(JSON.stringify({ type: 'launchAppResult', id: message.id })));
         });
+      } else if (message.type === 'appLogTail') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'appLogTailResult',
+                id: message.id,
+                bundleId: message.bundleId,
+                logs: 'first log line\nsecond log line',
+              }),
+            ),
+          );
+        });
       }
 
       callback?.();
@@ -59,6 +76,7 @@ jest.mock('ws', () => {
 describe('iOS launchApp serialization', () => {
   beforeEach(() => {
     sentMessages.length = 0;
+    mockSockets.length = 0;
   });
 
   it('serializes legacy mode-only launches without runtime or launch inputs', async () => {
@@ -171,6 +189,84 @@ describe('iOS launchApp serialization', () => {
       } as unknown as LaunchAppOptions),
     ).rejects.toThrow('runtime launches require RelaunchIfRunning');
     expect(sentMessages).toEqual([]);
+
+    client.disconnect();
+  });
+
+  it('sends execId for onShutdown and invokes callback with fetched log lines', async () => {
+    const { createInstanceClient } = await import('../src/ios-client');
+    let resolveShutdown!: () => void;
+    const shutdown = new Promise<void>((resolve) => {
+      resolveShutdown = resolve;
+    });
+    const onShutdown = jest.fn(async (exitCode: number, logs: string[]) => {
+      expect(exitCode).toBe(42);
+      expect(logs).toEqual(['first log line', 'second log line']);
+      resolveShutdown();
+    });
+    const client = await createInstanceClient({
+      apiUrl: 'https://example.test/v1/ios_123/api',
+      token: 'token',
+      logLevel: 'none',
+    });
+
+    await client.launchApp('com.example.app', {
+      mode: 'RelaunchIfRunning',
+      onShutdown,
+    });
+
+    const launch = sentMessages.find((message) => message['type'] === 'launchApp');
+    expect(launch).toMatchObject({
+      type: 'launchApp',
+      bundleId: 'com.example.app',
+      mode: 'RelaunchIfRunning',
+    });
+    expect(launch?.['execId']).toEqual(expect.any(String));
+    expect(launch).not.toHaveProperty('onShutdown');
+    const execId = launch?.['execId'];
+    if (typeof execId !== 'string') {
+      throw new Error('launchApp did not send execId');
+    }
+    const socket = mockSockets[0];
+    if (!socket) {
+      throw new Error('mock WebSocket was not created');
+    }
+
+    socket.emit(
+      'message',
+      Buffer.from(
+        JSON.stringify({
+          type: 'appShutdown',
+          execId,
+          bundleId: 'com.example.app',
+          exitCode: 42,
+          logLineCount: 2,
+        }),
+      ),
+    );
+
+    await shutdown;
+    const appLogTail = sentMessages.find((message) => message['type'] === 'appLogTail');
+    expect(appLogTail).toMatchObject({
+      type: 'appLogTail',
+      bundleId: 'com.example.app',
+      lines: 2,
+    });
+
+    socket.emit(
+      'message',
+      Buffer.from(
+        JSON.stringify({
+          type: 'appShutdown',
+          execId,
+          bundleId: 'com.example.app',
+          exitCode: 42,
+          logLineCount: 2,
+        }),
+      ),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(onShutdown).toHaveBeenCalledTimes(1);
 
     client.disconnect();
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes WebSocket message handling and launchApp behavior for consumers using onShutdown; CLI aliases are backward-compatible.
> 
> **Overview**
> **iOS `launchApp`** can take an optional **`onShutdown`** callback. When set, the client sends an **`execId`** with the launch request and listens for server **`appShutdown`** notifications (exit code + log line count). It then tails app logs via **`appLogTail`**, splits them into lines, and invokes the callback once per execution; duplicate notifications are ignored. Handlers are registered in a notification map that survives transient reconnects but is cleared on intentional disconnect or when reconnection is abandoned. Failed launches unregister the pending handler.
> 
> **CLI:** documents an **`assets`** topic mirroring **`asset`**, and adds **`assets:*`** oclif aliases for push, pull, list, and delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaaf3d8c8500ffa2964bb1233f6e9b4e0153c4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->