### PR TITLE
cli,api: add --testflight upload for signed Xcode device builds

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -20,7 +20,7 @@ type SigningFlags = {
   'provisioning-profile'?: string;
 };
 type TestflightFlags = {
-  testflight: boolean;
+  'upload-to-testflight': boolean;
   'asc-key-id'?: string;
   'asc-issuer-id'?: string;
   'asc-key'?: string;
@@ -44,7 +44,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
-    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --testflight --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
+    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload-to-testflight --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
@@ -112,19 +112,19 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Path to a .mobileprovision profile. Requires --certificate-p12 and --certificate-password.',
     }),
-    testflight: Flags.boolean({
+    'upload-to-testflight': Flags.boolean({
       description:
         'Upload the signed IPA to TestFlight after the build. Requires the signing flags plus --asc-key-id and --asc-key.',
       default: false,
     }),
     'asc-key-id': Flags.string({
-      description: 'App Store Connect API key ID for --testflight, e.g. 2X9R4HXF34.',
+      description: 'App Store Connect API key ID for --upload-to-testflight, e.g. 2X9R4HXF34.',
     }),
     'asc-issuer-id': Flags.string({
       description: 'App Store Connect issuer ID for team API keys. Omit when using an individual API key.',
     }),
     'asc-key': Flags.string({
-      description: 'Path to the App Store Connect API private key (.p8) for --testflight.',
+      description: 'Path to the App Store Connect API private key (.p8) for --upload-to-testflight.',
     }),
     'asc-wait-timeout': Flags.integer({
       description:
@@ -164,7 +164,7 @@ export default class XcodeBuild extends BaseCommand {
     if (flags.ios && hasSigningFlags(flags)) {
       this.error('--ios builds run on a simulator and cannot use signing flags.');
     }
-    if (flags.ios && (flags.testflight || hasTestflightFlags(flags))) {
+    if (flags.ios && (flags['upload-to-testflight'] || hasTestflightFlags(flags))) {
       this.error('--ios builds run on a simulator and cannot upload to TestFlight.');
     }
 
@@ -208,19 +208,19 @@ export default class XcodeBuild extends BaseCommand {
         }
         options.signing = signing;
       }
-      if (!flags.testflight && hasTestflightFlags(flags)) {
+      if (!flags['upload-to-testflight'] && hasTestflightFlags(flags)) {
         // Reserved: a bare ASC credential may gain other meanings later
         // (managed signing, entitlement preflight), so it never implies one.
-        this.error('The asc flags require --testflight.');
+        this.error('The asc flags require --upload-to-testflight.');
       }
-      if (flags.testflight) {
+      if (flags['upload-to-testflight']) {
         if (!signing) {
           this.error(
-            '--testflight uploads the signed IPA, so it requires --certificate-p12, --certificate-password, and --provisioning-profile.',
+            '--upload-to-testflight delivers the signed IPA, so it requires --certificate-p12, --certificate-password, and --provisioning-profile.',
           );
         }
         if (settings.sdk !== 'iphoneos') {
-          this.error('--testflight requires --sdk iphoneos.');
+          this.error('--upload-to-testflight requires --sdk iphoneos.');
         }
         options.testflight = await this.buildTestflightOptions(flags);
       }
@@ -342,7 +342,7 @@ export default class XcodeBuild extends BaseCommand {
 
   private async buildTestflightOptions(flags: TestflightFlags): Promise<TestflightUploadConfig> {
     if (!flags['asc-key-id'] || !flags['asc-key']) {
-      this.error('--testflight requires both --asc-key-id and --asc-key.');
+      this.error('--upload-to-testflight requires both --asc-key-id and --asc-key.');
     }
     return {
       apiKeyId: flags['asc-key-id'],

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -14,6 +14,12 @@ type SigningFlags = {
   'certificate-password'?: string;
   'provisioning-profile'?: string;
 };
+type TestflightFlags = {
+  testflight: boolean;
+  'asc-key-id'?: string;
+  'asc-issuer-id'?: string;
+  'asc-key'?: string;
+};
 
 export default class XcodeBuild extends BaseCommand {
   static summary = 'Run xcodebuild on an Xcode sandbox';
@@ -32,6 +38,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
+    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --testflight --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
@@ -99,6 +106,25 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Path to a .mobileprovision profile. Requires --certificate-p12 and --certificate-password.',
     }),
+    testflight: Flags.boolean({
+      description:
+        'Upload the signed IPA to TestFlight (App Store Connect) after the build. Requires the signing flags plus --asc-key-id and --asc-key.',
+      default: false,
+    }),
+    'asc-key-id': Flags.string({
+      description: 'App Store Connect API key ID for --testflight, e.g. 2X9R4HXF34.',
+      env: 'ASC_KEY_ID',
+    }),
+    'asc-issuer-id': Flags.string({
+      description:
+        'App Store Connect issuer ID for team API keys. Omit when using an individual API key.',
+      env: 'ASC_ISSUER_ID',
+    }),
+    'asc-key': Flags.string({
+      description:
+        'Path to the App Store Connect API private key (.p8) for --testflight. Alternatively set ASC_PRIVATE_KEY_B64 to the base64-encoded key content.',
+      env: 'ASC_KEY_PATH',
+    }),
     'basis-cache-dir': Flags.string({
       description: 'Directory to use for the client-side delta sync cache during the pre-build sync step.',
     }),
@@ -130,6 +156,9 @@ export default class XcodeBuild extends BaseCommand {
     }
     if (flags.ios && hasSigningFlags(flags)) {
       this.error('--ios builds run on a simulator and cannot use signing flags.');
+    }
+    if (flags.ios && flags.testflight) {
+      this.error('--ios builds run on a simulator and cannot upload to TestFlight.');
     }
 
     await this.withAuth(async () => {
@@ -171,6 +200,17 @@ export default class XcodeBuild extends BaseCommand {
           this.error('Signing is only supported for device SDK builds. Use --sdk iphoneos or --sdk watchos.');
         }
         options.signing = signing;
+      }
+      if (flags.testflight) {
+        if (!signing) {
+          this.error(
+            '--testflight uploads the signed IPA, so it requires --certificate-p12, --certificate-password, and --provisioning-profile.',
+          );
+        }
+        if (settings.sdk !== 'iphoneos') {
+          this.error('--testflight requires --sdk iphoneos.');
+        }
+        options.testflight = await this.buildTestflightOptions(flags);
       }
       if (flags.upload && flags['signed-upload-url']) {
         this.error('Use either --upload or --signed-upload-url, not both.');
@@ -215,10 +255,32 @@ export default class XcodeBuild extends BaseCommand {
       const result = await proc;
 
       if (result.exitCode !== 0) {
+        if (result.testflight?.state === 'failed') {
+          this.error(
+            "TestFlight upload failed; the build and signing succeeded. See App Store Connect's response in the log above.",
+            { exit: result.exitCode },
+          );
+        }
         this.error(`xcodebuild failed with exit code ${result.exitCode}`, { exit: result.exitCode });
+      }
+      // Old limbuild servers silently drop the unknown testflight request
+      // field and report a successful build without ever uploading, so a
+      // zero exit without a single testflight event means the feature is
+      // missing, not that the upload succeeded.
+      if (flags.testflight && !result.testflight) {
+        this.error(
+          "This instance's limbuild does not support --testflight yet. Recreate the instance or retry later.",
+        );
       }
 
       this.output(`\nBuild succeeded (exit code ${result.exitCode})`);
+      if (result.testflight?.state === 'accepted') {
+        this.output('TestFlight: accepted by App Store Connect.');
+      } else if (result.testflight?.state === 'processing') {
+        this.output(
+          `TestFlight: uploaded, still processing on Apple's side (upload ${result.testflight.uploadId ?? 'unknown'}).`,
+        );
+      }
       if (flags.ios) {
         const signedStreamUrl = await this.resolveSimulatorStreamUrl(target, xcodeClient);
         if (signedStreamUrl) {
@@ -254,9 +316,45 @@ export default class XcodeBuild extends BaseCommand {
     }
 
     return {
-      certificateP12Base64: (await readFile(flags['certificate-p12']!)).toString('base64'),
+      certificateP12Base64: await this.readFileBase64(flags['certificate-p12']!, '--certificate-p12'),
       certificatePassword: flags['certificate-password']!,
-      provisioningProfileBase64: (await readFile(flags['provisioning-profile']!)).toString('base64'),
+      provisioningProfileBase64: await this.readFileBase64(
+        flags['provisioning-profile']!,
+        '--provisioning-profile',
+      ),
+    };
+  }
+
+  private async readFileBase64(path: string, flagName: string): Promise<string> {
+    try {
+      return (await readFile(path)).toString('base64');
+    } catch (err) {
+      this.error(`Failed to read ${flagName} file at ${path}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  private async buildTestflightOptions(flags: TestflightFlags): Promise<{
+    apiKeyId: string;
+    apiIssuerId?: string;
+    apiPrivateKeyBase64: string;
+  }> {
+    if (!flags['asc-key-id']) {
+      this.error('--testflight requires --asc-key-id (or the ASC_KEY_ID environment variable).');
+    }
+    let apiPrivateKeyBase64: string;
+    if (flags['asc-key']) {
+      apiPrivateKeyBase64 = await this.readFileBase64(flags['asc-key'], '--asc-key');
+    } else if (process.env.ASC_PRIVATE_KEY_B64) {
+      apiPrivateKeyBase64 = process.env.ASC_PRIVATE_KEY_B64;
+    } else {
+      this.error(
+        '--testflight requires the App Store Connect API private key: pass --asc-key <path-to-.p8> or set ASC_PRIVATE_KEY_B64.',
+      );
+    }
+    return {
+      apiKeyId: flags['asc-key-id'],
+      ...(flags['asc-issuer-id'] && { apiIssuerId: flags['asc-issuer-id'] }),
+      apiPrivateKeyBase64,
     };
   }
 

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -110,8 +110,7 @@ export default class XcodeBuild extends BaseCommand {
         'App Store Connect API key ID, e.g. 2X9R4HXF34. Passing the asc flags uploads the signed IPA to TestFlight after the build; requires the signing flags and --asc-key.',
     }),
     'asc-issuer-id': Flags.string({
-      description:
-        'App Store Connect issuer ID for team API keys. Omit when using an individual API key.',
+      description: 'App Store Connect issuer ID for team API keys. Omit when using an individual API key.',
     }),
     'asc-key': Flags.string({
       description: 'Path to the App Store Connect API private key (.p8). Requires --asc-key-id.',
@@ -270,7 +269,9 @@ export default class XcodeBuild extends BaseCommand {
         this.output('TestFlight: accepted by App Store Connect.');
       } else if (result.testflight?.state === 'processing') {
         this.output(
-          `TestFlight: uploaded, still processing on Apple's side (upload ${result.testflight.uploadId ?? 'unknown'}).`,
+          `TestFlight: uploaded, still processing on Apple's side (upload ${
+            result.testflight.uploadId ?? 'unknown'
+          }).`,
         );
       }
       if (flags.ios) {

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -20,6 +20,7 @@ type SigningFlags = {
   'provisioning-profile'?: string;
 };
 type TestflightFlags = {
+  testflight: boolean;
   'asc-key-id'?: string;
   'asc-issuer-id'?: string;
   'asc-key'?: string;
@@ -43,7 +44,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
-    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
+    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --testflight --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
@@ -111,15 +112,19 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Path to a .mobileprovision profile. Requires --certificate-p12 and --certificate-password.',
     }),
-    'asc-key-id': Flags.string({
+    testflight: Flags.boolean({
       description:
-        'App Store Connect API key ID, e.g. 2X9R4HXF34. Passing the asc flags uploads the signed IPA to TestFlight after the build; requires the signing flags and --asc-key.',
+        'Upload the signed IPA to TestFlight after the build. Requires the signing flags plus --asc-key-id and --asc-key.',
+      default: false,
+    }),
+    'asc-key-id': Flags.string({
+      description: 'App Store Connect API key ID for --testflight, e.g. 2X9R4HXF34.',
     }),
     'asc-issuer-id': Flags.string({
       description: 'App Store Connect issuer ID for team API keys. Omit when using an individual API key.',
     }),
     'asc-key': Flags.string({
-      description: 'Path to the App Store Connect API private key (.p8). Requires --asc-key-id.',
+      description: 'Path to the App Store Connect API private key (.p8) for --testflight.',
     }),
     'asc-wait-timeout': Flags.integer({
       description:
@@ -159,7 +164,7 @@ export default class XcodeBuild extends BaseCommand {
     if (flags.ios && hasSigningFlags(flags)) {
       this.error('--ios builds run on a simulator and cannot use signing flags.');
     }
-    if (flags.ios && hasTestflightFlags(flags)) {
+    if (flags.ios && (flags.testflight || hasTestflightFlags(flags))) {
       this.error('--ios builds run on a simulator and cannot upload to TestFlight.');
     }
 
@@ -203,17 +208,21 @@ export default class XcodeBuild extends BaseCommand {
         }
         options.signing = signing;
       }
-      const testflight = await this.buildTestflightOptions(flags);
-      if (testflight) {
+      if (!flags.testflight && hasTestflightFlags(flags)) {
+        // Reserved: a bare ASC credential may gain other meanings later
+        // (managed signing, entitlement preflight), so it never implies one.
+        this.error('The asc flags require --testflight.');
+      }
+      if (flags.testflight) {
         if (!signing) {
           this.error(
-            'TestFlight upload delivers the signed IPA, so the asc flags require --certificate-p12, --certificate-password, and --provisioning-profile.',
+            '--testflight uploads the signed IPA, so it requires --certificate-p12, --certificate-password, and --provisioning-profile.',
           );
         }
         if (settings.sdk !== 'iphoneos') {
-          this.error('TestFlight upload requires --sdk iphoneos.');
+          this.error('--testflight requires --sdk iphoneos.');
         }
-        options.testflight = testflight;
+        options.testflight = await this.buildTestflightOptions(flags);
       }
       if (flags.upload && flags['signed-upload-url']) {
         this.error('Use either --upload or --signed-upload-url, not both.');
@@ -331,14 +340,9 @@ export default class XcodeBuild extends BaseCommand {
     }
   }
 
-  // Mirrors the signing convention: passing any asc flag expresses the intent
-  // to upload to TestFlight, no separate toggle.
-  private async buildTestflightOptions(flags: TestflightFlags): Promise<TestflightUploadConfig | undefined> {
-    if (!hasTestflightFlags(flags)) {
-      return undefined;
-    }
+  private async buildTestflightOptions(flags: TestflightFlags): Promise<TestflightUploadConfig> {
     if (!flags['asc-key-id'] || !flags['asc-key']) {
-      this.error('TestFlight upload requires both --asc-key-id and --asc-key.');
+      this.error('--testflight requires both --asc-key-id and --asc-key.');
     }
     return {
       apiKeyId: flags['asc-key-id'],

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -266,15 +266,6 @@ export default class XcodeBuild extends BaseCommand {
         }
         this.error(`xcodebuild failed with exit code ${result.exitCode}`, { exit: result.exitCode });
       }
-      // Old limbuild servers silently drop the unknown testflight request
-      // field and report a successful build without ever uploading, so a
-      // zero exit without a single testflight event means the feature is
-      // missing, not that the upload succeeded.
-      if (options.testflight && !result.testflight) {
-        this.error(
-          "This instance's limbuild does not support TestFlight upload yet. Recreate the instance or retry later.",
-        );
-      }
 
       this.output(`\nBuild succeeded (exit code ${result.exitCode})`);
       if (result.testflight?.state === 'accepted') {

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -267,6 +267,12 @@ export default class XcodeBuild extends BaseCommand {
       const result = await proc;
 
       if (result.exitCode !== 0) {
+        if (result.timedOut) {
+          this.error(
+            'Timed out waiting for the build to finish; the remote build may still be running. Check the instance before retrying.',
+            { exit: result.exitCode },
+          );
+        }
         if (result.testflight?.state === 'failed') {
           this.error(
             "TestFlight upload failed; the build and signing succeeded. See App Store Connect's response in the log above.",

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -15,7 +15,6 @@ type SigningFlags = {
   'provisioning-profile'?: string;
 };
 type TestflightFlags = {
-  testflight: boolean;
   'asc-key-id'?: string;
   'asc-issuer-id'?: string;
   'asc-key'?: string;
@@ -38,7 +37,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
-    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --testflight --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
+    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
@@ -106,24 +105,16 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Path to a .mobileprovision profile. Requires --certificate-p12 and --certificate-password.',
     }),
-    testflight: Flags.boolean({
-      description:
-        'Upload the signed IPA to TestFlight (App Store Connect) after the build. Requires the signing flags plus --asc-key-id and --asc-key.',
-      default: false,
-    }),
     'asc-key-id': Flags.string({
-      description: 'App Store Connect API key ID for --testflight, e.g. 2X9R4HXF34.',
-      env: 'ASC_KEY_ID',
+      description:
+        'App Store Connect API key ID, e.g. 2X9R4HXF34. Passing the asc flags uploads the signed IPA to TestFlight after the build; requires the signing flags and --asc-key.',
     }),
     'asc-issuer-id': Flags.string({
       description:
         'App Store Connect issuer ID for team API keys. Omit when using an individual API key.',
-      env: 'ASC_ISSUER_ID',
     }),
     'asc-key': Flags.string({
-      description:
-        'Path to the App Store Connect API private key (.p8) for --testflight. Alternatively set ASC_PRIVATE_KEY_B64 to the base64-encoded key content.',
-      env: 'ASC_KEY_PATH',
+      description: 'Path to the App Store Connect API private key (.p8). Requires --asc-key-id.',
     }),
     'basis-cache-dir': Flags.string({
       description: 'Directory to use for the client-side delta sync cache during the pre-build sync step.',
@@ -157,7 +148,7 @@ export default class XcodeBuild extends BaseCommand {
     if (flags.ios && hasSigningFlags(flags)) {
       this.error('--ios builds run on a simulator and cannot use signing flags.');
     }
-    if (flags.ios && flags.testflight) {
+    if (flags.ios && hasTestflightFlags(flags)) {
       this.error('--ios builds run on a simulator and cannot upload to TestFlight.');
     }
 
@@ -201,16 +192,17 @@ export default class XcodeBuild extends BaseCommand {
         }
         options.signing = signing;
       }
-      if (flags.testflight) {
+      const testflight = await this.buildTestflightOptions(flags);
+      if (testflight) {
         if (!signing) {
           this.error(
-            '--testflight uploads the signed IPA, so it requires --certificate-p12, --certificate-password, and --provisioning-profile.',
+            'TestFlight upload delivers the signed IPA, so the asc flags require --certificate-p12, --certificate-password, and --provisioning-profile.',
           );
         }
         if (settings.sdk !== 'iphoneos') {
-          this.error('--testflight requires --sdk iphoneos.');
+          this.error('TestFlight upload requires --sdk iphoneos.');
         }
-        options.testflight = await this.buildTestflightOptions(flags);
+        options.testflight = testflight;
       }
       if (flags.upload && flags['signed-upload-url']) {
         this.error('Use either --upload or --signed-upload-url, not both.');
@@ -267,9 +259,9 @@ export default class XcodeBuild extends BaseCommand {
       // field and report a successful build without ever uploading, so a
       // zero exit without a single testflight event means the feature is
       // missing, not that the upload succeeded.
-      if (flags.testflight && !result.testflight) {
+      if (options.testflight && !result.testflight) {
         this.error(
-          "This instance's limbuild does not support --testflight yet. Recreate the instance or retry later.",
+          "This instance's limbuild does not support TestFlight upload yet. Recreate the instance or retry later.",
         );
       }
 
@@ -333,28 +325,26 @@ export default class XcodeBuild extends BaseCommand {
     }
   }
 
-  private async buildTestflightOptions(flags: TestflightFlags): Promise<{
-    apiKeyId: string;
-    apiIssuerId?: string;
-    apiPrivateKeyBase64: string;
-  }> {
-    if (!flags['asc-key-id']) {
-      this.error('--testflight requires --asc-key-id (or the ASC_KEY_ID environment variable).');
+  // Mirrors the signing convention: passing any asc flag expresses the intent
+  // to upload to TestFlight, no separate toggle.
+  private async buildTestflightOptions(flags: TestflightFlags): Promise<
+    | {
+        apiKeyId: string;
+        apiIssuerId?: string;
+        apiPrivateKeyBase64: string;
+      }
+    | undefined
+  > {
+    if (!hasTestflightFlags(flags)) {
+      return undefined;
     }
-    let apiPrivateKeyBase64: string;
-    if (flags['asc-key']) {
-      apiPrivateKeyBase64 = await this.readFileBase64(flags['asc-key'], '--asc-key');
-    } else if (process.env.ASC_PRIVATE_KEY_B64) {
-      apiPrivateKeyBase64 = process.env.ASC_PRIVATE_KEY_B64;
-    } else {
-      this.error(
-        '--testflight requires the App Store Connect API private key: pass --asc-key <path-to-.p8> or set ASC_PRIVATE_KEY_B64.',
-      );
+    if (!flags['asc-key-id'] || !flags['asc-key']) {
+      this.error('TestFlight upload requires both --asc-key-id and --asc-key.');
     }
     return {
       apiKeyId: flags['asc-key-id'],
       ...(flags['asc-issuer-id'] && { apiIssuerId: flags['asc-issuer-id'] }),
-      apiPrivateKeyBase64,
+      apiPrivateKeyBase64: await this.readFileBase64(flags['asc-key'], '--asc-key'),
     };
   }
 
@@ -402,5 +392,13 @@ function hasSigningFlags(flags: SigningFlags): boolean {
     flags['certificate-p12'] !== undefined ||
     flags['certificate-password'] !== undefined ||
     flags['provisioning-profile'] !== undefined
+  );
+}
+
+function hasTestflightFlags(flags: TestflightFlags): boolean {
+  return (
+    flags['asc-key-id'] !== undefined ||
+    flags['asc-issuer-id'] !== undefined ||
+    flags['asc-key'] !== undefined
   );
 }

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -5,7 +5,12 @@ import { compileIgnorePatterns } from '../../lib/ignore-patterns';
 import { formatDurationMs } from '../../lib/duration';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
-import { parseBuildSettingEntries, type XcodeBuildOptions, type XcodeClient } from '@limrun/api';
+import {
+  parseBuildSettingEntries,
+  type TestflightUploadConfig,
+  type XcodeBuildOptions,
+  type XcodeClient,
+} from '@limrun/api';
 
 const DEVICE_SDKS = new Set(['iphoneos', 'watchos']);
 const SIMULATOR_SDKS = new Set(['iphonesimulator', 'watchsimulator']);
@@ -18,6 +23,7 @@ type TestflightFlags = {
   'asc-key-id'?: string;
   'asc-issuer-id'?: string;
   'asc-key'?: string;
+  'asc-wait-timeout'?: number;
 };
 
 export default class XcodeBuild extends BaseCommand {
@@ -114,6 +120,12 @@ export default class XcodeBuild extends BaseCommand {
     }),
     'asc-key': Flags.string({
       description: 'Path to the App Store Connect API private key (.p8). Requires --asc-key-id.',
+    }),
+    'asc-wait-timeout': Flags.integer({
+      description:
+        "How many seconds to watch for App Store Connect's processing verdict after the TestFlight upload. A rejection within the window fails the build; expiry without a verdict succeeds with the build still processing. 0 skips the watch. Defaults to 120, max 1800.",
+      min: 0,
+      max: 1800,
     }),
     'basis-cache-dir': Flags.string({
       description: 'Directory to use for the client-side delta sync cache during the pre-build sync step.',
@@ -273,6 +285,8 @@ export default class XcodeBuild extends BaseCommand {
             result.testflight.uploadId ?? 'unknown'
           }).`,
         );
+      } else if (result.testflight?.state === 'unknown') {
+        this.output('TestFlight: upload status could not be read; check App Store Connect.');
       }
       if (flags.ios) {
         const signedStreamUrl = await this.resolveSimulatorStreamUrl(target, xcodeClient);
@@ -328,14 +342,7 @@ export default class XcodeBuild extends BaseCommand {
 
   // Mirrors the signing convention: passing any asc flag expresses the intent
   // to upload to TestFlight, no separate toggle.
-  private async buildTestflightOptions(flags: TestflightFlags): Promise<
-    | {
-        apiKeyId: string;
-        apiIssuerId?: string;
-        apiPrivateKeyBase64: string;
-      }
-    | undefined
-  > {
+  private async buildTestflightOptions(flags: TestflightFlags): Promise<TestflightUploadConfig | undefined> {
     if (!hasTestflightFlags(flags)) {
       return undefined;
     }
@@ -346,6 +353,7 @@ export default class XcodeBuild extends BaseCommand {
       apiKeyId: flags['asc-key-id'],
       ...(flags['asc-issuer-id'] && { apiIssuerId: flags['asc-issuer-id'] }),
       apiPrivateKeyBase64: await this.readFileBase64(flags['asc-key'], '--asc-key'),
+      ...(flags['asc-wait-timeout'] !== undefined && { waitTimeoutSeconds: flags['asc-wait-timeout'] }),
     };
   }
 
@@ -400,6 +408,7 @@ function hasTestflightFlags(flags: TestflightFlags): boolean {
   return (
     flags['asc-key-id'] !== undefined ||
     flags['asc-issuer-id'] !== undefined ||
-    flags['asc-key'] !== undefined
+    flags['asc-key'] !== undefined ||
+    flags['asc-wait-timeout'] !== undefined
   );
 }

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -263,7 +263,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
     // build is not force-failed client-side while the server still succeeds.
     let timeoutMs = 3600 * 1000;
     if (request.testflight) {
-      timeoutMs += ((request.testflight.waitTimeoutSeconds ?? 120) + 900) * 1000;
+      timeoutMs += (Math.max(0, request.testflight.waitTimeoutSeconds ?? 120) + 900) * 1000;
     }
     let exitCode: number;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -57,7 +57,8 @@ export type ExecResult = {
 };
 
 export type TestflightEvent = {
-  state: 'uploading' | 'processing' | 'accepted' | 'failed';
+  /** 'unknown' means a testflight event arrived but its payload was unreadable. */
+  state: 'uploading' | 'processing' | 'accepted' | 'failed' | 'unknown';
   uploadId?: string;
   buildId?: string;
 };
@@ -347,6 +348,9 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
               try {
                 this.testflightEvent = JSON.parse(data) as TestflightEvent;
               } catch {
+                // The event itself proves the server ran the TestFlight step,
+                // so never let a payload glitch look like a missing feature.
+                this.testflightEvent = { state: 'unknown' };
                 this.log('warn', `SSE testflight event has invalid data: ${data}`);
               }
             } else if (eventType === 'exitCode') {

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -30,6 +30,7 @@ export type ExecRequest = {
     certificatePassword?: string;
     provisioningProfileBase64?: string;
   };
+  testflight?: TestflightUploadConfig;
   buildSettings?: Record<string, string>;
   signedUploadUrl?: string;
   additionalMetadata?: {
@@ -48,6 +49,33 @@ export type ExecResult = {
   execId: string;
   status: 'SUCCEEDED' | 'FAILED' | 'CANCELLED';
   signedDownloadUrl?: string;
+  /**
+   * Last TestFlight state streamed by the server. Absent when the build ran
+   * without a testflight request, or when the server predates the feature.
+   */
+  testflight?: TestflightEvent;
+};
+
+export type TestflightEvent = {
+  state: 'uploading' | 'processing' | 'accepted' | 'failed';
+  uploadId?: string;
+  buildId?: string;
+};
+
+export type TestflightUploadConfig = {
+  /** App Store Connect API key ID, e.g. 2X9R4HXF34. */
+  apiKeyId: string;
+  /** Issuer ID for team API keys. Omit for individual API keys. */
+  apiIssuerId?: string;
+  /** Base64-encoded content of the .p8 private key file. */
+  apiPrivateKeyBase64: string;
+  /**
+   * How long the server watches for App Store Connect's processing verdict
+   * after the upload. A FAILED verdict within the window fails the build;
+   * expiry without a verdict succeeds with the build still processing on
+   * Apple's side. 0 skips the watch. Defaults to 120.
+   */
+  waitTimeoutSeconds?: number;
 };
 
 type DataListener = (chunk: string) => void;
@@ -121,6 +149,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
   private abortController = new AbortController();
   private sseConnection: EventSourceClient | null = null;
   private killed = false;
+  private testflightEvent: TestflightEvent | null = null;
   private readonly options: ExecOptions;
   private readonly log: (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
 
@@ -228,7 +257,13 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
     // 2. Stream logs via SSE and wait for exit code
     const eventsUrl = `${apiUrl}/exec/${this.execId}/events`;
 
-    const timeoutMs = 3600 * 1000; // 1 hour max
+    // 1 hour max for the build itself; a TestFlight request extends the
+    // budget by its server-side verdict watch plus upload headroom so a long
+    // build is not force-failed client-side while the server still succeeds.
+    let timeoutMs = 3600 * 1000;
+    if (request.testflight) {
+      timeoutMs += ((request.testflight.waitTimeoutSeconds ?? 120) + 900) * 1000;
+    }
     let exitCode: number;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
@@ -275,6 +310,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       execId: this.execId!,
       status,
       ...(request.additionalMetadata ?? {}),
+      ...(this.testflightEvent ? { testflight: this.testflightEvent } : {}),
     };
 
     this.log('debug', `Build finished: ${result.status} (exit ${result.exitCode})`);
@@ -307,6 +343,12 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
               this.stdout.emit('data', data);
             } else if (eventType === 'stderr') {
               this.stderr.emit('data', data);
+            } else if (eventType === 'testflight') {
+              try {
+                this.testflightEvent = JSON.parse(data) as TestflightEvent;
+              } catch {
+                this.log('warn', `SSE testflight event has invalid data: ${data}`);
+              }
             } else if (eventType === 'exitCode') {
               const exitCode = parseInt(data, 10);
               if (Number.isNaN(exitCode)) {

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -54,6 +54,12 @@ export type ExecResult = {
    * without a testflight request, or when the server predates the feature.
    */
   testflight?: TestflightEvent;
+  /**
+   * True when the client gave up waiting for the build's event stream. The
+   * exit code is fabricated in that case; the remote build may still be
+   * running and may yet succeed.
+   */
+  timedOut?: boolean;
 };
 
 export type TestflightEvent = {
@@ -266,6 +272,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       timeoutMs += (Math.max(0, request.testflight.waitTimeoutSeconds ?? 120) + 900) * 1000;
     }
     let exitCode: number;
+    let timedOut = false;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       exitCode = await Promise.race([
@@ -279,8 +286,11 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
         log('debug', 'Build killed');
         exitCode = -1;
       } else {
+        // The client stopped waiting; the remote build may still be running.
+        // The fabricated exit code must not read as a build failure.
         log('warn', 'SSE completion timeout');
         exitCode = 1;
+        timedOut = true;
       }
     } finally {
       clearTimeout(timeoutId);
@@ -312,6 +322,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       status,
       ...(request.additionalMetadata ?? {}),
       ...(this.testflightEvent ? { testflight: this.testflightEvent } : {}),
+      ...(timedOut ? { timedOut } : {}),
     };
 
     this.log('debug', `Build finished: ${result.status} (exit ${result.exitCode})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export {
   type ExecOptions,
   type ExecResult,
   type ExecChildProcess,
+  type TestflightEvent,
+  type TestflightUploadConfig,
 } from './exec-client';
 export {
   type XcodeCreateClientParams,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -76,7 +76,6 @@ export type XcodeSigningConfig = {
   provisioningProfileBase64?: string;
 };
 
-
 export type ReactNativeBuildConfig = {
   /**
    * Relative path from the synced workspace root to the Expo app directory.

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -4,7 +4,9 @@ import crypto from 'crypto';
 
 import { XcodeInstances as GeneratedXcodeInstances, type XcodeInstance } from './xcode-instances';
 import { type IosInstance } from './ios-instances';
-import { exec, type ExecChildProcess, type ExecRequest } from '../exec-client';
+import { exec, type ExecChildProcess, type ExecRequest, type TestflightUploadConfig } from '../exec-client';
+
+export type { TestflightUploadConfig } from '../exec-client';
 import {
   syncFolder as syncFolderImpl,
   type AdditionalFileSyncEntry,
@@ -74,6 +76,7 @@ export type XcodeSigningConfig = {
   provisioningProfileBase64?: string;
 };
 
+
 export type ReactNativeBuildConfig = {
   /**
    * Relative path from the synced workspace root to the Expo app directory.
@@ -95,6 +98,13 @@ export type ReactNativeBuildConfig = {
 export type XcodeBuildOptions = {
   upload?: { assetName: string } | { signedUploadUrl: string };
   signing?: XcodeSigningConfig;
+  /**
+   * Upload the signed device IPA to TestFlight after the build. Requires
+   * signing and sdk=iphoneos. Check ExecResult.testflight on completion: it is
+   * absent when the instance's limbuild predates the feature (old servers
+   * silently ignore this option).
+   */
+  testflight?: TestflightUploadConfig;
   reactNative?: ReactNativeBuildConfig;
   buildSettings?: Record<string, string>;
 };
@@ -640,6 +650,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ...(settings && { xcodebuild: settings }),
           ...(options?.reactNative && { reactNative: options.reactNative }),
           ...(options?.signing && { signing: options.signing }),
+          ...(options?.testflight && { testflight: options.testflight }),
           ...(options?.buildSettings && { buildSettings: options.buildSettings }),
         };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Handles App Store Connect private keys and changes long-running build completion semantics (timeouts, TestFlight failure vs xcodebuild success); server must implement the new exec field and SSE events.
> 
> **Overview**
> Adds an optional **TestFlight upload** path after signed **iphoneos** remote `xcodebuild` runs, wired from the CLI through the API client to the exec/SSE layer.
> 
> The **`xcode build`** command gains `--upload-to-testflight` plus App Store Connect flags (`--asc-key-id`, `--asc-key`, optional `--asc-issuer-id`, `--asc-wait-timeout`). ASC credentials are only allowed with `--upload-to-testflight`; TestFlight is blocked on `--ios` simulator builds and requires the same signing inputs as device IPA builds. Signing/profile/key files are read via a shared **`readFileBase64`** helper with clearer read failures.
> 
> **`@limrun/api`** extends **`ExecRequest`** / **`XcodeBuildOptions`** with **`testflight`**, exports **`TestflightUploadConfig`** and **`TestflightEvent`**, and **`ExecResult`** now surfaces **`testflight`** state and **`timedOut`**. The exec client listens for SSE **`testflight`** events, extends the stream wait when a TestFlight request is present, and the CLI maps timeout vs TestFlight failure vs success messaging after the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc85ac0f08584a0b4fce94a1014a9c1d060d709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->