### PR TITLE
xcode: add xcodegen override flags

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -664,6 +664,12 @@ lim asset pull my-app-build -o ./build-output
 
 `lim xcode build [PATH]` automatically performs a one-shot code sync for the given project path before invoking `xcodebuild`. The sync step automatically ignores build artifacts (`build/`, `DerivedData/`, `.build/`), dependency folders (`Pods/`, `Carthage/Build/`, `.swiftpm/`), and user-specific files (`xcuserdata/`, `.dSYM/`).
 
+For [XcodeGen](https://github.com/yonaskolb/XcodeGen) projects whose generated `.xcodeproj` is gitignored, the server generates it from your synced `project.yml` automatically before the build — it looks next to a pinned `--project`/`--workspace` path, at the synced folder root, and one directory level down. If your spec has a different name or location, pin it with `--xcodegen-spec <path>`, optionally control the output directory with `--xcodegen-project <dir>`, and anchor relative paths in the spec with `--xcodegen-project-root <dir>`; all paths are relative to the synced folder root and mirror `xcodegen generate --spec/--project/--project-root`. Passing any of these flags always regenerates the project on the server:
+
+```bash
+lim xcode build ./MyProject --xcodegen-spec specs/app.yml --xcodegen-project ios
+```
+
 Pass `--build-setting KEY=VALUE` to set Xcode build settings on the build. Allowed keys are a server-maintained allowlist of safe settings (currently `SWIFT_ACTIVE_COMPILATION_CONDITIONS`) plus any `APP_CONFIG_*` key for app configuration. Keys are passed to xcodebuild verbatim; use `$(inherited)` to append rather than replace, e.g. `--build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN'` (single-quote it so your shell does not evaluate `$(inherited)`) enables `#if LIMRUN`. An `APP_CONFIG_DEV_LOGIN_SECRET` value is referenced in `Info.plist` as `<string>$(APP_CONFIG_DEV_LOGIN_SECRET)</string>` and read at runtime with `Bundle.main`; its value is redacted in build logs.
 
 Provide `--certificate-p12`, `--certificate-password`, and `--provisioning-profile` together to sign a real-device build. When signing assets are provided without `--sdk`, the CLI builds with `iphoneos`; pass `--sdk watchos` for signed watchOS device builds.

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.18.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "0.39.7",
+        "@limrun/api": "file:../../dist",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -33,20 +33,9 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@limrun/api": {
+    "../../dist": {
+      "name": "@limrun/api",
       "version": "0.39.7",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.7.tgz",
-      "integrity": "sha512-eI4RCUOodJatKsRUPMq9mfYZ7nEqTJX/cKVDD/h+2lBfQ7f2wwlN/Wl96iVYNApe6JLYn1V+buOTMTgSshwf8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@limrun/xdelta3-wasm": "0.2.0",
@@ -59,11 +48,19 @@
         "yauzl": "^3.4.0"
       }
     },
-    "node_modules/@limrun/xdelta3-wasm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz",
-      "integrity": "sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==",
-      "license": "Apache-2.0"
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@limrun/api": {
+      "resolved": "../../dist",
+      "link": true
     },
     "node_modules/@oclif/core": {
       "version": "4.10.5",
@@ -147,15 +144,6 @@
       "dependencies": {
         "@types/node": "*",
         "kleur": "^3.0.3"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/ansi-escapes": {
@@ -428,27 +416,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eventsource-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventsource-client/-/eventsource-client-1.2.0.tgz",
-      "integrity": "sha512-kDI75RSzO3TwyG/K9w1ap8XwqSPcwi6jaMkNulfVeZmSeUM49U8kUzk1s+vKNt0tGrXgK47i+620Yasn1ccFiw==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -518,28 +485,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/indent-string": {
@@ -719,12 +664,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -754,15 +693,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/run-applescript": {
@@ -878,15 +808,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -929,27 +850,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -978,18 +878,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.39.7",
+    "@limrun/api": "file:../../dist",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -44,6 +44,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./ExpoApp --configuration Debug --dev-server-url https://abc123.exp.direct',
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
+    '<%= config.bin %> xcode build ./MyProject --xcodegen-spec specs/app.yml --xcodegen-project ios',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload-to-testflight --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
@@ -77,6 +78,18 @@ export default class XcodeBuild extends BaseCommand {
       description: 'Workspace file to pass to xcodebuild, such as MyApp.xcworkspace',
     }),
     project: Flags.string({ description: 'Project file to pass to xcodebuild, such as MyApp.xcodeproj' }),
+    'xcodegen-spec': Flags.string({
+      description:
+        'XcodeGen project spec path relative to the synced folder root, like `xcodegen generate --spec`. Forces server-side generation with the bundled XcodeGen. Omit to use project.yml at the root.',
+    }),
+    'xcodegen-project': Flags.string({
+      description:
+        "Directory (relative to the synced folder root) the Xcode project is generated into, like `xcodegen generate --project`. Forces server-side generation. Defaults to the spec file's directory.",
+    }),
+    'xcodegen-project-root': Flags.string({
+      description:
+        "Project root directory (relative to the synced folder root) that relative paths in the spec resolve against, like `xcodegen generate --project-root`. Forces server-side generation. Defaults to the spec file's directory.",
+    }),
     sdk: Flags.string({
       description: 'SDK family to build for.',
       options: ['iphonesimulator', 'iphoneos', 'watchsimulator', 'watchos'],
@@ -164,6 +177,14 @@ export default class XcodeBuild extends BaseCommand {
         '--ios builds run on a simulator. Use --sdk iphonesimulator, --sdk watchsimulator, or omit --sdk.',
       );
     }
+    if (
+      (flags['xcodegen-spec'] || flags['xcodegen-project'] || flags['xcodegen-project-root']) &&
+      (flags['dev-server-url'] || flags['expo-app-dir'])
+    ) {
+      this.error(
+        '--xcodegen-spec/--xcodegen-project apply to native XcodeGen projects and cannot be combined with Expo / React Native flags.',
+      );
+    }
     if (flags.ios && hasSigningFlags(flags)) {
       this.error('--ios builds run on a simulator and cannot use signing flags.');
     }
@@ -189,6 +210,13 @@ export default class XcodeBuild extends BaseCommand {
       if (flags.configuration) settings.configuration = flags.configuration;
 
       const options: XcodeBuildOptions = {};
+      if (flags['xcodegen-spec'] || flags['xcodegen-project'] || flags['xcodegen-project-root']) {
+        options.xcodegen = {
+          ...(flags['xcodegen-spec'] && { spec: flags['xcodegen-spec'] }),
+          ...(flags['xcodegen-project'] && { project: flags['xcodegen-project'] }),
+          ...(flags['xcodegen-project-root'] && { projectRoot: flags['xcodegen-project-root'] }),
+        };
+      }
       if (flags['dev-server-url'] || flags['expo-app-dir']) {
         options.reactNative = {
           ...(flags['expo-app-dir'] && { expoAppDir: flags['expo-app-dir'] }),

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -21,6 +21,11 @@ export type ExecRequest = {
     sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos';
     configuration?: 'Debug' | 'Release';
   };
+  xcodegen?: {
+    spec?: string;
+    project?: string;
+    projectRoot?: string;
+  };
   reactNative?: {
     expoAppDir?: string;
     devServerURL?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export {
   DEFAULT_RBE_TUNNEL_PORT,
   type XcodeProjectConfig,
   type XcodeBuildOptions,
+  type XcodeGenConfig,
   type ReactNativeBuildConfig,
   type SimulatorAttachResult,
   type SimulatorStatus,

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -47,6 +47,7 @@ export {
   type XcodeClient,
   type XcodeProjectConfig,
   type XcodeBuildOptions,
+  type XcodeGenConfig,
   type ReactNativeBuildConfig,
   type SimulatorAttachResult,
   type SimulatorStatus,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -82,6 +82,28 @@ export type XcodeProjectConfig = {
   configuration?: 'Debug' | 'Release';
 };
 
+export type XcodeGenConfig = {
+  /**
+   * Relative path from the synced workspace root to the XcodeGen project
+   * spec file, like `xcodegen generate --spec`. Omit to use project.yml at
+   * the workspace root.
+   */
+  spec?: string;
+  /**
+   * Relative path from the synced workspace root to the directory the Xcode
+   * project is generated into, like `xcodegen generate --project`. Omit to
+   * generate into the spec file's directory.
+   */
+  project?: string;
+  /**
+   * Relative path from the synced workspace root to the project root
+   * directory that relative paths in the spec resolve against, like
+   * `xcodegen generate --project-root`. Omit to use the spec file's
+   * directory.
+   */
+  projectRoot?: string;
+};
+
 export type XcodeSigningConfig = {
   certificateP12Base64?: string;
   certificatePassword?: string;
@@ -117,6 +139,14 @@ export type XcodeBuildOptions = {
    */
   testflight?: TestflightUploadConfig;
   reactNative?: ReactNativeBuildConfig;
+  /**
+   * Explicit XcodeGen inputs for server-side project generation. By default
+   * limbuild only generates from a project.yml it discovers, and only when
+   * the client did not sync the .xcodeproj itself. Setting either field
+   * forces generation with these paths, mirroring `xcodegen generate
+   * --spec/--project` run at the synced workspace root.
+   */
+  xcodegen?: XcodeGenConfig;
   buildSettings?: Record<string, string>;
 };
 
@@ -641,6 +671,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
         const request: ExecRequest = {
           command: 'xcodebuild',
           ...(settings && { xcodebuild: settings }),
+          ...(options?.xcodegen && { xcodegen: options.xcodegen }),
           ...(options?.reactNative && { reactNative: options.reactNative }),
           ...(options?.signing && { signing: options.signing }),
           ...(options?.testflight && { testflight: options.testflight }),

--- a/tests/android-basis-cache.test.ts
+++ b/tests/android-basis-cache.test.ts
@@ -19,7 +19,10 @@ function tempDir(): string {
 
 type TestServer = { url: string; requests: string[]; close: () => Promise<void> };
 
-async function startServer(state: AndroidSyncState, seedBodies: Record<string, Buffer> = {}): Promise<TestServer> {
+async function startServer(
+  state: AndroidSyncState,
+  seedBodies: Record<string, Buffer> = {},
+): Promise<TestServer> {
   const requests: string[] = [];
   const server = http.createServer((req, res) => {
     requests.push(req.url ?? '');
@@ -98,7 +101,10 @@ describe('bootstrapAndroidBasisCache', () => {
     fs.writeFileSync(basisPath, Buffer.from('basis this instance never saw'));
     const seedBytes = Buffer.from('seed apk retained on instance');
     const seedSha = sha256Hex(seedBytes);
-    const server = await startServer({ seeds: [{ sha256: seedSha, size: seedBytes.length }] }, { [seedSha]: seedBytes });
+    const server = await startServer(
+      { seeds: [{ sha256: seedSha, size: seedBytes.length }] },
+      { [seedSha]: seedBytes },
+    );
     const progress: Array<[number, number]> = [];
     try {
       await bootstrapAndroidBasisCache(apkPath, basisCacheDir, server.url, 'tok', noopLog, (done, total) =>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the remote build request contract and CLI validation for a core `xcode build` path; the local `file:../../dist` dependency must not ship to npm if unintended.
> 
> **Overview**
> Adds **explicit XcodeGen controls** to `lim xcode build` so the remote sandbox can regenerate `.xcodeproj` from custom spec paths, not only auto-discovered `project.yml`.
> 
> New flags **`--xcodegen-spec`**, **`--xcodegen-project`**, and **`--xcodegen-project-root`** (paths relative to the synced folder) are forwarded through **`XcodeBuildOptions.xcodegen`** on the SDK and included on the **`/exec` xcodebuild** payload as **`xcodegen`**. Using any of these flags forces server-side generation, matching `xcodegen generate --spec/--project/--project-root`. The CLI rejects combining them with Expo/React Native options (`--dev-server-url`, `--expo-app-dir`).
> 
> README documents XcodeGen behavior and the new flags. **`packages/cli`** temporarily depends on **`@limrun/api` via `file:../../dist`** (lockfile updated) instead of the published npm version—likely for local SDK iteration in this branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5b7f130e85ba4e6217f9966b0c990179b9d65f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->