### PR TITLE
cli: show progress bar on asset and android basis fetch operations

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lim",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lim",
-      "version": "0.18.4",
+      "version": "0.18.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "0.39.5",
+        "@limrun/api": "0.39.7",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.5.tgz",
-      "integrity": "sha512-RL2r65xn5AaYRe6422MrqpYJs1pyREPfbYUTTVYt77RagevX+IQToS6NTtn4ewZOGJBW4lE7T78bgM5CZEZD/A==",
+      "version": "0.39.7",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.7.tgz",
+      "integrity": "sha512-eI4RCUOodJatKsRUPMq9mfYZ7nEqTJX/cKVDD/h+2lBfQ7f2wwlN/Wl96iVYNApe6JLYn1V+buOTMTgSshwf8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@limrun/xdelta3-wasm": "0.2.0",
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "Use remote XCode, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.39.5",
+    "@limrun/api": "0.39.7",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/android/sync.ts
+++ b/packages/cli/src/commands/android/sync.ts
@@ -3,6 +3,7 @@ import { BaseCommand } from '../../base-command';
 import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
 import { formatDurationMs } from '../../lib/duration';
 import { formatBytes } from '../../lib/bytes';
+import { ByteProgressBar } from '../../lib/byte-progress';
 
 export default class AndroidSync extends BaseCommand {
   static summary = 'Sync an APK to a running Android instance';
@@ -59,22 +60,30 @@ export default class AndroidSync extends BaseCommand {
       const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
 
       this.info(`Syncing APK ${args.path} to instance ${id}...`);
-      const syncStart = Date.now();
 
-      const result = await client.syncApp(args.path, {
-        watch: flags.watch,
-        install: flags.install,
-        basisCacheDir: flags['basis-cache-dir'],
-        launchMode: flags['launch-mode'] as 'ForegroundIfRunning' | 'RelaunchIfRunning' | undefined,
-        onBasisDownload: (sizeBytes?: number) => {
-          const downloadSize = sizeBytes === undefined ? '' : ` (${formatBytes(sizeBytes)} download)`;
-          this.info(`Fetching Android sync basis from instance${downloadSize}...`);
-        },
-      });
-
-      const syncDuration = formatDurationMs(Date.now() - syncStart);
-      const syncedSize = result.bytesSent !== undefined ? ` (${formatBytes(result.bytesSent)} sent)` : '';
-      this.output(`Sync completed in ${syncDuration}${syncedSize}.`);
+      const basisBar = new ByteProgressBar('Fetching basis', this.shouldSuppressInfo());
+      let result;
+      try {
+        result = await client.syncApp(args.path, {
+          watch: flags.watch,
+          install: flags.install,
+          basisCacheDir: flags['basis-cache-dir'],
+          launchMode: flags['launch-mode'] as 'ForegroundIfRunning' | 'RelaunchIfRunning' | undefined,
+          onBasisDownloadProgress: (downloadedBytes, totalBytes) => {
+            basisBar.update(downloadedBytes, totalBytes);
+          },
+          onSyncComplete: (event) => {
+            basisBar.stop();
+            this.output(
+              `Sync completed in ${formatDurationMs(event.durationMs)} (${formatBytes(
+                event.bytesSent,
+              )} sent).`,
+            );
+          },
+        });
+      } finally {
+        basisBar.stop();
+      }
 
       if (flags.watch && result.stopWatching) {
         this.output('Watching for changes. Press Ctrl+C to stop.');

--- a/packages/cli/src/commands/asset/pull.ts
+++ b/packages/cli/src/commands/asset/pull.ts
@@ -1,7 +1,10 @@
 import path from 'path';
 import fs from 'fs';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
+import { ByteProgressBar } from '../../lib/byte-progress';
 
 export default class AssetPull extends BaseCommand {
   static summary = 'Download an asset file';
@@ -84,8 +87,23 @@ export default class AssetPull extends BaseCommand {
         this.error(`Failed to download file: ${body}`);
       }
 
-      const buffer = Buffer.from(await resp.arrayBuffer());
-      fs.writeFileSync(fullPath, buffer);
+      const totalBytes = Number(resp.headers.get('content-length') ?? 0);
+      const bar = new ByteProgressBar('Pulling', this.shouldSuppressInfo());
+      try {
+        if (!resp.body) {
+          fs.writeFileSync(fullPath, Buffer.alloc(0));
+        } else {
+          let transferredBytes = 0;
+          const source = Readable.fromWeb(resp.body as any);
+          source.on('data', (chunk: Buffer) => {
+            transferredBytes += chunk.length;
+            bar.update(transferredBytes, totalBytes);
+          });
+          await pipeline(source, fs.createWriteStream(fullPath));
+        }
+      } finally {
+        bar.stop();
+      }
       this.output(`Saved to ${fullPath}`);
     });
   }

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
+import { ByteProgressBar } from '../../lib/byte-progress';
 
 export default class AssetPush extends BaseCommand {
   static summary = 'Upload an asset file';
@@ -36,14 +37,26 @@ export default class AssetPush extends BaseCommand {
     }
 
     const assetName = flags.name || path.basename(filePath);
-    this.info(`Name: ${assetName}`);
-
     await this.withAuth(async () => {
-      const asset = await this.client.assets.getOrUpload({
-        path: filePath,
-        name: assetName,
-        ttl: flags.ttl,
-      });
+      // Only opt into the streaming upload path when progress would actually be
+      // reported (bar on a TTY, milestone lines otherwise); --json/--quiet keeps
+      // the plain buffered upload.
+      const showProgress = !this.shouldSuppressInfo();
+      const bar = new ByteProgressBar('Pushing', !showProgress);
+      let asset;
+      try {
+        asset = await this.client.assets.getOrUpload({
+          path: filePath,
+          name: assetName,
+          ttl: flags.ttl,
+          ...(showProgress && {
+            onUploadProgress: (uploadedBytes: number, totalBytes: number) =>
+              bar.update(uploadedBytes, totalBytes),
+          }),
+        });
+      } finally {
+        bar.stop();
+      }
 
       this.output(`ID: ${asset.id}`);
       if (asset.expiresAt) {

--- a/packages/cli/src/commands/ios/sync.ts
+++ b/packages/cli/src/commands/ios/sync.ts
@@ -60,18 +60,19 @@ export default class IosSync extends BaseCommand {
       const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
 
       this.info(`Syncing app bundle ${syncPath} to instance ${id}...`);
-      const syncStart = Date.now();
 
       const result = await client.syncApp(syncPath, {
         watch: flags.watch,
         install: flags.install,
         basisCacheDir: flags['basis-cache-dir'],
         launchMode: flags['launch-mode'] as 'ForegroundIfRunning' | 'RelaunchIfRunning' | undefined,
+        onSyncComplete: (event) => {
+          this.output(
+            `Sync completed in ${formatDurationMs(event.durationMs)} (${formatBytes(event.bytesSent)} sent).`,
+          );
+        },
       });
 
-      const syncDuration = formatDurationMs(Date.now() - syncStart);
-      const syncedSize = result.bytesSent !== undefined ? ` (${formatBytes(result.bytesSent)} sent)` : '';
-      this.output(`Sync completed in ${syncDuration}${syncedSize}.`);
       if (result.installedBundleId) {
         this.output(`Installed bundle ID: ${result.installedBundleId}`);
       }

--- a/packages/cli/src/commands/xcode/sync.ts
+++ b/packages/cli/src/commands/xcode/sync.ts
@@ -73,7 +73,6 @@ export default class XcodeSync extends BaseCommand {
       const xcodeClient = await this.resolveXcodeClient(target);
 
       this.info(`Syncing ${syncPath} to instance ${id}...`);
-      const syncStart = Date.now();
 
       const syncOptions = {
         watch: flags.watch,
@@ -82,12 +81,13 @@ export default class XcodeSync extends BaseCommand {
         ignore: compileIgnorePatterns(flags.ignore),
         include: compileIgnorePatterns(flags.include),
         additionalFiles: parseAdditionalFileFlags(flags['additional-file']),
+        onSyncComplete: (event: { bytesSent: number; durationMs: number }) => {
+          this.output(
+            `Sync completed in ${formatDurationMs(event.durationMs)} (${formatBytes(event.bytesSent)} sent).`,
+          );
+        },
       };
       const result = await xcodeClient.sync(syncPath, syncOptions as Parameters<typeof xcodeClient.sync>[1]);
-
-      const syncDuration = formatDurationMs(Date.now() - syncStart);
-      const syncedSize = result.bytesSent !== undefined ? ` (${formatBytes(result.bytesSent)} sent)` : '';
-      this.output(`Sync completed in ${syncDuration}${syncedSize}.`);
 
       if (flags.watch && result.stopWatching) {
         this.output('Watching for changes. Press Ctrl+C to stop.');

--- a/packages/cli/src/lib/byte-progress.ts
+++ b/packages/cli/src/lib/byte-progress.ts
@@ -1,0 +1,62 @@
+import { SingleBar } from 'cli-progress';
+import { formatBytes } from './bytes';
+
+/**
+ * Byte-transfer progress reporting on stderr, shared by commands that move
+ * files (asset push/pull, sync basis download). On a TTY it renders a live
+ * progress bar; on non-interactive output (CI, pipes) it prints at most four
+ * milestone lines (25/50/75/100%) so logs stay short. Everything is a no-op
+ * when the owning command is in --json/--quiet mode, so callers don't need to
+ * branch. Output starts lazily on the first update so commands that end up
+ * transferring nothing (e.g. push short-circuits on an md5 match) stay silent.
+ */
+export class ByteProgressBar {
+  private bar?: SingleBar;
+  private milestonesPrinted = 0;
+
+  constructor(
+    private readonly label: string,
+    private readonly suppressed: boolean,
+  ) {}
+
+  update(transferredBytes: number, totalBytes: number): void {
+    if (this.suppressed || totalBytes <= 0) {
+      return;
+    }
+    if (!process.stderr.isTTY) {
+      const milestone = Math.min(4, Math.floor((transferredBytes / totalBytes) * 4));
+      if (milestone > this.milestonesPrinted) {
+        this.milestonesPrinted = milestone;
+        process.stderr.write(
+          `${this.label} ${milestone * 25}% (${formatBytes(transferredBytes)} / ${formatBytes(
+            totalBytes,
+          )})\n`,
+        );
+      }
+      return;
+    }
+    if (!this.bar) {
+      this.bar = new SingleBar({
+        format: `${this.label} [{bar}] {percentage}% | {transferred} / {size}`,
+        stream: process.stderr,
+        hideCursor: true,
+        barCompleteChar: '\u2588',
+        barIncompleteChar: '\u2591',
+      });
+      this.bar.start(totalBytes, 0, {
+        transferred: formatBytes(0),
+        size: formatBytes(totalBytes),
+      });
+    }
+    this.bar.update(transferredBytes, {
+      transferred: formatBytes(transferredBytes),
+      size: formatBytes(totalBytes),
+    });
+  }
+
+  stop(): void {
+    this.bar?.stop();
+    this.bar = undefined;
+    this.milestonesPrinted = 0;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UX and streaming I/O changes only; progress is suppressed for json/quiet and push only enables streaming upload when progress is shown.
> 
> **Overview**
> Adds a shared **`ByteProgressBar`** helper that reports transfer progress on **stderr** (live bar on a TTY, sparse 25% milestones otherwise) and stays silent under **`--json`/`--quiet`**.
> 
> **`asset pull`** streams the signed download to disk with progress instead of loading the whole file into memory. **`asset push`** passes **`onUploadProgress`** to **`getOrUpload`** only when progress would be shown, so scripted uploads keep the prior buffered behavior.
> 
> **`android sync`** switches from a one-shot basis message to **`onBasisDownloadProgress`** and reports each sync via **`onSyncComplete`** from **`@limrun/api`**. **`ios sync`** and **`xcode sync`** also use **`onSyncComplete`** for completion timing/size instead of local timers.
> 
> CLI version **0.18.5**; dependency **`@limrun/api`** **0.39.7**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb2016f7dd9038d40e0bbf0502c4bc6c75ad57b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->