### PR TITLE
cli: show how much data is sent as part of sync

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lim",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.18.1",
+      "version": "0.18.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "^0.39.1",
+        "@limrun/api": "0.39.2",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.1.tgz",
-      "integrity": "sha512-Bny+k2aTFuAHA/svB0mel+l6fdnX/PnJIFJUQnJdW1t3v5k6MdEnstwBrRzlvcmcY/IuXJfuLObP9H45KLnzng==",
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.2.tgz",
+      "integrity": "sha512-vddbRh7wpKAC+lDFGb11oe3WjpfPm1IDwvu0RNO6eaNMJhPb7l5cm450N6woONoIQ9drzAqj5YynxcGVgfROcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@limrun/xdelta3-wasm": "0.2.0",
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.39.1",
+    "@limrun/api": "0.39.2",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/android/sync.ts
+++ b/packages/cli/src/commands/android/sync.ts
@@ -1,6 +1,8 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
+import { formatDurationMs } from '../../lib/duration';
+import { formatBytes } from '../../lib/bytes';
 
 export default class AndroidSync extends BaseCommand {
   static summary = 'Sync an APK to a running Android instance';
@@ -57,6 +59,7 @@ export default class AndroidSync extends BaseCommand {
       const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
 
       this.info(`Syncing APK ${args.path} to instance ${id}...`);
+      const syncStart = Date.now();
 
       const result = await client.syncApp(args.path, {
         watch: flags.watch,
@@ -65,10 +68,9 @@ export default class AndroidSync extends BaseCommand {
         launchMode: flags['launch-mode'] as 'ForegroundIfRunning' | 'RelaunchIfRunning' | undefined,
       });
 
-      this.output('APK sync complete.');
-      if (result.installedBundleId) {
-        this.output(`Installed package: ${result.installedBundleId}`);
-      }
+      const syncDuration = formatDurationMs(Date.now() - syncStart);
+      const syncedSize = result.bytesSent !== undefined ? ` (${formatBytes(result.bytesSent)} sent)` : '';
+      this.output(`Sync completed in ${syncDuration}${syncedSize}.`);
 
       if (flags.watch && result.stopWatching) {
         this.output('Watching for changes. Press Ctrl+C to stop.');

--- a/packages/cli/src/commands/ios/sync.ts
+++ b/packages/cli/src/commands/ios/sync.ts
@@ -1,6 +1,8 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { getIosInstanceClient } from '../../lib/instance-client-factory';
+import { formatDurationMs } from '../../lib/duration';
+import { formatBytes } from '../../lib/bytes';
 
 export default class IosSync extends BaseCommand {
   static summary = 'Sync a built app bundle to a running iOS instance';
@@ -58,6 +60,7 @@ export default class IosSync extends BaseCommand {
       const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
 
       this.info(`Syncing app bundle ${syncPath} to instance ${id}...`);
+      const syncStart = Date.now();
 
       const result = await client.syncApp(syncPath, {
         watch: flags.watch,
@@ -66,7 +69,9 @@ export default class IosSync extends BaseCommand {
         launchMode: flags['launch-mode'] as 'ForegroundIfRunning' | 'RelaunchIfRunning' | undefined,
       });
 
-      this.output('App sync complete.');
+      const syncDuration = formatDurationMs(Date.now() - syncStart);
+      const syncedSize = result.bytesSent !== undefined ? ` (${formatBytes(result.bytesSent)} sent)` : '';
+      this.output(`Sync completed in ${syncDuration}${syncedSize}.`);
       if (result.installedBundleId) {
         this.output(`Installed bundle ID: ${result.installedBundleId}`);
       }

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -3,6 +3,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { compileIgnorePatterns } from '../../lib/ignore-patterns';
 import { formatDurationMs } from '../../lib/duration';
+import { formatBytes } from '../../lib/bytes';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
 import {
@@ -241,9 +242,14 @@ export default class XcodeBuild extends BaseCommand {
         ignore: compileIgnorePatterns(flags.ignore),
         additionalFiles: parseAdditionalFileFlags(flags['additional-file']),
       };
-      await xcodeClient.sync(syncPath, syncOptions as Parameters<typeof xcodeClient.sync>[1]);
+      const syncResult = await xcodeClient.sync(
+        syncPath,
+        syncOptions as Parameters<typeof xcodeClient.sync>[1],
+      );
       const syncDuration = formatDurationMs(Date.now() - syncStart);
-      this.info(`Sync complete in ${syncDuration}.`);
+      const syncedSize =
+        syncResult.bytesSent !== undefined ? ` (${formatBytes(syncResult.bytesSent)} sent)` : '';
+      this.info(`Sync completed in ${syncDuration}${syncedSize}.`);
 
       this.info('Starting xcodebuild...');
 

--- a/packages/cli/src/commands/xcode/sync.ts
+++ b/packages/cli/src/commands/xcode/sync.ts
@@ -2,6 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { compileIgnorePatterns } from '../../lib/ignore-patterns';
 import { formatDurationMs } from '../../lib/duration';
+import { formatBytes } from '../../lib/bytes';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
 
 export default class XcodeSync extends BaseCommand {
@@ -79,7 +80,8 @@ export default class XcodeSync extends BaseCommand {
       const result = await xcodeClient.sync(syncPath, syncOptions as Parameters<typeof xcodeClient.sync>[1]);
 
       const syncDuration = formatDurationMs(Date.now() - syncStart);
-      this.output(`Sync complete in ${syncDuration}.`);
+      const syncedSize = result.bytesSent !== undefined ? ` (${formatBytes(result.bytesSent)} sent)` : '';
+      this.output(`Sync completed in ${syncDuration}${syncedSize}.`);
 
       if (flags.watch && result.stopWatching) {
         this.output('Watching for changes. Press Ctrl+C to stop.');

--- a/packages/cli/src/lib/bytes.ts
+++ b/packages/cli/src/lib/bytes.ts
@@ -1,0 +1,14 @@
+export function formatBytes(bytes: number): string {
+  if (bytes < 1000) {
+    return `${bytes}B`;
+  }
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = '';
+  for (const u of units) {
+    value /= 1000;
+    unit = u;
+    if (value < 1000) break;
+  }
+  return `${value >= 100 ? value.toFixed(0) : value.toFixed(1)}${unit}`;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and a dependency pin only; no auth or sync protocol changes in this diff.
> 
> **Overview**
> Sync commands now report **how much data was transferred** alongside elapsed time, using `bytesSent` from `@limrun/api` when the SDK provides it.
> 
> A new `formatBytes` helper formats sizes for CLI output. **Android**, **iOS**, **Xcode sync**, and the pre-build sync in **`xcode build`** print messages like `Sync completed in 1.2s (45.3MB sent).` instead of generic “sync complete” lines. **Android sync** no longer prints the installed package ID after sync (iOS still reports bundle ID when present).
> 
> The **`lim`** package is bumped to **0.18.2** with **`@limrun/api`** pinned to **0.39.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52412683391269d495897de7ffb815f46458c6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->