### PR TITLE
sync: add onSyncComplete to return info to user on syncs

### DIFF
--- a/src/folder-sync.ts
+++ b/src/folder-sync.ts
@@ -60,6 +60,18 @@ export type FolderSyncOptions = {
   additionalFiles?: AdditionalFileSyncEntry[];
   /** Force transport content encoding. Android APK sync uses identity because APKs are already compressed. */
   compression?: 'zstd' | 'gzip' | 'identity';
+  /**
+   * Called after every successful sync: the one-shot sync, the initial sync
+   * in watch mode, and each watch-triggered re-sync.
+   */
+  onSyncComplete?: (result: SyncCompleteEvent) => void;
+};
+
+export type SyncCompleteEvent = {
+  bytesSent: number;
+  durationMs: number;
+  installedAppPath?: string;
+  installedBundleId?: string;
 };
 
 export type SyncFolderResult = {
@@ -582,12 +594,22 @@ export async function syncFolder(
     (opts.log ?? noopLogger)(level, `syncFolder: ${msg}`);
   };
   log('debug', `setup ${localFolderPath} watch=${opts.watch} basisCacheDir=${opts.basisCacheDir}`);
-  if (!opts.watch) {
-    const result = await syncFolderOnce(localFolderPath, opts);
+  const syncOnce = async (reason?: string): Promise<SyncFolderResult> => {
+    const start = nowMs();
+    const result = await syncFolderOnce(localFolderPath, opts, reason);
+    opts.onSyncComplete?.({
+      bytesSent: result.bytesSent ?? 0,
+      durationMs: nowMs() - start,
+      ...(result.installedAppPath !== undefined ? { installedAppPath: result.installedAppPath } : {}),
+      ...(result.installedBundleId !== undefined ? { installedBundleId: result.installedBundleId } : {}),
+    });
     return result;
+  };
+  if (!opts.watch) {
+    return await syncOnce();
   }
   // Initial sync, then watch for changes and re-run sync in the background.
-  const first = await syncFolderOnce(localFolderPath, opts, 'startup');
+  const first = await syncOnce('startup');
   let inFlight = false;
   let queued = false;
   let closed = false;
@@ -597,7 +619,7 @@ export async function syncFolder(
   const run = async (reason: string) => {
     inFlight = true;
     try {
-      await syncFolderOnce(localFolderPath, opts, reason);
+      await syncOnce(reason);
     } finally {
       inFlight = false;
       if (queued && !closed) {
@@ -785,7 +807,7 @@ async function syncFolderOnce(
     }
     slog('debug', `full(file): ${f.path} size=${f.size}`);
     if (f.size >= LARGE_UPLOAD_NOTICE_BYTES) {
-      slog('info', `uploading large file ${f.path} (${fmtBytes(f.size)})`);
+      slog('debug', `uploading large file ${f.path} (${fmtBytes(f.size)})`);
     }
     bytesSentFull += f.size;
     return {
@@ -861,7 +883,7 @@ async function syncFolderOnce(
       // exactly like first-pass fulls, or a fresh-daemon resync of a warm
       // cache reports "sent=0B" while gigabytes upload.
       if (entry.size >= LARGE_UPLOAD_NOTICE_BYTES) {
-        slog('info', `uploading large file ${entry.path} (${fmtBytes(entry.size)})`);
+        slog('debug', `uploading large file ${entry.path} (${fmtBytes(entry.size)})`);
       }
       bytesSentFull += entry.size;
       changedPaths.add(entry.path);
@@ -877,7 +899,7 @@ async function syncFolderOnce(
     }
     if (retryPayloads.length > 0) {
       slog(
-        'info',
+        'debug',
         `daemon requested a full upload for ${retryPayloads.length} files (no matching basis); retrying once`,
       );
       const retryMeta: FolderSyncHttpMeta = {
@@ -916,7 +938,7 @@ async function syncFolderOnce(
   const tookMs = nowMs() - totalStart;
   const totalBytes = bytesSentFull + bytesSentDelta;
   slog(
-    'info',
+    'debug',
     `sync complete: files=${allFiles.length} changed=${changedPaths.size} sent=${fmtBytes(
       totalBytes,
     )} in ${fmtMs(tookMs)}`,

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -96,7 +96,7 @@ async function bootstrapAndroidBasisCache(
   apiUrl: string,
   token: string,
   log: FolderSyncOptions['log'],
-  onBasisDownload?: (sizeBytes?: number) => void,
+  onBasisDownloadProgress?: (downloadedBytes: number, totalBytes: number) => void,
 ): Promise<void> {
   const remotePath = path.basename(apkPath);
   const basisPath = path.join(basisCacheDir, remotePath);
@@ -131,8 +131,15 @@ async function bootstrapAndroidBasisCache(
   if (!seed) {
     return;
   }
-  onBasisDownload?.(seed.size);
-  await downloadFileToLocalPath(buildSyncSeedUrl(apiUrl, seed.sha256), token, basisPath);
+  // Announce the download before any bytes flow so consumers can react to the
+  // expected size even during connection setup / time-to-first-byte.
+  onBasisDownloadProgress?.(0, seed.size ?? 0);
+  await downloadFileToLocalPath(
+    buildSyncSeedUrl(apiUrl, seed.sha256),
+    token,
+    basisPath,
+    onBasisDownloadProgress,
+  );
   log('debug', `seeded Android basis cache from instance seed: ${seed.sha256}`);
 }
 
@@ -239,7 +246,12 @@ export type InstanceClient = {
       watch?: boolean;
       launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
       basisCacheDir?: string;
-      onBasisDownload?: (sizeBytes?: number) => void;
+      /**
+       * Called while the basis seed is downloaded from the instance. Fires once with
+       * `(0, expectedSizeBytes)` before the download starts (expectedSizeBytes is 0 when
+       * unknown), then repeatedly as bytes arrive.
+       */
+      onBasisDownloadProgress?: (downloadedBytes: number, totalBytes: number) => void;
       /** Called after every successful sync, including watch-triggered re-syncs. */
       onSyncComplete?: FolderSyncOptions['onSyncComplete'];
     },
@@ -1305,7 +1317,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         options.apiUrl,
         options.token,
         syncLog,
-        syncOpts?.onBasisDownload,
+        syncOpts?.onBasisDownloadProgress,
       );
       return await syncFolder(resolvedPath, {
         apiUrl: options.apiUrl,

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -240,6 +240,8 @@ export type InstanceClient = {
       launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
       basisCacheDir?: string;
       onBasisDownload?: (sizeBytes?: number) => void;
+      /** Called after every successful sync, including watch-triggered re-syncs. */
+      onSyncComplete?: FolderSyncOptions['onSyncComplete'];
     },
   ) => Promise<SyncFolderResult>;
 
@@ -1316,6 +1318,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         ignoreFn: () => false,
         log: syncLog,
         compression: 'identity',
+        ...(syncOpts?.onSyncComplete ? { onSyncComplete: syncOpts.onSyncComplete } : {}),
       });
     };
 

--- a/src/internal/download-file.ts
+++ b/src/internal/download-file.ts
@@ -5,7 +5,12 @@ import { pipeline } from 'stream/promises';
 
 import { nodeProxyTransport } from './proxy-transport';
 
-export async function downloadFileToLocalPath(url: string, token: string, localPath: string): Promise<void> {
+export async function downloadFileToLocalPath(
+  url: string,
+  token: string,
+  localPath: string,
+  onProgress?: (downloadedBytes: number, totalBytes: number) => void,
+): Promise<void> {
   const maxRetries = 3;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -27,7 +32,16 @@ export async function downloadFileToLocalPath(url: string, token: string, localP
       throw new Error('Download failed: response body is missing');
     }
     await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
-    await pipeline(Readable.fromWeb(response.body as any), fs.createWriteStream(localPath));
+    const source = Readable.fromWeb(response.body as any);
+    if (onProgress) {
+      const totalBytes = Number(response.headers.get('content-length') ?? 0);
+      let downloadedBytes = 0;
+      source.on('data', (chunk: Buffer) => {
+        downloadedBytes += chunk.length;
+        onProgress(downloadedBytes, totalBytes);
+      });
+    }
+    await pipeline(source, fs.createWriteStream(localPath));
     return;
   }
 }

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -661,6 +661,8 @@ export type InstanceClient = {
       basisCacheDir?: string;
       launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
       watch?: boolean;
+      /** Called after every successful sync, including watch-triggered re-syncs. */
+      onSyncComplete?: FolderSyncOptions['onSyncComplete'];
     },
   ) => Promise<SyncFolderResult>;
 
@@ -2086,6 +2088,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         basisCacheDir?: string;
         launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
         watch?: boolean;
+        onSyncComplete?: FolderSyncOptions['onSyncComplete'];
       },
     ): Promise<SyncFolderResult> => {
       const preparedApp = await prepareAppBundlePath(localAppBundlePath);
@@ -2133,6 +2136,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         install: opts?.install ?? true,
         launchMode: opts?.launchMode ?? 'ForegroundIfRunning',
         watch: preparedApp.isArchive ? false : shouldWatch,
+        ...(opts?.onSyncComplete ? { onSyncComplete: opts.onSyncComplete } : {}),
       };
       const result = await syncFolder(appBundlePath, folderSyncOpts);
       if (!preparedApp.isArchive || !preparedApp.archivePath || !shouldWatch) {
@@ -2142,6 +2146,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         archivePath: preparedApp.archivePath,
         log: syncLog,
         onExtracted: async () => {
+          // syncFolder fires onSyncComplete itself, so archive re-syncs
+          // surface through the same callback.
           await syncFolder(appBundlePath, folderSyncOpts);
         },
       });

--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -33,6 +33,13 @@ export interface AssetGetOrUploadParams {
    * Optional platform for the asset.
    */
   platform?: AssetPlatform;
+
+  /**
+   * Optional callback fired as upload bytes are handed to the network, for progress
+   * reporting. Not called when the server already has identical content (md5 match)
+   * and the upload is skipped.
+   */
+  onUploadProgress?: (uploadedBytes: number, totalBytes: number) => void;
 }
 
 export interface AssetGetOrUploadResponse {
@@ -43,6 +50,36 @@ export interface AssetGetOrUploadResponse {
   platform?: AssetPlatform;
   md5: string;
   expiresAt?: string;
+}
+
+/**
+ * Body init for the signed-URL PUT. Without a progress callback the buffer is sent
+ * directly. With one, the buffer is wrapped in a ReadableStream so the callback can
+ * fire as chunks are pulled onto the socket; the explicit Content-Length header set
+ * by the caller keeps the request non-chunked, which signed URLs require.
+ */
+function uploadBodyInit(
+  data: Buffer,
+  onProgress?: (uploadedBytes: number, totalBytes: number) => void,
+): { body: NonNullable<RequestInit['body']>; duplex?: 'half' } {
+  if (!onProgress) {
+    return { body: data as unknown as NonNullable<RequestInit['body']> };
+  }
+  const chunkSize = 256 * 1024;
+  let sent = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= data.length) {
+        controller.close();
+        return;
+      }
+      const chunk = data.subarray(sent, Math.min(sent + chunkSize, data.length));
+      sent += chunk.length;
+      controller.enqueue(chunk);
+      onProgress(sent, data.length);
+    },
+  });
+  return { body: stream as unknown as NonNullable<RequestInit['body']>, duplex: 'half' };
 }
 
 export class Assets extends GeneratedAssets {
@@ -78,7 +115,7 @@ export class Assets extends GeneratedAssets {
         'Content-Type': 'application/octet-stream',
       },
       method: 'PUT',
-      body: data,
+      ...uploadBodyInit(data, body.onUploadProgress),
     });
     if (uploadResponse.status !== 200) {
       throw new Error(`Failed to upload asset: ${uploadResponse.status} ${await uploadResponse.text()}`);

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -55,6 +55,8 @@ export type SyncOptions = {
    * Extra files to sync on every sync pass.
    */
   additionalFiles?: AdditionalFileSyncEntry[];
+  /** Called after every successful sync, including watch-triggered re-syncs. */
+  onSyncComplete?: FolderSyncOptions['onSyncComplete'];
 };
 
 export type SyncResult = {
@@ -615,6 +617,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           // the default skip behavior.
           syncSymlinks: true,
           ...(additionalFiles ? { additionalFiles } : {}),
+          ...(opts?.onSyncComplete ? { onSyncComplete: opts.onSyncComplete } : {}),
         };
 
         const result = await syncFolderImpl(localCodePath, codeSyncOpts);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive optional callbacks and log-level changes; no changes to sync protocol or default behavior when hooks are omitted.
> 
> **Overview**
> Adds **`onSyncComplete`** on folder sync (and wires it through Android/iOS `syncApp` and Xcode workspace `sync`). After each successful pass—including watch re-syncs—it reports **`bytesSent`**, **`durationMs`**, and optional install **`installedAppPath`** / **`installedBundleId`**.
> 
> **Progress reporting:** Android basis seed download uses **`onBasisDownloadProgress(downloaded, total)`** (including `(0, expectedSize)` before bytes flow) via an optional hook on **`downloadFileToLocalPath`**. Asset **`getOrUpload`** accepts **`onUploadProgress`** during signed-URL PUTs (skipped when MD5 dedup skips upload).
> 
> **Logging:** Several folder-sync messages (large uploads, sync summary, daemon full-upload retry) move from **info** to **debug** so default verbosity stays quieter while callbacks carry metrics to callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3689dc30c7a38804570a6f201572243bca1ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->