### PR TITLE
ios: launch-app should stream logs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -252,9 +252,14 @@ lim ios install-app https://example.com/app.ipa
 lim ios install-app https://example.com/app.ipa --md5 <hex-digest>
 lim ios install-app ./MyApp.ipa --launch-mode RelaunchIfRunning
 
-# Launch / terminate
+# Launch — streams the app's logs until the app exits or Ctrl+C
 lim ios launch-app com.example.myapp
 lim ios launch-app com.example.myapp --mode RelaunchIfRunning
+
+# Launch and exit immediately without streaming logs
+lim ios launch-app com.example.myapp --detach
+
+# Terminate
 lim ios terminate-app com.example.myapp
 
 # List installed apps
@@ -533,7 +538,7 @@ lim ios create --model iphone
 lim session start
 
 # Fast interaction loop — each command takes ~50ms
-lim ios launch-app com.example.myapp
+lim ios launch-app com.example.myapp --detach
 lim ios element-tree | jq '.tree'
 lim ios tap-element --ax-label "Login"
 lim ios type "user@example.com"
@@ -554,8 +559,8 @@ lim session start --id ios_phone_123
 lim session start --id ios_tablet_456
 
 # Agent controls both devices in parallel — ~50ms per command
-lim ios launch-app com.example.myapp --id ios_phone_123
-lim ios launch-app com.example.myapp --id ios_tablet_456
+lim ios launch-app com.example.myapp --id ios_phone_123 --detach
+lim ios launch-app com.example.myapp --id ios_tablet_456 --detach
 
 lim ios screenshot phone.png --id ios_phone_123
 lim ios screenshot tablet.png --id ios_tablet_456
@@ -584,7 +589,7 @@ done
 
 # Run tests against all devices
 for ID in "${IDS[@]}"; do
-  lim ios launch-app com.example.myapp --id $ID
+  lim ios launch-app com.example.myapp --id $ID --detach
   lim ios screenshot "test_${ID}.png" --id $ID
 done
 
@@ -620,7 +625,7 @@ lim xcode build ./MyProject --id ios_abc123 --scheme MyApp --workspace MyApp.xcw
 lim session start
 
 # 4. Test the built app on the simulator (~50ms per command)
-lim ios launch-app com.example.myapp
+lim ios launch-app com.example.myapp --detach
 lim ios element-tree | jq '.'
 lim ios screenshot built-app.png
 
@@ -770,7 +775,7 @@ lim ios create --install ./build/MyApp.ipa
 lim session start
 
 # Verify — each command takes ~50ms with session
-lim ios launch-app com.example.myapp
+lim ios launch-app com.example.myapp --detach
 sleep 2
 lim ios element-tree | grep "Welcome"
 lim ios screenshot test-result.png
@@ -816,7 +821,7 @@ lim xcode build ./MyiOSProject --id $ID --scheme MyApp --workspace MyApp.xcworks
 
 # Verify the built app on the simulator
 lim session start
-lim ios launch-app com.example.myapp
+lim ios launch-app com.example.myapp --detach
 sleep 2
 lim ios element-tree | grep "Welcome"
 lim ios screenshot test-result.png

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lim",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.18.2",
+      "version": "0.18.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "0.39.2",
+        "@limrun/api": "0.39.4",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.2.tgz",
-      "integrity": "sha512-vddbRh7wpKAC+lDFGb11oe3WjpfPm1IDwvu0RNO6eaNMJhPb7l5cm450N6woONoIQ9drzAqj5YynxcGVgfROcQ==",
+      "version": "0.39.4",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.4.tgz",
+      "integrity": "sha512-KarcBiyNYp+w8is/t7L5x7XuQZQSjOXrsv9cFR9au98ZPhjHEAKkuaJ9BGIl5R+4AONL9Wt+jX4sXL9tJyN/Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@limrun/xdelta3-wasm": "0.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.39.2",
+    "@limrun/api": "0.39.4",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/ios/launch-app.ts
+++ b/packages/cli/src/commands/ios/launch-app.ts
@@ -1,4 +1,5 @@
 import { Args, Flags } from '@oclif/core';
+import type { Ios } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
@@ -28,9 +29,10 @@ async function launchAppWithArgument(
 export default class IosLaunchApp extends BaseCommand {
   static summary = 'Launch an app on a running iOS instance';
   static description =
-    'Launch an installed app on a running iOS instance by bundle identifier. Choose `ForegroundIfRunning` to bring an already-running app to the front or `RelaunchIfRunning` to restart it. Use `--runtime detox` to launch with the Limrun-managed Detox runtime.';
+    'Launch an installed app on a running iOS instance by bundle identifier and stream its logs until the app exits or the command is interrupted. Use `--detach` to exit immediately after the launch instead. Choose `ForegroundIfRunning` to bring an already-running app to the front or `RelaunchIfRunning` to restart it. Use `--runtime detox` to launch with the Limrun-managed Detox runtime.';
   static examples = [
     '<%= config.bin %> ios launch-app com.example.app',
+    '<%= config.bin %> ios launch-app com.example.app --detach',
     '<%= config.bin %> ios launch-app com.example.app --mode RelaunchIfRunning --id <instance-ID>',
     '<%= config.bin %> ios launch-app host.exp.Exponent --runtime detox --detox-server-url ws://10.244.0.10:57091 --detox-session-id limrun-detox --detox-version 20.51.1 --id <instance-ID>',
   ];
@@ -43,6 +45,11 @@ export default class IosLaunchApp extends BaseCommand {
     ...BaseCommand.baseFlags,
     id: Flags.string({
       description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    detach: Flags.boolean({
+      char: 'd',
+      description: 'Exit right after launching instead of streaming app logs',
+      default: false,
     }),
     mode: Flags.string({
       description:
@@ -75,17 +82,78 @@ export default class IosLaunchApp extends BaseCommand {
       const launchArgument = buildLaunchAppArgument(flags as LaunchAppFlagValues, {
         modeExplicitlyProvided: flags.mode !== undefined,
       });
-      if (hasActiveSession(id)) {
-        await sendSessionCommand(id, 'launch-app', [args.bundleId, launchArgument]);
-      } else {
-        const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
-        try {
-          await launchAppWithArgument(client, args.bundleId, launchArgument);
-        } finally {
-          disconnect();
+
+      if (flags.detach) {
+        if (hasActiveSession(id)) {
+          await sendSessionCommand(id, 'launch-app', [args.bundleId, launchArgument]);
+        } else {
+          const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+          try {
+            await launchAppWithArgument(client, args.bundleId, launchArgument);
+          } finally {
+            disconnect();
+          }
         }
+        this.log(`Launched ${args.bundleId}`);
+        return;
       }
-      this.log(`Launched ${args.bundleId}`);
+
+      // Log streaming always needs a direct connection, even when a daemon
+      // session is active for the instance. The launch also goes through the
+      // direct client because the appExit notification that ends this command
+      // is delivered on the launching client's signaling WebSocket.
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      try {
+        // Subscribe before launching so early log lines are not missed.
+        const logStream = client.streamAppLog(args.bundleId);
+        logStream.on('line', (line: string) => {
+          process.stdout.write(line + '\n');
+        });
+        logStream.on('error', (err: Error) => {
+          this.warn(`App log stream error: ${err.message}`);
+        });
+
+        let notifyAppExited: () => void = () => {};
+        const appExited = new Promise<void>((resolve) => {
+          notifyAppExited = resolve;
+        });
+        const launchOptions: Ios.LaunchAppOptions = {
+          ...(typeof launchArgument === 'string' ? { mode: launchArgument } : launchArgument),
+          onExit: async () => {
+            notifyAppExited();
+          },
+        };
+
+        try {
+          await client.launchApp(args.bundleId, launchOptions);
+        } catch (error) {
+          logStream.stop();
+          throw error;
+        }
+
+        this.logToStderr(
+          `Launched ${args.bundleId}. Streaming app logs until the app exits; press Ctrl+C to stop earlier, or pass --detach to skip streaming.`,
+        );
+
+        await new Promise<void>((resolve) => {
+          const keepAlive = setInterval(() => {}, 1 << 30);
+          const finish = () => {
+            clearInterval(keepAlive);
+            logStream.stop();
+            resolve();
+          };
+          process.on('SIGINT', finish);
+          process.on('SIGTERM', finish);
+          logStream.on('close', finish);
+          void appExited.then(() => {
+            this.logToStderr(`${args.bundleId} exited.`);
+            // Log lines arrive in ~500ms batches; give the tail a moment to flush.
+            setTimeout(finish, 1000);
+          });
+        });
+      } finally {
+        disconnect();
+      }
     });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Default `launch-app` behavior changes from immediate exit to a long-running process, which can break scripts unless they pass `--detach`; streaming also bypasses the session path when not detached.
> 
> **Overview**
> **`lim ios launch-app` now blocks and streams the launched app’s logs** until the app exits, the log stream closes, or you interrupt with Ctrl+C. It uses a direct instance connection (not the session daemon) so `onExit` and log delivery stay on the same signaling WebSocket.
> 
> **`--detach` / `-d`** restores the previous fire-and-forget launch: it still routes through an active session when one exists, prints `Launched …`, and returns immediately.
> 
> Docs and session/automation examples are updated to use **`--detach`** where a quick launch is needed. The CLI is bumped to **0.18.3** with **`@limrun/api` 0.39.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d33836a43fd9a6e0da62c45dc01bb0ed6a2d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->