### PR TITLE
cli: bump version to 0.18.0 with @limrun/api 0.39

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lim",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "^0.38.0",
+        "@limrun/api": "^0.39.0",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,20 +44,26 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.38.0.tgz",
-      "integrity": "sha512-60MADFTeyhc/lti5FYQ6NOgFFEQo3YnfZMBETy7G+p4CKvJGE8Yy4fd+BVR1OUNE9POaKxPgRLRZ5VxOVQIjXQ==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.1.tgz",
+      "integrity": "sha512-Bny+k2aTFuAHA/svB0mel+l6fdnX/PnJIFJUQnJdW1t3v5k6MdEnstwBrRzlvcmcY/IuXJfuLObP9H45KLnzng==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@limrun/xdelta3-wasm": "0.2.0",
         "eventsource-client": "^1.2.0",
         "https-proxy-agent": "7.0.6",
         "ignore": "^7.0.5",
         "proxy-from-env": "^2.1.0",
         "undici": "7.24.7",
         "ws": "^8.18.3",
-        "xdelta3-wasm": "^1.0.0",
         "yauzl": "^3.4.0"
       }
+    },
+    "node_modules/@limrun/xdelta3-wasm": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz",
+      "integrity": "sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@oclif/core": {
       "version": "4.10.5",
@@ -972,15 +978,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xdelta3-wasm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/xdelta3-wasm/-/xdelta3-wasm-1.0.0.tgz",
-      "integrity": "sha512-vhS28BhVaE3S/PGG1KQIwjBVqJecuS5Sdh82UAZysbnYaU93KS6l8ZPtsqonNZMeuyFgrGW9D44hh2lwQCsidA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yauzl": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.38.0",
+    "@limrun/api": "^0.39.0",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and dependency-only changes with no CLI implementation edits; risk is limited to whatever behavior ships in @limrun/api 0.39.x.
> 
> **Overview**
> Releases **`lim` 0.18.0** by bumping the package version and upgrading the sole runtime dependency **`@limrun/api`** from `^0.38.0` to **`^0.39.0`** (lockfile pins **0.39.1**). The lockfile refresh also reflects API’s switch from **`xdelta3-wasm`** to **`@limrun/xdelta3-wasm`** as a transitive dependency—no CLI source or command changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e91cd55d85e3829ce12566cf0a62f2f540e656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->