### PR TITLE
folder-sync: sync symlinks, layered ignore, and --include

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -141,6 +141,11 @@ export default class XcodeBuild extends BaseCommand {
         'Regular expression to ignore matching relative paths during the pre-build sync. Repeat for multiple patterns.',
       multiple: true,
     }),
+    include: Flags.string({
+      description:
+        'Regular expression to force-sync matching relative paths even when gitignored (for example generated sources: --include "^ios/GeneratedKit/"). If a parent directory is itself gitignored, the pattern must also match that directory (e.g. use "^ios/" not "GeneratedKit/") or the subtree stays pruned. Repeat for multiple patterns.',
+      multiple: true,
+    }),
     'additional-file': Flags.string({
       description:
         'Additional file to sync before building as localPath=remotePath, for example ~/.netrc=~/.netrc. Repeat for multiple files.',
@@ -240,6 +245,7 @@ export default class XcodeBuild extends BaseCommand {
         install: false,
         basisCacheDir: flags['basis-cache-dir'],
         ignore: compileIgnorePatterns(flags.ignore),
+        include: compileIgnorePatterns(flags.include),
         additionalFiles: parseAdditionalFileFlags(flags['additional-file']),
       };
       const syncResult = await xcodeClient.sync(

--- a/packages/cli/src/commands/xcode/sync.ts
+++ b/packages/cli/src/commands/xcode/sync.ts
@@ -50,6 +50,11 @@ export default class XcodeSync extends BaseCommand {
         'Regular expression to ignore matching relative paths during sync. Repeat for multiple patterns.',
       multiple: true,
     }),
+    include: Flags.string({
+      description:
+        'Regular expression to force-sync matching relative paths even when gitignored (for example generated sources: --include "^ios/GeneratedKit/"). If a parent directory is itself gitignored, the pattern must also match that directory (e.g. use "^ios/" not "GeneratedKit/") or the subtree stays pruned. Repeat for multiple patterns.',
+      multiple: true,
+    }),
     'additional-file': Flags.string({
       description:
         'Additional file to sync as localPath=remotePath, for example ~/.netrc=~/.netrc. Repeat for multiple files.',
@@ -75,6 +80,7 @@ export default class XcodeSync extends BaseCommand {
         install: flags.install,
         basisCacheDir: flags['basis-cache-dir'],
         ignore: compileIgnorePatterns(flags.ignore),
+        include: compileIgnorePatterns(flags.include),
         additionalFiles: parseAdditionalFileFlags(flags['additional-file']),
       };
       const result = await xcodeClient.sync(syncPath, syncOptions as Parameters<typeof xcodeClient.sync>[1]);

--- a/src/folder-sync-ignore.ts
+++ b/src/folder-sync-ignore.ts
@@ -25,11 +25,10 @@ export type IgnoreFnOptions = {
   include?: IgnoreFn;
   /**
    * "Xcode project sync mode." Enables the default Xcode/dependency excludes
-   * (build/, Pods/, xcuserdata/, …), nested-.gitignore honoring, and the
-   * `.xcodeproj`/`.xcworkspace` force-include. When unset (e.g. the app-bundle
-   * install sync) only the root .gitignore is read and no project force-
-   * include applies, so a build artifact isn't reshaped by gitignore files
-   * embedded in it.
+   * (build/, Pods/, xcuserdata/, …) and nested-.gitignore honoring. When
+   * unset (e.g. the app-bundle install sync) only the root .gitignore is
+   * read, so a build artifact isn't reshaped by gitignore files embedded
+   * in it.
    */
   xcodeDefaults?: boolean;
   basisCacheDir: string;
@@ -92,10 +91,10 @@ const XCODE_DEFAULT_EXCLUDE_PREFIXES = [
  *  1. `.git`, `.DS_Store`, the basis cache: excluded, never overridable.
  *  2. User include (--include): explicit intent beats the default excludes.
  *  3. Default Xcode/dependency excludes (when xcodeDefaults is set).
- *  4. Built-in force-includes: `*.xcconfig` (all callers) plus `.xcodeproj` /
- *     `.xcworkspace` bundles (when xcodeDefaults is set) - build-critical
- *     artifacts customers routinely gitignore. Junk at layer 3 runs first so
- *     xcuserdata/.dSYM inside a bundle stay out.
+ *  4. Built-in force-include: `*.xcconfig` (gitignored xcconfigs are still
+ *     required to reproduce the build remotely). Gitignored projects are NOT
+ *     force-included: limbuild regenerates them from project.yml, and
+ *     exact-version holdouts force-sync theirs with `--include`.
  *  5. `.gitignore` chain: the root file, plus nested ones with git semantics
  *     when xcodeDefaults is set (rules bind relative to their containing
  *     directory, deeper files override shallower ones). Only a decisive
@@ -210,15 +209,11 @@ export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions):
       }
       if (normalized.includes('/xcuserdata/') || normalized.includes('.dSYM/')) return true;
     }
-    // 4. Built-in force-includes. `.xcconfig` is unconditional (matches the
-    // long-standing behavior for every caller); the project-bundle force-
-    // include is Xcode-project-specific and gated with the other Xcode rules.
+    // 4. Built-in force-include: gitignored xcconfigs are still required to
+    // reproduce the build remotely. Gitignored .xcodeproj bundles are NOT
+    // force-included: limbuild regenerates them from project.yml, and
+    // exact-version holdouts force-sync theirs with --include.
     if (withoutTrailingSlash.endsWith('.xcconfig')) return false;
-    if (options.xcodeDefaults) {
-      for (const segment of withoutTrailingSlash.split('/')) {
-        if (segment.endsWith('.xcodeproj') || segment.endsWith('.xcworkspace')) return false;
-      }
-    }
     // 5. The .gitignore chain. Only a decisive *exclude* short-circuits; a
     // negation re-include (decision.ignored === false) still falls through to
     // the user --ignore layer, matching the pre-restructure precedence where

--- a/src/folder-sync-ignore.ts
+++ b/src/folder-sync-ignore.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import ignorePkg from 'ignore';
+import ignorePkg, { type Ignore } from 'ignore';
 
 const execFileAsync = promisify(execFile);
 
@@ -11,7 +11,27 @@ export type IgnoreFn = (relativePath: string) => boolean;
 export type IgnoreLogger = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
 
 export type IgnoreFnOptions = {
+  /** User-supplied extra excludes (the CLI's --ignore). Consulted after every built-in layer. */
   additional?: IgnoreFn;
+  /**
+   * User-supplied force-includes (the CLI's --include): matches sync even when
+   * gitignored or covered by the default Xcode excludes. Only `.git`,
+   * `.DS_Store`, and the basis cache stay excluded. Note: the walk prunes
+   * gitignore-excluded directories, so to rescue files under a wholly-ignored
+   * parent the predicate must also match the parent directory paths (probed
+   * with a trailing slash), e.g. `^ios/` reaches `ios/GeneratedKit/...` but
+   * `GeneratedKit/` alone does not.
+   */
+  include?: IgnoreFn;
+  /**
+   * "Xcode project sync mode." Enables the default Xcode/dependency excludes
+   * (build/, Pods/, xcuserdata/, …), nested-.gitignore honoring, and the
+   * `.xcodeproj`/`.xcworkspace` force-include. When unset (e.g. the app-bundle
+   * install sync) only the root .gitignore is read and no project force-
+   * include applies, so a build artifact isn't reshaped by gitignore files
+   * embedded in it.
+   */
+  xcodeDefaults?: boolean;
   basisCacheDir: string;
   log?: IgnoreLogger;
 };
@@ -52,21 +72,98 @@ async function getGitTrackedSets(rootDir: string): Promise<GitTrackedSets | null
   }
 }
 
+// Root-anchored (top-level only) default excludes; nested build junk is the
+// project's own nested .gitignore's job. xcuserdata/.dSYM below are any-depth.
+const XCODE_DEFAULT_EXCLUDE_PREFIXES = [
+  'build/',
+  '.build/',
+  'DerivedData/',
+  'Index.noindex/',
+  'ModuleCache.noindex/',
+  '.index-build/',
+  '.swiftpm/',
+  'Pods/',
+  'Carthage/Build/',
+];
+
+/**
+ * Builds the layered sync ignore predicate. First decisive answer wins:
+ *
+ *  1. `.git`, `.DS_Store`, the basis cache: excluded, never overridable.
+ *  2. User include (--include): explicit intent beats the default excludes.
+ *  3. Default Xcode/dependency excludes (when xcodeDefaults is set).
+ *  4. Built-in force-includes: `*.xcconfig` (all callers) plus `.xcodeproj` /
+ *     `.xcworkspace` bundles (when xcodeDefaults is set) - build-critical
+ *     artifacts customers routinely gitignore. Junk at layer 3 runs first so
+ *     xcuserdata/.dSYM inside a bundle stay out.
+ *  5. `.gitignore` chain: the root file, plus nested ones with git semantics
+ *     when xcodeDefaults is set (rules bind relative to their containing
+ *     directory, deeper files override shallower ones). Only a decisive
+ *     *exclude* short-circuits; a negation re-include defers to layer 6.
+ *     Directory pruning in the walk means only layers 2 and 4 can reach a
+ *     file whose parent directory is gitignore-excluded, and only when the
+ *     predicate matches the pruned parent directory paths too.
+ *  6. User ignore (--ignore).
+ */
 export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions): Promise<IgnoreFn> {
   const rootResolved = path.resolve(rootDir);
+
+  // Per-directory .gitignore instances, lazily loaded; key is the dir path
+  // relative to the root ('' = root), value null when the dir has none.
   // ignorecase: false matches git's default semantics. The package defaults to true,
   // which silently drops e.g. `Vendor/` when .gitignore says `vendor/` (Ruby convention).
   // allowRelativePaths: true so a `../`-style path doesn't throw mid-sync — treat it as
   // "not ignored" and let it through, since the cost of dropping a needed file is higher
   // than including an unexpected one.
-  const ig = ignorePkg({ ignorecase: false, allowRelativePaths: true });
-  const gitignorePath = path.join(rootResolved, '.gitignore');
-  try {
-    const content = await fs.promises.readFile(gitignorePath, 'utf-8');
-    ig.add(content);
-  } catch {
-    // No .gitignore file, return empty ignore instance
-  }
+  const dirIgnores = new Map<string, Ignore | null>();
+  const gitignoreFor = (dirRel: string): Ignore | null => {
+    let ig = dirIgnores.get(dirRel);
+    if (ig !== undefined) return ig;
+    try {
+      const content = fs.readFileSync(
+        path.join(rootResolved, dirRel.split('/').join(path.sep), '.gitignore'),
+        'utf-8',
+      );
+      ig = ignorePkg({ ignorecase: false, allowRelativePaths: true }).add(content);
+    } catch {
+      ig = null;
+    }
+    dirIgnores.set(dirRel, ig);
+    return ig;
+  };
+
+  // xcodeDefaults selects "Xcode project sync mode": besides the default junk
+  // excludes it also enables nested-.gitignore honoring and the project-file
+  // force-includes below. Callers that don't set it (e.g. the app-bundle
+  // install sync) keep the legacy behavior: root-only .gitignore and no
+  // project force-includes, so a build artifact isn't reshaped by gitignore
+  // files or Xcode-specific rules that happen to sit inside it.
+  const nestedGitignore = !!options.xcodeDefaults;
+
+  // Evaluates the .gitignore chain for a path (trailing slash preserved so
+  // dir-only rules like `build/` match the directory itself). Files are
+  // consulted root-to-deepest; the last decisive match wins, so deeper
+  // files naturally override shallower ones. When nestedGitignore is off,
+  // only the root .gitignore is consulted.
+  const gitignoreDecision = (testPath: string): { ignored: boolean; rule?: string } | undefined => {
+    const withoutTrailingSlash = testPath.replace(/\/+$/, '');
+    const trailingSlash = testPath.endsWith('/') ? '/' : '';
+    const parts = withoutTrailingSlash.split('/');
+    let decision: { ignored: boolean; rule?: string } | undefined;
+    const depth = nestedGitignore ? parts.length : 1;
+    for (let i = 0; i < depth; i++) {
+      const ig = gitignoreFor(parts.slice(0, i).join('/'));
+      if (!ig) continue;
+      const result = ig.test(parts.slice(i).join('/') + trailingSlash);
+      if (result.ignored || result.unignored) {
+        decision = { ignored: result.ignored };
+        const rule = (result as { rule?: { pattern?: string } }).rule?.pattern;
+        if (rule !== undefined) decision.rule = rule;
+      }
+    }
+    return decision;
+  };
+
   const basisCacheRelative = normalizeRelativePath(
     path.relative(rootResolved, options.basisCacheDir),
   ).replace(/\/+$/, '');
@@ -86,6 +183,7 @@ export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions):
     if (!normalized) return false;
     const withoutTrailingSlash = normalized.replace(/\/+$/, '');
 
+    // 1. Never overridable.
     if (
       withoutTrailingSlash === '.git' ||
       withoutTrailingSlash.startsWith('.git/') ||
@@ -103,16 +201,38 @@ export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions):
     ) {
       return true;
     }
+    // 2. User include.
+    if (options.include?.(normalized)) return false;
+    // 3. Default Xcode/dependency excludes.
+    if (options.xcodeDefaults) {
+      for (const prefix of XCODE_DEFAULT_EXCLUDE_PREFIXES) {
+        if (normalized.startsWith(prefix)) return true;
+      }
+      if (normalized.includes('/xcuserdata/') || normalized.includes('.dSYM/')) return true;
+    }
+    // 4. Built-in force-includes. `.xcconfig` is unconditional (matches the
+    // long-standing behavior for every caller); the project-bundle force-
+    // include is Xcode-project-specific and gated with the other Xcode rules.
     if (withoutTrailingSlash.endsWith('.xcconfig')) return false;
-    if (ig.ignores(normalized)) {
+    if (options.xcodeDefaults) {
+      for (const segment of withoutTrailingSlash.split('/')) {
+        if (segment.endsWith('.xcodeproj') || segment.endsWith('.xcworkspace')) return false;
+      }
+    }
+    // 5. The .gitignore chain. Only a decisive *exclude* short-circuits; a
+    // negation re-include (decision.ignored === false) still falls through to
+    // the user --ignore layer, matching the pre-restructure precedence where
+    // gitignore never overrode --ignore for a re-included path.
+    const decision = gitignoreDecision(normalized);
+    if (decision?.ignored) {
       if (
         trackedSets &&
         (trackedSets.tracked.has(withoutTrailingSlash) || trackedSets.prefixes.has(withoutTrailingSlash))
       ) {
-        const rule = ig.test(normalized).rule?.pattern ?? '<unknown>';
+        const rule = decision.rule ?? '<unknown>';
         if (!warnedRules.has(rule)) {
           warnedRules.add(rule);
-          const msg = `.gitignore rule '${rule}' is dropping '${withoutTrailingSlash}', which is tracked in git. The remote build will not see this path. Remove or scope the rule if you need it synced.`;
+          const msg = `.gitignore rule '${rule}' is dropping '${withoutTrailingSlash}', which is tracked in git. The remote build will not see this path. Remove or scope the rule, or pass --include, if you need it synced.`;
           if (log) {
             log('warn', msg);
           } else {
@@ -122,6 +242,7 @@ export async function createIgnoreFn(rootDir: string, options: IgnoreFnOptions):
       }
       return true;
     }
+    // 6. User ignore.
     if (options.additional?.(normalized)) return true;
     return false;
   };

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -696,7 +696,6 @@ async function syncFolderOnce(
 
   // Track how many bytes we actually transmit to the server (single HTTP request).
   let bytesSentFull = 0;
-  let retryChanged = 0;
   let bytesSentDelta = 0;
   let httpSendMsTotal = 0;
   let deltaEncodeMsTotal = 0;
@@ -738,6 +737,9 @@ async function syncFolderOnce(
 
   // Symlink entries travel in the manifest only, with no payloads.
   const changedFiles = changed.filter((f) => f.linkTarget === undefined);
+  // Grows in the needFull retry below; sized here so the summary counts
+  // every path that actually shipped this sync.
+  const changedPaths = new Set(changed.map((f) => f.path));
 
   const encodedPayloads = await mapLimit(changedFiles, encodeLimit, async (f): Promise<EncodedPayload> => {
     const basisPath = cacheGet(opts.basisCacheDir, f.path);
@@ -851,7 +853,6 @@ async function syncFolderOnce(
           `recreate the instance or retry later. Paths: ${needFullLinks.join(', ')}`,
       );
     }
-    const changedPaths = new Set(changed.map((f) => f.path));
     const retryPayloads: EncodedPayload[] = [];
     for (const p of need) {
       const entry = fileMap.get(p);
@@ -863,9 +864,7 @@ async function syncFolderOnce(
         slog('info', `uploading large file ${entry.path} (${fmtBytes(entry.size)})`);
       }
       bytesSentFull += entry.size;
-      if (!changedPaths.has(entry.path)) {
-        retryChanged += 1;
-      }
+      changedPaths.add(entry.path);
       retryPayloads.push({
         payload: {
           kind: 'full',
@@ -919,7 +918,7 @@ async function syncFolderOnce(
   const totalBytes = bytesSentFull + bytesSentDelta;
   slog(
     'info',
-    `sync complete: files=${allFiles.length} changed=${changed.length + retryChanged} sent=${fmtBytes(
+    `sync complete: files=${allFiles.length} changed=${changedPaths.size} sent=${fmtBytes(
       totalBytes,
     )} in ${fmtMs(tookMs)}`,
   );

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -403,7 +403,9 @@ async function collectAdditionalFiles(
   }
   const out: FileEntry[] = [];
   for (const additionalFile of additionalFiles) {
-    const remotePath = additionalFile.remotePath;
+    // Canonicalize user-supplied remote paths ("./netrc" -> "netrc") so the
+    // manifest key matches what the daemon applies and echoes in needFull.
+    const remotePath = path.posix.normalize(additionalFile.remotePath);
     const absPath = path.resolve(additionalFile.localPath);
     const st = await fs.promises.stat(absPath);
     if (!st.isFile()) {

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -286,27 +286,34 @@ async function sha256FileHex(filePath: string): Promise<string> {
 }
 
 /**
- * Validates a symlink's readlink target at sync time: it must be relative
- * and lexically resolve inside the sync root when joined with the link's
- * directory (the daemon enforces the same policy on apply).
+ * Validates a symlink's readlink target at sync time: it must be relative,
+ * backslash-free, and lexically resolve inside the sync root when joined
+ * with the link's directory (the daemon enforces the same policy on apply,
+ * so failing here is the same failure with a better message).
  */
 function validateSymlinkTarget(rel: string, target: string): void {
-  const slashTarget = target.split(path.sep).join('/');
-  const outside = () =>
-    new Error(
-      `symlink ${rel} -> ${target} points outside the sync root; ` +
-        'run the sync from the repo root that contains the target, or remove the link',
+  if (target.includes('\\')) {
+    throw new Error(
+      `symlink ${rel} -> ${target} target contains a backslash, which the daemon rejects; ` +
+        'remove the link or pass --ignore to skip it',
     );
-  if (path.posix.isAbsolute(slashTarget) || path.win32.isAbsolute(target)) {
-    throw outside();
   }
-  const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(rel), slashTarget));
+  const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(rel), target));
   if (resolved === '.' || resolved === '..' || resolved.startsWith('../')) {
-    throw outside();
+    throw new Error(
+      `symlink ${rel} -> ${target} points outside the sync root; ` +
+        'run the sync from the repo root that contains the target, remove the link, ' +
+        'or pass --ignore to skip it',
+    );
   }
 }
 
-async function walkFiles(root: string, ignoreFn: IgnoreFn, syncSymlinks: boolean): Promise<FileEntry[]> {
+async function walkFiles(
+  root: string,
+  ignoreFn: IgnoreFn,
+  syncSymlinks: boolean,
+  log?: FolderSyncOptions['log'],
+): Promise<FileEntry[]> {
   const rootResolved = path.resolve(root);
   const rootStat = await fs.promises.stat(rootResolved);
   if (rootStat.isFile()) {
@@ -353,6 +360,13 @@ async function walkFiles(root: string, ignoreFn: IgnoreFn, syncSymlinks: boolean
         // target.
         if (ignoreFn(rel) || ignoreFn(rel + '/')) continue;
         const target = (await fs.promises.readlink(abs)).split(path.sep).join('/');
+        // An absolute target can never resolve remotely and no sync root
+        // can contain it; skip it like pre-symlink clients did (with a
+        // warning) instead of failing a previously working sync.
+        if (path.posix.isAbsolute(target) || path.win32.isAbsolute(target)) {
+          log?.('warn', `skipping symlink ${rel} -> ${target}: absolute targets cannot resolve remotely`);
+          continue;
+        }
         validateSymlinkTarget(rel, target);
         const sha256 = crypto.createHash('sha256').update(target).digest('hex');
         out.push({
@@ -518,10 +532,11 @@ async function cachePut(
 ): Promise<void> {
   const segments = relPath.split('/');
   const dst = path.join(cacheRoot, segments.join(path.sep));
-  // Remove any ancestor that is a stale cache symlink before mkdir/write: a
-  // directory that previously synced as a symlink leaves the cache path a
-  // symlink, and writing children through it would corrupt the link target's
-  // cached entries (and dangle after the target moves). Only relevant when
+  // Remove any ancestor that is not a real directory before mkdir/write: a
+  // path that previously synced as a symlink (or a regular file that became
+  // a directory) leaves a stale cache inode, and writing children through a
+  // symlink would corrupt the link target's cached entries while mkdir over
+  // a file throws after the server already applied. Only relevant when
   // symlink sync is on; the caller passes checkedDirs (which also memoizes
   // ancestors already confirmed real, so the sorted walk skips shared
   // prefixes) then and omits it otherwise to skip the sweep entirely.
@@ -531,9 +546,9 @@ async function cachePut(
       ancestor = path.join(ancestor, segments[i]!);
       if (checkedDirs.has(ancestor)) continue;
       const ast = await fs.promises.lstat(ancestor).catch(() => null);
-      if (ast?.isSymbolicLink()) {
+      if (ast && !ast.isDirectory()) {
         await fs.promises.rm(ancestor, { recursive: true, force: true });
-      } else if (ast?.isDirectory()) {
+      } else if (ast) {
         checkedDirs.add(ancestor);
       }
     }
@@ -665,7 +680,7 @@ async function syncFolderOnce(
   const log = opts.log ?? noopLogger;
   const slog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => log(level, `syncFolder: ${msg}`);
 
-  const files = await walkFiles(localFolderPath, opts.ignoreFn, opts.syncSymlinks ?? false);
+  const files = await walkFiles(localFolderPath, opts.ignoreFn, opts.syncSymlinks ?? false, slog);
   const additionalFiles = await collectAdditionalFiles(opts.additionalFiles);
   const allFiles = [...files, ...additionalFiles].sort((a, b) => a.path.localeCompare(b.path));
   const fileMap = new Map(allFiles.map((f) => [f.path, f]));
@@ -679,6 +694,7 @@ async function syncFolderOnce(
 
   // Track how many bytes we actually transmit to the server (single HTTP request).
   let bytesSentFull = 0;
+  let retryChanged = 0;
   let bytesSentDelta = 0;
   let httpSendMsTotal = 0;
   let deltaEncodeMsTotal = 0;
@@ -718,7 +734,7 @@ async function syncFolderOnce(
     }
   }
 
-  // Symlink entries travel in the manifest only — no payloads.
+  // Symlink entries travel in the manifest only, with no payloads.
   const changedFiles = changed.filter((f) => f.linkTarget === undefined);
 
   const encodedPayloads = await mapLimit(changedFiles, encodeLimit, async (f): Promise<EncodedPayload> => {
@@ -824,7 +840,7 @@ async function syncFolderOnce(
     const need = new Set(resp.needFull);
     // A daemon that predates symlink support json-drops the `link` field and
     // asks for these entries as full files. Streaming absPath would FOLLOW
-    // the link and silently materialize target content remotely — fail loud
+    // the link and silently materialize target content remotely, so fail loud
     // instead. (New daemons never put symlink entries in needFull.)
     const needFullLinks = [...need].filter((p) => fileMap.get(p)?.linkTarget !== undefined);
     if (needFullLinks.length > 0) {
@@ -833,10 +849,21 @@ async function syncFolderOnce(
           `recreate the instance or retry later. Paths: ${needFullLinks.join(', ')}`,
       );
     }
+    const changedPaths = new Set(changed.map((f) => f.path));
     const retryPayloads: EncodedPayload[] = [];
     for (const p of need) {
       const entry = fileMap.get(p);
       if (!entry) continue;
+      // The retry uploads real bytes: count them (and surface large files)
+      // exactly like first-pass fulls, or a fresh-daemon resync of a warm
+      // cache reports "sent=0B" while gigabytes upload.
+      if (entry.size >= LARGE_UPLOAD_NOTICE_BYTES) {
+        slog('info', `uploading large file ${entry.path} (${fmtBytes(entry.size)})`);
+      }
+      bytesSentFull += entry.size;
+      if (!changedPaths.has(entry.path)) {
+        retryChanged += 1;
+      }
       retryPayloads.push({
         payload: {
           kind: 'full',
@@ -849,7 +876,10 @@ async function syncFolderOnce(
       bytesSentFull += entry.size;
     }
     if (retryPayloads.length > 0) {
-      slog('debug', `server requested full for ${retryPayloads.length} files; retrying once`);
+      slog(
+        'info',
+        `daemon requested a full upload for ${retryPayloads.length} files (no matching basis); retrying once`,
+      );
       const retryMeta: FolderSyncHttpMeta = {
         ...meta,
         id: genId('sync'),
@@ -887,7 +917,7 @@ async function syncFolderOnce(
   const totalBytes = bytesSentFull + bytesSentDelta;
   slog(
     'info',
-    `sync complete: files=${allFiles.length} changed=${changed.length} sent=${fmtBytes(
+    `sync complete: files=${allFiles.length} changed=${changed.length + retryChanged} sent=${fmtBytes(
       totalBytes,
     )} in ${fmtMs(tookMs)}`,
   );

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -874,7 +874,6 @@ async function syncFolderOnce(
         },
         filePath: entry.absPath,
       });
-      bytesSentFull += entry.size;
     }
     if (retryPayloads.length > 0) {
       slog(

--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -48,6 +48,12 @@ export type FolderSyncOptions = {
    */
   ignoreFn: IgnoreFn;
   /**
+   * Sync symlinks as symlinks (relative, in-root targets only). Off by
+   * default: only the limbuild workspace sync understands link entries;
+   * the limulator app-install sync keeps the historical skip behavior.
+   */
+  syncSymlinks?: boolean;
+  /**
    * Extra files to sync into limbuild. These are included
    * in every sync pass but are not watched directly.
    */
@@ -77,6 +83,12 @@ type FileEntry = {
   sha256: string;
   absPath: string;
   mode: number;
+  /**
+   * Symlink target (literal readlink output, forward slashes). Non-empty
+   * marks a symlink entry: the target string is the content (sha256/size
+   * describe it) and the entry never carries a payload.
+   */
+  linkTarget?: string;
 };
 
 type FolderSyncHttpPayload = {
@@ -94,7 +106,7 @@ type FolderSyncHttpMeta = {
   rootName: string;
   install?: boolean;
   launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
-  files: { path: string; size: number; sha256: string; mode: number }[];
+  files: { path: string; size: number; sha256: string; mode?: number; link?: string }[];
   payloads: FolderSyncHttpPayload[];
 };
 type FolderSyncHttpResponse = {
@@ -108,6 +120,10 @@ type FolderSyncHttpResponse = {
   bundleId?: string;
   error?: string;
 };
+
+/** Full uploads at or above this size get an info-level notice so "sync is
+ * stuck" turns into "a GB-scale file is being uploaded". */
+const LARGE_UPLOAD_NOTICE_BYTES = 64 * 1024 * 1024;
 
 const noopLogger = (_level: 'debug' | 'info' | 'warn' | 'error', _msg: string) => {
   // Intentionally empty: callers (e.g. ios-client.ts) should provide their own logger
@@ -269,7 +285,28 @@ async function sha256FileHex(filePath: string): Promise<string> {
   });
 }
 
-async function walkFiles(root: string, ignoreFn: IgnoreFn): Promise<FileEntry[]> {
+/**
+ * Validates a symlink's readlink target at sync time: it must be relative
+ * and lexically resolve inside the sync root when joined with the link's
+ * directory (the daemon enforces the same policy on apply).
+ */
+function validateSymlinkTarget(rel: string, target: string): void {
+  const slashTarget = target.split(path.sep).join('/');
+  const outside = () =>
+    new Error(
+      `symlink ${rel} -> ${target} points outside the sync root; ` +
+        'run the sync from the repo root that contains the target, or remove the link',
+    );
+  if (path.posix.isAbsolute(slashTarget) || path.win32.isAbsolute(target)) {
+    throw outside();
+  }
+  const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(rel), slashTarget));
+  if (resolved === '.' || resolved === '..' || resolved.startsWith('../')) {
+    throw outside();
+  }
+}
+
+async function walkFiles(root: string, ignoreFn: IgnoreFn, syncSymlinks: boolean): Promise<FileEntry[]> {
   const rootResolved = path.resolve(root);
   const rootStat = await fs.promises.stat(rootResolved);
   if (rootStat.isFile()) {
@@ -303,6 +340,29 @@ async function walkFiles(root: string, ignoreFn: IgnoreFn): Promise<FileEntry[]>
         // Check custom ignores (directories have trailing slash)
         if (ignoreFn(relDir)) continue;
         stack.push(abs);
+        continue;
+      }
+      if (ent.isSymbolicLink()) {
+        if (!syncSymlinks) continue;
+        // Symlinks ship as link entries with the literal target: a
+        // symlinked directory arrives here too and is sent as a link, not
+        // traversed (git semantics). The target string is the content.
+        // Probe both forms: a symlink named e.g. `Pods` or `build` may point
+        // at a directory, so directory-only excludes (`Pods/`, `build/`)
+        // must match it and skip before validation rejects an out-of-root
+        // target.
+        if (ignoreFn(rel) || ignoreFn(rel + '/')) continue;
+        const target = (await fs.promises.readlink(abs)).split(path.sep).join('/');
+        validateSymlinkTarget(rel, target);
+        const sha256 = crypto.createHash('sha256').update(target).digest('hex');
+        out.push({
+          path: rel,
+          size: Buffer.byteLength(target),
+          sha256,
+          absPath: abs,
+          mode: 0,
+          linkTarget: target,
+        });
         continue;
       }
       if (!ent.isFile()) continue;
@@ -449,9 +509,47 @@ export async function encodeXdelta3Patch(
   return bytesWritten;
 }
 
-async function cachePut(cacheRoot: string, relPath: string, srcFile: string): Promise<void> {
-  const dst = path.join(cacheRoot, relPath.split('/').join(path.sep));
+async function cachePut(
+  cacheRoot: string,
+  relPath: string,
+  srcFile: string,
+  linkTarget?: string,
+  checkedDirs?: Set<string>,
+): Promise<void> {
+  const segments = relPath.split('/');
+  const dst = path.join(cacheRoot, segments.join(path.sep));
+  // Remove any ancestor that is a stale cache symlink before mkdir/write: a
+  // directory that previously synced as a symlink leaves the cache path a
+  // symlink, and writing children through it would corrupt the link target's
+  // cached entries (and dangle after the target moves). Only relevant when
+  // symlink sync is on; the caller passes checkedDirs (which also memoizes
+  // ancestors already confirmed real, so the sorted walk skips shared
+  // prefixes) then and omits it otherwise to skip the sweep entirely.
+  if (checkedDirs) {
+    let ancestor = cacheRoot;
+    for (let i = 0; i < segments.length - 1; i++) {
+      ancestor = path.join(ancestor, segments[i]!);
+      if (checkedDirs.has(ancestor)) continue;
+      const ast = await fs.promises.lstat(ancestor).catch(() => null);
+      if (ast?.isSymbolicLink()) {
+        await fs.promises.rm(ancestor, { recursive: true, force: true });
+      } else if (ast?.isDirectory()) {
+        checkedDirs.add(ancestor);
+      }
+    }
+  }
   await fs.promises.mkdir(path.dirname(dst), { recursive: true });
+  // Replace the destination inode when its type doesn't match what we're
+  // writing: a stale symlink (copyFile would follow it) or a stale directory
+  // (copyFile onto a dir throws EISDIR) left by a since-changed path.
+  const st = await fs.promises.lstat(dst).catch(() => null);
+  if (st && (st.isSymbolicLink() || st.isDirectory() || linkTarget !== undefined)) {
+    await fs.promises.rm(dst, { recursive: true, force: true });
+  }
+  if (linkTarget !== undefined) {
+    await fs.promises.symlink(linkTarget, dst);
+    return;
+  }
   await fs.promises.copyFile(srcFile, dst);
 }
 
@@ -567,7 +665,7 @@ async function syncFolderOnce(
   const log = opts.log ?? noopLogger;
   const slog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => log(level, `syncFolder: ${msg}`);
 
-  const files = await walkFiles(localFolderPath, opts.ignoreFn);
+  const files = await walkFiles(localFolderPath, opts.ignoreFn, opts.syncSymlinks ?? false);
   const additionalFiles = await collectAdditionalFiles(opts.additionalFiles);
   const allFiles = [...files, ...additionalFiles].sort((a, b) => a.path.localeCompare(b.path));
   const fileMap = new Map(allFiles.map((f) => [f.path, f]));
@@ -587,11 +685,30 @@ async function syncFolderOnce(
   type EncodedPayload = { payload: FolderSyncHttpPayload; filePath: string; cleanupDir?: string };
 
   // Build payload list by comparing against local basis cache (single-flight/watch assumes server matches cache).
+  // lstat, never stat/existsSync: those follow symlinks and misreport a
+  // basis symlink (dangling or pointing at another cached file) as the
+  // file itself.
   const encodeLimit = concurrencyLimit();
   const changed: FileEntry[] = [];
   for (const f of allFiles) {
     const basisPath = cacheGet(opts.basisCacheDir, f.path);
-    if (!fs.existsSync(basisPath)) {
+    const basisStat = await fs.promises.lstat(basisPath).catch(() => null);
+    if (!basisStat) {
+      changed.push(f);
+      continue;
+    }
+    if (f.linkTarget !== undefined) {
+      if (!basisStat.isSymbolicLink()) {
+        changed.push(f);
+        continue;
+      }
+      const basisTarget = (await fs.promises.readlink(basisPath)).split(path.sep).join('/');
+      if (basisTarget !== f.linkTarget) {
+        changed.push(f);
+      }
+      continue;
+    }
+    if (!basisStat.isFile()) {
       changed.push(f);
       continue;
     }
@@ -601,9 +718,14 @@ async function syncFolderOnce(
     }
   }
 
-  const encodedPayloads = await mapLimit(changed, encodeLimit, async (f): Promise<EncodedPayload> => {
+  // Symlink entries travel in the manifest only — no payloads.
+  const changedFiles = changed.filter((f) => f.linkTarget === undefined);
+
+  const encodedPayloads = await mapLimit(changedFiles, encodeLimit, async (f): Promise<EncodedPayload> => {
     const basisPath = cacheGet(opts.basisCacheDir, f.path);
-    if (f.size >= MIN_XDELTA_TARGET_BYTES && fs.existsSync(basisPath)) {
+    const basisStat =
+      f.size >= MIN_XDELTA_TARGET_BYTES ? await fs.promises.lstat(basisPath).catch(() => null) : null;
+    if (basisStat?.isFile()) {
       const basisSha = await sha256FileHex(basisPath);
       const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'limulator-xdelta3-'));
       const patchPath = path.join(tmpDir, 'patch.xdelta3');
@@ -642,6 +764,9 @@ async function syncFolderOnce(
       }
     }
     slog('debug', `full(file): ${f.path} size=${f.size}`);
+    if (f.size >= LARGE_UPLOAD_NOTICE_BYTES) {
+      slog('info', `uploading large file ${f.path} (${fmtBytes(f.size)})`);
+    }
     bytesSentFull += f.size;
     return {
       payload: {
@@ -663,7 +788,8 @@ async function syncFolderOnce(
       path: f.path,
       size: f.size,
       sha256: f.sha256.toLowerCase(),
-      mode: f.mode,
+      // Symlink entries carry the target; regular files carry the mode bits.
+      ...(f.linkTarget !== undefined ? { link: f.linkTarget } : { mode: f.mode }),
     })),
     payloads: encodedPayloads.map((p) => p.payload),
   };
@@ -696,6 +822,17 @@ async function syncFolderOnce(
   // Retry once if server needs full for some paths (basis mismatch).
   if (!resp.ok && resp.needFull && resp.needFull.length > 0) {
     const need = new Set(resp.needFull);
+    // A daemon that predates symlink support json-drops the `link` field and
+    // asks for these entries as full files. Streaming absPath would FOLLOW
+    // the link and silently materialize target content remotely — fail loud
+    // instead. (New daemons never put symlink entries in needFull.)
+    const needFullLinks = [...need].filter((p) => fileMap.get(p)?.linkTarget !== undefined);
+    if (needFullLinks.length > 0) {
+      throw new Error(
+        "this instance's build daemon does not support symlinks yet (needs an updated limbuild); " +
+          `recreate the instance or retry later. Paths: ${needFullLinks.join(', ')}`,
+      );
+    }
     const retryPayloads: EncodedPayload[] = [];
     for (const p of need) {
       const entry = fileMap.get(p);
@@ -749,11 +886,12 @@ async function syncFolderOnce(
   const tookMs = nowMs() - totalStart;
   const totalBytes = bytesSentFull + bytesSentDelta;
   slog(
-    'debug',
-    `sync finished files=${allFiles.length} sent=${fmtBytes(totalBytes)} syncWork=${fmtMs(
-      syncWorkMs,
-    )} total=${fmtMs(tookMs)}`,
+    'info',
+    `sync complete: files=${allFiles.length} changed=${changed.length} sent=${fmtBytes(
+      totalBytes,
+    )} in ${fmtMs(tookMs)}`,
   );
+  slog('debug', `sync timing syncWork=${fmtMs(syncWorkMs)} total=${fmtMs(tookMs)}`);
   const out: SyncFolderResult = { bytesSent: totalBytes };
   if (resp.installedAppPath) {
     out.installedAppPath = resp.installedAppPath;
@@ -762,8 +900,12 @@ async function syncFolderOnce(
     out.installedBundleId = resp.bundleId;
   }
   // Update local cache optimistically: after a successful sync, cache reflects current local tree.
+  // The stale-symlink-ancestor sweep only matters when symlink sync is on
+  // (otherwise the cache never holds a symlink); checkedDirs memoizes ancestors
+  // across the sorted walk.
+  const checkedDirs = opts.syncSymlinks ? new Set<string>() : undefined;
   for (const f of allFiles) {
-    await cachePut(opts.basisCacheDir, f.path, f.absPath);
+    await cachePut(opts.basisCacheDir, f.path, f.absPath, f.linkTarget, checkedDirs);
   }
   return out;
 }

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -46,6 +46,12 @@ export type SyncOptions = {
    */
   ignore?: (relativePath: string) => boolean;
   /**
+   * Optional predicate for force-including paths that would otherwise be
+   * dropped (gitignored generated sources, default Xcode excludes). Same
+   * calling convention as `ignore`; return true to force-sync the path.
+   */
+  include?: (relativePath: string) => boolean;
+  /**
    * Extra files to sync on every sync pass.
    */
   additionalFiles?: AdditionalFileSyncEntry[];
@@ -596,40 +602,18 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ignoreFn: await createIgnoreFn(localCodePath, {
             basisCacheDir,
             log,
-            additional: (relativePath: string) => {
-              if (
-                relativePath.startsWith('build/') ||
-                relativePath.startsWith('.build/') ||
-                relativePath.startsWith('DerivedData/') ||
-                relativePath.startsWith('Index.noindex/') ||
-                relativePath.startsWith('ModuleCache.noindex/') ||
-                relativePath.startsWith('.index-build/')
-              ) {
-                return true;
-              }
-              if (
-                relativePath.startsWith('.swiftpm/') ||
-                relativePath.startsWith('Pods/') ||
-                relativePath.startsWith('Carthage/Build/')
-              ) {
-                return true;
-              }
-              if (relativePath.includes('/xcuserdata/')) {
-                return true;
-              }
-              if (relativePath.includes('.dSYM/')) {
-                return true;
-              }
-              if (opts?.ignore?.(relativePath)) {
-                return true;
-              }
-              return false;
-            },
+            xcodeDefaults: true,
+            ...(opts?.include ? { include: opts.include } : {}),
+            ...(opts?.ignore ? { additional: opts.ignore } : {}),
           }),
           basisCacheDir,
           watch: opts?.watch ?? true,
           launchMode: 'ForegroundIfRunning',
           log,
+          // The limbuild workspace sync understands symlink entries; the
+          // limulator app-install sync (ios-client.ts) does not and keeps
+          // the default skip behavior.
+          syncSymlinks: true,
           ...(additionalFiles ? { additionalFiles } : {}),
         };
 

--- a/tests/folder-sync-ignore.test.ts
+++ b/tests/folder-sync-ignore.test.ts
@@ -1,0 +1,151 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createIgnoreFn, type IgnoreFn } from '@limrun/api/folder-sync-ignore';
+
+// Precedence table mirroring the Go harness parity test
+// (limrun test/integration/limbuild/folder_sync_ignore_test.go). Layers,
+// first decisive answer wins:
+//   1. .git/.DS_Store/basis-cache  2. user include  3. xcode default junk
+//   4. built-in force-include (.xcconfig, .xcodeproj/.xcworkspace)
+//   5. .gitignore chain (root + nested)  6. user ignore
+describe('createIgnoreFn', () => {
+  let dir: string;
+  let ignore: IgnoreFn;
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'folder-sync-ignore-test-'));
+    fs.writeFileSync(
+      path.join(dir, '.gitignore'),
+      [
+        'node_modules/',
+        'ios',
+        'android',
+        '*.log',
+        '!keep.log',
+        '*.xcconfig', // proves the .xcconfig override beats .gitignore
+        '*.xcodeproj', // generated projects, gitignored like Whop-style monorepos
+        '*.xcworkspace',
+      ].join('\n'),
+    );
+    // Nested .gitignore: rules bind relative to apps/foo/, and the deeper
+    // negation overrides the root *.log rule.
+    fs.mkdirSync(path.join(dir, 'apps', 'foo'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'apps', 'foo', '.gitignore'),
+      ['.build/', 'Generated/', '!important.log'].join('\n'),
+    );
+    ignore = await createIgnoreFn(dir, {
+      basisCacheDir: path.join(os.tmpdir(), 'some-other-place'),
+      xcodeDefaults: true,
+      include: (rel) => rel.startsWith('apps/foo/Generated/Kit/'),
+      // Also excludes apps/foo/important.log, which the nested !important.log
+      // negation re-includes: proves --ignore still wins over a gitignore
+      // re-include (layer 6 runs after a non-decisive gitignore answer).
+      additional: (rel) => rel.startsWith('secrets/') || rel.endsWith('important.log'),
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test.each<[string, boolean, string]>([
+    // Dot-files are NOT blanket-skipped.
+    ['.npmrc', false, 'npm config must reach the build'],
+    ['.xcode.env', false, 'RN build env, not git/DS_Store, not gitignored'],
+    ['App.tsx', false, 'ordinary source file'],
+    // Always-exclude.
+    ['.git/HEAD', true, '.git is always excluded'],
+    ['a/b/.git/config', true, 'nested .git is always excluded'],
+    ['.DS_Store', true, '.DS_Store is always excluded'],
+    ['sub/.DS_Store', true, 'nested .DS_Store is always excluded'],
+    // Always-include override.
+    ['Config.xcconfig', false, '.xcconfig overrides the *.xcconfig gitignore rule'],
+    // Root .gitignore (incl. dir-only rule and negation).
+    ['node_modules/', true, 'dir-only gitignore rule prunes the directory'],
+    ['node_modules/foo/index.js', true, 'files under a gitignored dir'],
+    ['ios/', true, "bare 'ios' rule matches the directory"],
+    ['ios/Podfile', true, 'files under gitignored ios/'],
+    ['debug.log', true, '*.log gitignore rule'],
+    ['keep.log', false, 'negation !keep.log re-includes'],
+    // Nested .gitignore, rules relative to apps/foo/.
+    ['apps/foo/.build/', true, 'nested .gitignore excludes its .build/'],
+    ['apps/foo/.build/manifest.db', true, 'files under nested-excluded dir'],
+    ['apps/foo/Generated/', true, 'nested Generated/ rule'],
+    ['apps/bar/Generated/x.swift', false, "nested rules don't leak to sibling trees"],
+    ['apps/foo/important.log', true, 'user --ignore wins over a gitignore negation re-include'],
+    ['apps/foo/debug.log', true, 'root *.log still applies where not negated'],
+    // User include force-syncs past nested gitignore.
+    ['apps/foo/Generated/Kit/Package.swift', false, 'include overrides nested gitignore'],
+    // Built-in force-include: gitignored generated projects still sync
+    // (when their parent dir is not itself pruned by gitignore).
+    ['app/App.xcodeproj/project.pbxproj', false, 'gitignored .xcodeproj is force-included'],
+    ['app/App.xcworkspace/contents.xcworkspacedata', false, 'gitignored .xcworkspace is force-included'],
+    ['app/App.xcodeproj/', false, '.xcodeproj directory itself is force-included so the walk descends'],
+    // ...but junk inside project bundles stays out (junk beats force-include).
+    [
+      'app/App.xcodeproj/project.xcworkspace/xcuserdata/u.plist',
+      true,
+      'xcuserdata inside a force-included bundle stays excluded',
+    ],
+    // Default Xcode/dependency excludes (even if not gitignored).
+    ['Pods/Manifest.lock', true, 'Pods/ is a default exclude'],
+    ['.swiftpm/x', true, '.swiftpm/ is a default exclude'],
+    ['build/out', true, 'build/ is a default exclude'],
+    ['DerivedData/x', true, 'DerivedData/ is a default exclude'],
+    ['Carthage/Build/x', true, 'Carthage/Build/ is a default exclude'],
+    ['sub/build/out', false, 'default dir excludes are root-anchored'],
+    ['a/proj.xcodeproj/project.xcworkspace/xcuserdata/u.plist', true, 'xcuserdata anywhere'],
+    ['Foo.dSYM/Contents/x', true, '.dSYM anywhere'],
+    // User ignore runs last.
+    ['secrets/key.pem', true, 'user --ignore excludes'],
+    ['secrets/Config.xcconfig', false, 'built-in force-include beats user --ignore (existing behavior)'],
+  ])('ignore(%s) = %s  // %s', (rel, want) => {
+    expect(ignore(rel)).toBe(want);
+  });
+});
+
+// The app-bundle install sync calls createIgnoreFn without xcodeDefaults, and
+// must keep the legacy behavior: only the root .gitignore is read, and the
+// .xcodeproj/.xcworkspace force-include does NOT apply (a build artifact is
+// not reshaped by gitignore files or Xcode rules embedded in it). .xcconfig
+// force-include stays unconditional, as it always was.
+describe('createIgnoreFn without xcodeDefaults (app-install legacy mode)', () => {
+  let dir: string;
+  let ignore: IgnoreFn;
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'folder-sync-ignore-legacy-'));
+    fs.writeFileSync(path.join(dir, '.gitignore'), ['*.log'].join('\n'));
+    fs.mkdirSync(path.join(dir, 'nested'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'nested', '.gitignore'), ['keep.txt'].join('\n'));
+    ignore = await createIgnoreFn(dir, {
+      basisCacheDir: path.join(os.tmpdir(), 'some-other-place'),
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test.each<[string, boolean, string]>([
+    ['root.log', true, 'root .gitignore still applies'],
+    ['nested/keep.txt', false, 'nested .gitignore is NOT honored in legacy mode'],
+    ['App.xcodeproj/project.pbxproj', false, 'gitignored-or-not, no rule excludes it here'],
+    ['Config.xcconfig', false, '.xcconfig force-include is unconditional'],
+    ['Pods/Manifest.lock', false, 'default junk excludes are off without xcodeDefaults'],
+  ])('ignore(%s) = %s  // %s', (rel, want) => {
+    expect(ignore(rel)).toBe(want);
+  });
+
+  test('.xcodeproj is NOT force-included when gitignored in legacy mode', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'folder-sync-ignore-legacy2-'));
+    fs.writeFileSync(path.join(d, '.gitignore'), ['*.xcodeproj'].join('\n'));
+    const ig = await createIgnoreFn(d, { basisCacheDir: path.join(os.tmpdir(), 'x') });
+    // Without xcodeDefaults the project force-include is off, so the gitignore
+    // rule wins and the bundle is excluded (legacy app-install behavior).
+    expect(ig('App.xcodeproj/project.pbxproj')).toBe(true);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+});

--- a/tests/folder-sync-ignore.test.ts
+++ b/tests/folder-sync-ignore.test.ts
@@ -7,7 +7,7 @@ import { createIgnoreFn, type IgnoreFn } from '@limrun/api/folder-sync-ignore';
 // (limrun test/integration/limbuild/folder_sync_ignore_test.go). Layers,
 // first decisive answer wins:
 //   1. .git/.DS_Store/basis-cache  2. user include  3. xcode default junk
-//   4. built-in force-include (.xcconfig, .xcodeproj/.xcworkspace)
+//   4. built-in force-include (.xcconfig only)
 //   5. .gitignore chain (root + nested)  6. user ignore
 describe('createIgnoreFn', () => {
   let dir: string;
@@ -38,7 +38,7 @@ describe('createIgnoreFn', () => {
     ignore = await createIgnoreFn(dir, {
       basisCacheDir: path.join(os.tmpdir(), 'some-other-place'),
       xcodeDefaults: true,
-      include: (rel) => rel.startsWith('apps/foo/Generated/Kit/'),
+      include: (rel) => rel.startsWith('apps/foo/Generated/Kit/') || rel.startsWith('pinned/'),
       // Also excludes apps/foo/important.log, which the nested !important.log
       // negation re-includes: proves --ignore still wins over a gitignore
       // re-include (layer 6 runs after a non-decisive gitignore answer).
@@ -78,17 +78,13 @@ describe('createIgnoreFn', () => {
     ['apps/foo/debug.log', true, 'root *.log still applies where not negated'],
     // User include force-syncs past nested gitignore.
     ['apps/foo/Generated/Kit/Package.swift', false, 'include overrides nested gitignore'],
-    // Built-in force-include: gitignored generated projects still sync
-    // (when their parent dir is not itself pruned by gitignore).
-    ['app/App.xcodeproj/project.pbxproj', false, 'gitignored .xcodeproj is force-included'],
-    ['app/App.xcworkspace/contents.xcworkspacedata', false, 'gitignored .xcworkspace is force-included'],
-    ['app/App.xcodeproj/', false, '.xcodeproj directory itself is force-included so the walk descends'],
-    // ...but junk inside project bundles stays out (junk beats force-include).
-    [
-      'app/App.xcodeproj/project.xcworkspace/xcuserdata/u.plist',
-      true,
-      'xcuserdata inside a force-included bundle stays excluded',
-    ],
+    // Gitignored generated projects are NOT force-included: limbuild
+    // regenerates them from project.yml, and exact-version holdouts
+    // force-sync theirs with --include (proven below).
+    ['app/App.xcodeproj/project.pbxproj', true, 'gitignored .xcodeproj respects gitignore'],
+    ['app/App.xcworkspace/contents.xcworkspacedata', true, 'gitignored .xcworkspace respects gitignore'],
+    ['app/App.xcodeproj/', true, 'gitignored .xcodeproj directory is pruned'],
+    ['pinned/Exact.xcodeproj/project.pbxproj', false, '--include rescues a gitignored .xcodeproj'],
     // Default Xcode/dependency excludes (even if not gitignored).
     ['Pods/Manifest.lock', true, 'Pods/ is a default exclude'],
     ['.swiftpm/x', true, '.swiftpm/ is a default exclude'],
@@ -107,10 +103,10 @@ describe('createIgnoreFn', () => {
 });
 
 // The app-bundle install sync calls createIgnoreFn without xcodeDefaults, and
-// must keep the legacy behavior: only the root .gitignore is read, and the
-// .xcodeproj/.xcworkspace force-include does NOT apply (a build artifact is
-// not reshaped by gitignore files or Xcode rules embedded in it). .xcconfig
-// force-include stays unconditional, as it always was.
+// must keep the legacy behavior: only the root .gitignore is read and no
+// default Xcode excludes apply (a build artifact is not reshaped by gitignore
+// files embedded in it). .xcconfig force-include stays unconditional, as it
+// always was.
 describe('createIgnoreFn without xcodeDefaults (app-install legacy mode)', () => {
   let dir: string;
   let ignore: IgnoreFn;
@@ -137,15 +133,5 @@ describe('createIgnoreFn without xcodeDefaults (app-install legacy mode)', () =>
     ['Pods/Manifest.lock', false, 'default junk excludes are off without xcodeDefaults'],
   ])('ignore(%s) = %s  // %s', (rel, want) => {
     expect(ignore(rel)).toBe(want);
-  });
-
-  test('.xcodeproj is NOT force-included when gitignored in legacy mode', async () => {
-    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'folder-sync-ignore-legacy2-'));
-    fs.writeFileSync(path.join(d, '.gitignore'), ['*.xcodeproj'].join('\n'));
-    const ig = await createIgnoreFn(d, { basisCacheDir: path.join(os.tmpdir(), 'x') });
-    // Without xcodeDefaults the project force-include is off, so the gitignore
-    // rule wins and the bundle is excluded (legacy app-install behavior).
-    expect(ig('App.xcodeproj/project.pbxproj')).toBe(true);
-    fs.rmSync(d, { recursive: true, force: true });
   });
 });

--- a/tests/folder-sync-symlink.test.ts
+++ b/tests/folder-sync-symlink.test.ts
@@ -27,8 +27,10 @@ function decodeBody(raw: Buffer, encoding: string | undefined): Buffer {
   return raw;
 }
 
-async function startStubServer(response: object = { ok: true }): Promise<StubServer> {
+async function startStubServer(response: object | object[] = { ok: true }): Promise<StubServer> {
   const requests: WireMeta[] = [];
+  // An array means one response per request, in order (the last one repeats).
+  const responses = Array.isArray(response) ? response : [response];
   const server = http.createServer((req, res) => {
     const chunks: Buffer[] = [];
     req.on('data', (c) => chunks.push(c));
@@ -37,7 +39,7 @@ async function startStubServer(response: object = { ok: true }): Promise<StubSer
       const metaLen = body.readUInt32BE(0);
       requests.push(JSON.parse(body.subarray(4, 4 + metaLen).toString('utf-8')) as WireMeta);
       res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify(response));
+      res.end(JSON.stringify(responses[Math.min(requests.length - 1, responses.length - 1)]));
     });
   });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -185,6 +187,20 @@ describe('folder-sync symlinks', () => {
       await expect(syncFolder(tree, syncOpts(server, cache))).rejects.toThrow(/does not support symlinks/);
       // No retry request: the target's content must never be uploaded as a file.
       expect(server.requests).toHaveLength(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('needFull retry counts resent bytes once', async () => {
+    fs.writeFileSync(path.join(tree, 'ios', 'data.swift'), 'x'.repeat(1000));
+    const server = await startStubServer([{ ok: false, needFull: ['ios/data.swift'] }, { ok: true }]);
+    try {
+      const result = await syncFolder(tree, syncOpts(server, cache));
+      expect(server.requests).toHaveLength(2);
+      // Reported bytes must equal the payload bytes that went over the wire.
+      const wireBytes = server.requests.flatMap((r) => r.payloads).reduce((sum, p) => sum + p.length, 0);
+      expect(result.bytesSent).toBe(wireBytes);
     } finally {
       await server.close();
     }

--- a/tests/folder-sync-symlink.test.ts
+++ b/tests/folder-sync-symlink.test.ts
@@ -115,14 +115,44 @@ describe('folder-sync symlinks', () => {
     expect(meta.files.map((f) => f.path)).not.toContain('ios/link.swift');
   });
 
-  test.each([
-    ['/etc/hosts', 'absolute'],
-    ['../../outside.swift', 'escaping'],
-  ])('rejects %s (%s target) at sync time', async (target) => {
-    fs.symlinkSync(target, path.join(tree, 'ios', 'link.swift'));
+  test('rejects a relative escaping target at sync time', async () => {
+    fs.symlinkSync('../../outside.swift', path.join(tree, 'ios', 'link.swift'));
     const server = await startStubServer({ ok: true });
     try {
       await expect(syncFolder(tree, syncOpts(server, cache))).rejects.toThrow(/points outside the sync root/);
+      expect(server.requests).toHaveLength(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('warns and skips an absolute-target symlink instead of failing the sync', async () => {
+    // Absolute targets can never resolve remotely; pre-symlink clients
+    // silently skipped all links, so a decorative /usr/... link must not
+    // turn a working sync into a hard failure.
+    fs.symlinkSync('/etc/hosts', path.join(tree, 'ios', 'abs-link'));
+    const warnings: string[] = [];
+    const server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, {
+        ...syncOpts(server, cache),
+        log: (level, msg) => {
+          if (level === 'warn') warnings.push(msg);
+        },
+      });
+    } finally {
+      await server.close();
+    }
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]!.files.map((f) => f.path)).not.toContain('ios/abs-link');
+    expect(warnings.join('\n')).toMatch(/skipping symlink ios\/abs-link/);
+  });
+
+  test('rejects a backslash-containing target at sync time (daemon parity)', async () => {
+    fs.symlinkSync('weird\\name.swift', path.join(tree, 'ios', 'bs-link'));
+    const server = await startStubServer({ ok: true });
+    try {
+      await expect(syncFolder(tree, syncOpts(server, cache))).rejects.toThrow(/backslash/);
       expect(server.requests).toHaveLength(0);
     } finally {
       await server.close();

--- a/tests/folder-sync-symlink.test.ts
+++ b/tests/folder-sync-symlink.test.ts
@@ -1,0 +1,254 @@
+import fs from 'fs';
+import http from 'http';
+import os from 'os';
+import path from 'path';
+import zlib from 'zlib';
+import { syncFolder, type FolderSyncOptions } from '@limrun/api/folder-sync';
+
+type WireFile = { path: string; size: number; sha256: string; mode?: number; link?: string };
+type WireMeta = {
+  files: WireFile[];
+  payloads: { kind: 'delta' | 'full'; path: string; length: number }[];
+};
+
+type StubServer = {
+  url: string;
+  requests: WireMeta[];
+  close: () => Promise<void>;
+};
+
+function decodeBody(raw: Buffer, encoding: string | undefined): Buffer {
+  if (encoding === 'gzip') return zlib.gunzipSync(raw);
+  if (encoding === 'zstd') {
+    const decompress = (zlib as any).zstdDecompressSync as ((b: Buffer) => Buffer) | undefined;
+    if (!decompress) throw new Error('zstd request body but no zstd support in this Node');
+    return decompress(raw);
+  }
+  return raw;
+}
+
+async function startStubServer(response: object = { ok: true }): Promise<StubServer> {
+  const requests: WireMeta[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const body = decodeBody(Buffer.concat(chunks), req.headers['content-encoding'] as string);
+      const metaLen = body.readUInt32BE(0);
+      requests.push(JSON.parse(body.subarray(4, 4 + metaLen).toString('utf-8')) as WireMeta);
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(response));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as { port: number };
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+function syncOpts(server: StubServer, basisCacheDir: string): FolderSyncOptions {
+  return {
+    apiUrl: server.url,
+    token: 'test-token',
+    udid: 'test',
+    basisCacheDir,
+    install: false,
+    launchMode: 'ForegroundIfRunning',
+    watch: false,
+    log: () => {},
+    ignoreFn: () => false,
+    syncSymlinks: true,
+  };
+}
+
+describe('folder-sync symlinks', () => {
+  let tmpDir: string;
+  let tree: string;
+  let cache: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'folder-sync-symlink-test-'));
+    tree = path.join(tmpDir, 'proj');
+    cache = path.join(tmpDir, 'basis-cache');
+    fs.mkdirSync(path.join(tree, 'shared'), { recursive: true });
+    fs.mkdirSync(path.join(tree, 'ios'), { recursive: true });
+    fs.writeFileSync(path.join(tree, 'shared', 'real.swift'), 'let x = 1\n');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('emits link entries with the literal target and no payload', async () => {
+    fs.symlinkSync('../shared/real.swift', path.join(tree, 'ios', 'link.swift'));
+    const server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, syncOpts(server, cache));
+    } finally {
+      await server.close();
+    }
+
+    expect(server.requests).toHaveLength(1);
+    const meta = server.requests[0]!;
+    const link = meta.files.find((f) => f.path === 'ios/link.swift');
+    expect(link).toBeDefined();
+    expect(link!.link).toBe('../shared/real.swift');
+    expect(link!.mode).toBeUndefined();
+    expect(link!.size).toBe(Buffer.byteLength('../shared/real.swift'));
+    expect(meta.payloads.map((p) => p.path)).not.toContain('ios/link.swift');
+    // The regular file still travels as a normal full payload.
+    expect(meta.payloads.map((p) => p.path)).toContain('shared/real.swift');
+  });
+
+  test('symlinks are dropped when syncSymlinks is off (app-install path)', async () => {
+    fs.symlinkSync('../shared/real.swift', path.join(tree, 'ios', 'link.swift'));
+    const server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, { ...syncOpts(server, cache), syncSymlinks: false });
+    } finally {
+      await server.close();
+    }
+    const meta = server.requests[0]!;
+    expect(meta.files.map((f) => f.path)).not.toContain('ios/link.swift');
+  });
+
+  test.each([
+    ['/etc/hosts', 'absolute'],
+    ['../../outside.swift', 'escaping'],
+  ])('rejects %s (%s target) at sync time', async (target) => {
+    fs.symlinkSync(target, path.join(tree, 'ios', 'link.swift'));
+    const server = await startStubServer({ ok: true });
+    try {
+      await expect(syncFolder(tree, syncOpts(server, cache))).rejects.toThrow(/points outside the sync root/);
+      expect(server.requests).toHaveLength(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('a symlinked dir matching a dir-exclude is skipped, not validated/thrown', async () => {
+    // Pods -> /opt/shared-pods (absolute, out-of-root). An excluded symlink
+    // must be dropped by the ignore probe before validateSymlinkTarget throws.
+    fs.symlinkSync('/opt/shared-pods', path.join(tree, 'Pods'));
+    const server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, {
+        ...syncOpts(server, cache),
+        // Directory-form exclude, as the real Pods/ default would produce.
+        ignoreFn: (p) => p === 'Pods/',
+      });
+    } finally {
+      await server.close();
+    }
+    // Sync succeeded (no throw) and Pods was not uploaded.
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]!.files.map((f) => f.path)).not.toContain('Pods');
+  });
+
+  test('old daemon asking full for a symlink fails loud without uploading', async () => {
+    fs.symlinkSync('../shared/real.swift', path.join(tree, 'ios', 'link.swift'));
+    const server = await startStubServer({ ok: false, needFull: ['ios/link.swift'] });
+    try {
+      await expect(syncFolder(tree, syncOpts(server, cache))).rejects.toThrow(/does not support symlinks/);
+      // No retry request: the target's content must never be uploaded as a file.
+      expect(server.requests).toHaveLength(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('type flips: file->symlink sends a link entry; symlink->file sends a FULL payload', async () => {
+    const p = path.join(tree, 'ios', 'thing.swift');
+
+    // Sync 1: regular file, populates the basis cache.
+    fs.writeFileSync(p, 'regular v1\n');
+    let server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, syncOpts(server, cache));
+    } finally {
+      await server.close();
+    }
+
+    // Sync 2: replaced by a symlink -> link entry, no payload for the path.
+    fs.rmSync(p);
+    fs.symlinkSync('../shared/real.swift', p);
+    server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, syncOpts(server, cache));
+    } finally {
+      await server.close();
+    }
+    let meta = server.requests[0]!;
+    expect(meta.files.find((f) => f.path === 'ios/thing.swift')!.link).toBe('../shared/real.swift');
+    expect(meta.payloads.map((x) => x.path)).not.toContain('ios/thing.swift');
+
+    // Sync 3: back to a regular file. The basis cache holds a symlink for
+    // this path, so the client must send a FULL payload (never a delta
+    // against a link) and must not have written v2 content through the
+    // stale cache link into the cached target.
+    fs.rmSync(p);
+    fs.writeFileSync(p, 'regular v2\n');
+    server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, syncOpts(server, cache));
+    } finally {
+      await server.close();
+    }
+    meta = server.requests[0]!;
+    const payload = meta.payloads.find((x) => x.path === 'ios/thing.swift');
+    expect(payload).toBeDefined();
+    expect(payload!.kind).toBe('full');
+    const cachedTarget = fs.readFileSync(path.join(cache, 'shared', 'real.swift'), 'utf-8');
+    expect(cachedTarget).toBe('let x = 1\n');
+    // And the cache now holds a regular file for the flipped path.
+    expect(fs.lstatSync(path.join(cache, 'ios', 'thing.swift')).isSymbolicLink()).toBe(false);
+  });
+
+  test('unchanged symlink stays a symlink in the basis cache across syncs', async () => {
+    fs.symlinkSync('../shared/real.swift', path.join(tree, 'ios', 'link.swift'));
+    for (let i = 0; i < 2; i++) {
+      const server = await startStubServer({ ok: true });
+      try {
+        await syncFolder(tree, syncOpts(server, cache));
+      } finally {
+        await server.close();
+      }
+    }
+    const cached = path.join(cache, 'ios', 'link.swift');
+    expect(fs.lstatSync(cached).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(cached)).toBe('../shared/real.swift');
+  });
+
+  test('a symlinked dir replaced by a real dir does not corrupt the target basis', async () => {
+    // Sync 1: 'dir' is a symlink to the 'shared' directory.
+    fs.symlinkSync('shared', path.join(tree, 'dir'));
+    let server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, syncOpts(server, cache));
+    } finally {
+      await server.close();
+    }
+    expect(fs.lstatSync(path.join(cache, 'dir')).isSymbolicLink()).toBe(true);
+
+    // Sync 2: replace 'dir' with a real directory holding its own file. The
+    // stale cache symlink at cache/dir must be pruned so dir/a.txt is not
+    // written through it into cache/shared, corrupting shared/real.swift's basis.
+    fs.rmSync(path.join(tree, 'dir'));
+    fs.mkdirSync(path.join(tree, 'dir'));
+    fs.writeFileSync(path.join(tree, 'dir', 'a.txt'), 'dir-a-content\n');
+    server = await startStubServer({ ok: true });
+    try {
+      await syncFolder(tree, syncOpts(server, cache));
+    } finally {
+      await server.close();
+    }
+    // shared/real.swift basis is intact (not overwritten via the stale link).
+    expect(fs.readFileSync(path.join(cache, 'shared', 'real.swift'), 'utf-8')).toBe('let x = 1\n');
+    // cache/dir is now a real directory with the right file.
+    expect(fs.lstatSync(path.join(cache, 'dir')).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(cache, 'dir', 'a.txt'), 'utf-8')).toBe('dir-a-content\n');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes what files reach remote builds (ignore precedence and .xcodeproj behavior) and introduces a new wire format for symlinks; mistakes could omit or mis-sync project inputs, though behavior is covered by new tests.
> 
> **Overview**
> Adds **`--include`** on `xcode build` and `xcode sync` so regex patterns can **force-sync** paths that would otherwise be dropped (gitignored generated trees, default Xcode junk). Ignore logic is now a **fixed six-layer predicate** in `createIgnoreFn`: hard excludes, user include, Xcode default excludes (when `xcodeDefaults`), built-in `.xcconfig` force-include, nested/root `.gitignore` chain, then `--ignore`. Gitignored `.xcodeproj`/`.xcworkspace` are **no longer** auto-included; use `--include` when you need a pinned project on the remote.
> 
> **Folder sync** can optionally ship **symlinks as manifest `link` entries** (no payload) via `syncSymlinks` (enabled for limbuild workspace sync, off for app-install). Relative in-root targets are validated; absolute links are warned and skipped; old daemons that `needFull` on a link fail explicitly instead of following the link. Basis-cache diffing uses **`lstat`**, handles link metadata, and prunes stale symlink/file type flips when updating the cache.
> 
> SDK wiring moves Xcode default excludes into `xcodeDefaults: true` plus `include`/`ignore` hooks, with clearer sync logging (large uploads, completion summary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6cb9944dc8f458b06c5d6efebcc7471a8687b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->