### PR TITLE
sync: basis cache download should also be differential

### DIFF
--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -165,9 +165,9 @@ export type InstanceClient = {
       launchMode?: 'ForegroundIfRunning' | 'RelaunchIfRunning';
       basisCacheDir?: string;
       /**
-       * Called while the basis seed is downloaded from the instance. Fires once with
-       * `(0, expectedSizeBytes)` before the download starts (expectedSizeBytes is 0 when
-       * unknown), then repeatedly as bytes arrive.
+       * Called while missing basis-seed ranges are downloaded from the instance. Fires
+       * once with `(0, requiredDownloadBytes)` before transfer, then repeatedly as bytes
+       * arrive. A full-download fallback restarts progress with the complete seed size.
        */
       onBasisDownloadProgress?: (downloadedBytes: number, totalBytes: number) => void;
       /** Called after every successful sync, including watch-triggered re-syncs. */

--- a/src/internal/android-basis-cache.ts
+++ b/src/internal/android-basis-cache.ts
@@ -11,7 +11,7 @@ export type AndroidSyncState = {
     rootName?: string;
     files?: Array<{ path?: string; sha256?: string; size?: number; mode?: number }>;
   }>;
-  seeds?: Array<{ sha256?: string; size?: number; name?: string; mtime?: number }>;
+  seeds?: Array<{ sha256?: string; size?: number; mtime?: number }>;
 };
 
 type SyncLog = (level: 'debug' | 'info' | 'warn' | 'error', msg: string) => void;
@@ -86,7 +86,7 @@ export async function bootstrapAndroidBasisCache(
   }
   const seeds = [...(state.seeds ?? [])]
     .filter(
-      (seed): seed is { sha256: string; size?: number; name?: string; mtime?: number } =>
+      (seed): seed is { sha256: string; size?: number; mtime?: number } =>
         typeof seed.sha256 === 'string' && /^[0-9a-f]{64}$/i.test(seed.sha256),
     )
     .sort((a, b) => (b.mtime ?? 0) - (a.mtime ?? 0));

--- a/src/internal/android-basis-cache.ts
+++ b/src/internal/android-basis-cache.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { downloadFileToLocalPath } from './download-file';
 import { nodeProxyTransport } from './proxy-transport';
+import { reconstructSeedFromLocalFiles } from './seed-reconstruct';
 
 export type AndroidSyncState = {
   roots?: Array<{
@@ -93,16 +94,16 @@ export async function bootstrapAndroidBasisCache(
     serverShas.add(seed.sha256.toLowerCase());
   }
 
+  let staleBasisPath: string | undefined;
   if (fs.existsSync(basisPath)) {
     const basisSha = (await sha256FileHex(basisPath)).toLowerCase();
     if (serverShas.has(basisSha)) {
       return;
     }
-    // A delta against a basis this instance doesn't have only earns a needFull
-    // round trip and then a full upload (e.g. a warm cache pointed at a fresh
-    // instance), so drop the stale basis and re-seed below.
+    // Keep the stale basis temporarily: even though the instance cannot use it
+    // directly, many of its blocks may be reusable while reconstructing a seed.
     log('debug', `local basis ${basisSha} unknown to instance; re-seeding basis cache`);
-    await fs.promises.rm(basisPath, { force: true });
+    staleBasisPath = basisPath;
   }
 
   const localSha = (await sha256FileHex(apkPath)).toLowerCase();
@@ -116,16 +117,37 @@ export async function bootstrapAndroidBasisCache(
   }
   const seed = seeds[0];
   if (!seed) {
+    if (staleBasisPath) {
+      await fs.promises.rm(staleBasisPath, { force: true });
+    }
     return;
   }
-  // Announce the download before any bytes flow so consumers can react to the
-  // expected size even during connection setup / time-to-first-byte.
-  onBasisDownloadProgress?.(0, seed.size ?? 0);
-  await downloadFileToLocalPath(
-    buildSyncSeedUrl(apiUrl, seed.sha256),
-    token,
-    basisPath,
-    onBasisDownloadProgress,
-  );
-  log('debug', `seeded Android basis cache from instance seed: ${seed.sha256}`);
+  const seedUrl = buildSyncSeedUrl(apiUrl, seed.sha256);
+  try {
+    const result = await reconstructSeedFromLocalFiles({
+      signatureUrl: `${seedUrl}.sig`,
+      seedUrl,
+      token,
+      sourcePaths: staleBasisPath ? [apkPath, staleBasisPath] : [apkPath],
+      outputPath: basisPath,
+      expectedSha256: seed.sha256,
+      ...(onBasisDownloadProgress ? { onProgress: onBasisDownloadProgress } : {}),
+    });
+    log(
+      'debug',
+      `reconstructed Android basis seed ${seed.sha256}: matched=${result.matchedBlocks} downloaded=${result.downloadedBytes}`,
+    );
+  } catch (err) {
+    log(
+      'debug',
+      `basis seed reconstruction unavailable; downloading full seed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    // A failed reconstruction never replaces basisPath, so it is safe to
+    // truncate the stale basis in place for the full-download fallback.
+    onBasisDownloadProgress?.(0, seed.size ?? 0);
+    await downloadFileToLocalPath(seedUrl, token, basisPath, onBasisDownloadProgress);
+    log('debug', `seeded Android basis cache from full instance seed: ${seed.sha256}`);
+  }
 }

--- a/src/internal/seed-reconstruct.ts
+++ b/src/internal/seed-reconstruct.ts
@@ -1,0 +1,510 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Readable } from 'stream';
+
+import { nodeProxyTransport } from './proxy-transport';
+
+const SIGNATURE_VERSION = 1;
+const STRONG_HASH_HEX_LENGTH = 32;
+const SCAN_CHUNK_SIZE = 1024 * 1024;
+const MAX_ALIGNED_MISS_BYTES = 32 * 1024 * 1024;
+
+export type SeedSignatureBlock = {
+  w: number;
+  s: string;
+};
+
+export type SeedSignature = {
+  version: number;
+  blockSize: number;
+  fileSize: number;
+  sha256: string;
+  blocks: SeedSignatureBlock[];
+};
+
+export type SeedBlockMatch = {
+  sourcePath: string;
+  sourceOffset: number;
+};
+
+export type SeedByteRange = {
+  start: number;
+  end: number;
+};
+
+type ReconstructSeedOptions = {
+  signatureUrl: string;
+  seedUrl: string;
+  token: string;
+  sourcePaths: string[];
+  outputPath: string;
+  expectedSha256: string;
+  onProgress?: (downloadedBytes: number, totalBytes: number) => void;
+};
+
+function strongHash(buffer: Uint8Array): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex').slice(0, STRONG_HASH_HEX_LENGTH);
+}
+
+async function sha256FileHex(filePath: string): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+export function weakRollingChecksum(buffer: Uint8Array): number {
+  let a = 0;
+  let b = 0;
+  for (let i = 0; i < buffer.byteLength; i++) {
+    const value = buffer[i]!;
+    a = (a + value) & 0xffff;
+    b = (b + (buffer.byteLength - i) * value) & 0xffff;
+  }
+  return b * 0x10000 + a;
+}
+
+function validateSignature(value: unknown, expectedSha256: string): SeedSignature {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid seed signature: expected an object');
+  }
+  const candidate = value as Partial<SeedSignature>;
+  if (candidate.version !== SIGNATURE_VERSION) {
+    throw new Error(`Unsupported seed signature version: ${String(candidate.version)}`);
+  }
+  if (!Number.isSafeInteger(candidate.blockSize) || candidate.blockSize! <= 0) {
+    throw new Error('Invalid seed signature blockSize');
+  }
+  if (!Number.isSafeInteger(candidate.fileSize) || candidate.fileSize! < 0) {
+    throw new Error('Invalid seed signature fileSize');
+  }
+  if (
+    typeof candidate.sha256 !== 'string' ||
+    !/^[0-9a-f]{64}$/i.test(candidate.sha256) ||
+    candidate.sha256.toLowerCase() !== expectedSha256.toLowerCase()
+  ) {
+    throw new Error('Seed signature sha256 does not match the requested seed');
+  }
+  if (!Array.isArray(candidate.blocks)) {
+    throw new Error('Invalid seed signature blocks');
+  }
+  const expectedBlocks = Math.ceil(candidate.fileSize! / candidate.blockSize!);
+  if (candidate.blocks.length !== expectedBlocks) {
+    throw new Error(
+      `Invalid seed signature block count: got ${candidate.blocks.length}, expected ${expectedBlocks}`,
+    );
+  }
+  const blocks = candidate.blocks.map((block, index) => {
+    if (
+      !block ||
+      !Number.isInteger(block.w) ||
+      block.w < 0 ||
+      block.w > 0xffffffff ||
+      typeof block.s !== 'string' ||
+      !new RegExp(`^[0-9a-f]{${STRONG_HASH_HEX_LENGTH}}$`, 'i').test(block.s)
+    ) {
+      throw new Error(`Invalid seed signature block at index ${index}`);
+    }
+    return { w: block.w, s: block.s.toLowerCase() };
+  });
+  return {
+    version: candidate.version,
+    blockSize: candidate.blockSize!,
+    fileSize: candidate.fileSize!,
+    sha256: candidate.sha256.toLowerCase(),
+    blocks,
+  };
+}
+
+export async function fetchSeedSignature(
+  signatureUrl: string,
+  token: string,
+  expectedSha256: string,
+): Promise<SeedSignature> {
+  const response = await nodeProxyTransport.fetch(signatureUrl, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Seed signature download failed: ${response.status} ${body}`);
+  }
+  return validateSignature(await response.json(), expectedSha256);
+}
+
+async function readExactly(
+  handle: fs.promises.FileHandle,
+  buffer: Buffer,
+  length: number,
+  position: number,
+): Promise<void> {
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await handle.read(buffer, offset, length - offset, position + offset);
+    if (bytesRead <= 0) {
+      throw new Error(`Unexpected EOF at offset ${position + offset}`);
+    }
+    offset += bytesRead;
+  }
+}
+
+async function scanSourceForBlockLength(
+  sourcePath: string,
+  blockLength: number,
+  candidatesByWeak: Map<number, number[]>,
+  signature: SeedSignature,
+  matches: Map<number, SeedBlockMatch>,
+  unmatched: Set<number>,
+): Promise<void> {
+  const handle = await fs.promises.open(sourcePath, 'r');
+  try {
+    const sourceSize = (await handle.stat()).size;
+    if (sourceSize < blockLength || unmatched.size === 0) {
+      return;
+    }
+
+    const ring = Buffer.allocUnsafe(blockLength);
+    await readExactly(handle, ring, blockLength, 0);
+    let a = 0;
+    let b = 0;
+    for (let i = 0; i < blockLength; i++) {
+      const value = ring[i]!;
+      a = (a + value) & 0xffff;
+      b = (b + (blockLength - i) * value) & 0xffff;
+    }
+
+    let ringPosition = 0;
+    let sourceOffset = 0;
+    let candidateBuffer: Buffer | undefined;
+    const confirmCandidate = async (candidateIndexes: number[]) => {
+      candidateBuffer ??= Buffer.allocUnsafe(blockLength);
+      await readExactly(handle, candidateBuffer, blockLength, sourceOffset);
+      const strong = strongHash(candidateBuffer);
+      for (const index of candidateIndexes) {
+        if (unmatched.has(index) && signature.blocks[index]!.s === strong) {
+          matches.set(index, { sourcePath, sourceOffset });
+          unmatched.delete(index);
+        }
+      }
+    };
+
+    let candidateIndexes = candidatesByWeak.get(b * 0x10000 + a);
+    if (candidateIndexes?.some((index) => unmatched.has(index))) {
+      await confirmCandidate(candidateIndexes);
+    }
+    const incoming = Buffer.allocUnsafe(SCAN_CHUNK_SIZE);
+    let readPosition = blockLength;
+    while (readPosition < sourceSize && unmatched.size > 0) {
+      const requested = Math.min(incoming.byteLength, sourceSize - readPosition);
+      const { bytesRead } = await handle.read(incoming, 0, requested, readPosition);
+      if (bytesRead <= 0) {
+        break;
+      }
+      for (let i = 0; i < bytesRead && unmatched.size > 0; i++) {
+        const outgoingValue = ring[ringPosition]!;
+        const incomingValue = incoming[i]!;
+        ring[ringPosition] = incomingValue;
+        ringPosition++;
+        if (ringPosition === blockLength) {
+          ringPosition = 0;
+        }
+        a = (a - outgoingValue + incomingValue) & 0xffff;
+        b = (b - ((blockLength * outgoingValue) & 0xffff) + a) & 0xffff;
+        sourceOffset++;
+        candidateIndexes = candidatesByWeak.get(b * 0x10000 + a);
+        if (candidateIndexes?.some((index) => unmatched.has(index))) {
+          await confirmCandidate(candidateIndexes);
+        }
+      }
+      readPosition += bytesRead;
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function findSeedBlockMatches(
+  sourcePaths: string[],
+  signature: SeedSignature,
+): Promise<Map<number, SeedBlockMatch>> {
+  const matches = new Map<number, SeedBlockMatch>();
+
+  // APK rebuilds commonly preserve ZIP entry offsets. Check blocks at their
+  // target offsets first using native SHA-256, which is dramatically faster
+  // than a byte-by-byte rolling scan for large files.
+  for (const sourcePath of sourcePaths) {
+    const stat = await fs.promises.stat(sourcePath).catch(() => undefined);
+    if (!stat?.isFile()) {
+      continue;
+    }
+    const handle = await fs.promises.open(sourcePath, 'r');
+    const block = Buffer.allocUnsafe(signature.blockSize);
+    try {
+      for (let index = 0; index < signature.blocks.length; index++) {
+        if (matches.has(index)) {
+          continue;
+        }
+        const sourceOffset = index * signature.blockSize;
+        const length = Math.min(signature.blockSize, signature.fileSize - sourceOffset);
+        if (sourceOffset + length > stat.size) {
+          continue;
+        }
+        await readExactly(handle, block, length, sourceOffset);
+        if (strongHash(block.subarray(0, length)) === signature.blocks[index]!.s) {
+          matches.set(index, { sourcePath, sourceOffset });
+        }
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+
+  const alignedMissBytes = signature.blocks.reduce((total, _block, index) => {
+    if (matches.has(index)) {
+      return total;
+    }
+    const offset = index * signature.blockSize;
+    return total + Math.min(signature.blockSize, signature.fileSize - offset);
+  }, 0);
+  const alignedMatchRatio = signature.blocks.length === 0 ? 1 : matches.size / signature.blocks.length;
+  if (alignedMatchRatio >= 0.8 && alignedMissBytes <= MAX_ALIGNED_MISS_BYTES) {
+    return matches;
+  }
+
+  const indexesByLength = new Map<number, number[]>();
+  for (let index = 0; index < signature.blocks.length; index++) {
+    if (matches.has(index)) {
+      continue;
+    }
+    const offset = index * signature.blockSize;
+    const length = Math.min(signature.blockSize, signature.fileSize - offset);
+    const indexes = indexesByLength.get(length) ?? [];
+    indexes.push(index);
+    indexesByLength.set(length, indexes);
+  }
+
+  for (const [blockLength, indexes] of indexesByLength) {
+    // A trailing partial block is worth at most one block of transfer savings.
+    // Avoid a second byte-by-byte scan of the whole APK: check the seed's
+    // expected offset and the end of each source, which cover unchanged layout
+    // and suffix-aligned rebuilds respectively.
+    if (blockLength !== signature.blockSize) {
+      const index = indexes[0]!;
+      const expected = signature.blocks[index]!;
+      for (const sourcePath of sourcePaths) {
+        const stat = await fs.promises.stat(sourcePath).catch(() => undefined);
+        if (!stat?.isFile() || stat.size < blockLength) {
+          continue;
+        }
+        const offsets = new Set([index * signature.blockSize, stat.size - blockLength]);
+        const handle = await fs.promises.open(sourcePath, 'r');
+        try {
+          for (const sourceOffset of offsets) {
+            if (sourceOffset < 0 || sourceOffset + blockLength > stat.size) {
+              continue;
+            }
+            const block = Buffer.allocUnsafe(blockLength);
+            await readExactly(handle, block, blockLength, sourceOffset);
+            if (weakRollingChecksum(block) === expected.w && strongHash(block) === expected.s) {
+              matches.set(index, { sourcePath, sourceOffset });
+              break;
+            }
+          }
+        } finally {
+          await handle.close();
+        }
+        if (matches.has(index)) {
+          break;
+        }
+      }
+      continue;
+    }
+
+    const candidatesByWeak = new Map<number, number[]>();
+    for (const index of indexes) {
+      const weak = signature.blocks[index]!.w;
+      const candidates = candidatesByWeak.get(weak) ?? [];
+      candidates.push(index);
+      candidatesByWeak.set(weak, candidates);
+    }
+    const unmatched = new Set(indexes);
+    for (const sourcePath of sourcePaths) {
+      const stat = await fs.promises.stat(sourcePath).catch(() => undefined);
+      if (!stat?.isFile()) {
+        continue;
+      }
+      await scanSourceForBlockLength(
+        sourcePath,
+        blockLength,
+        candidatesByWeak,
+        signature,
+        matches,
+        unmatched,
+      );
+      if (unmatched.size === 0) {
+        break;
+      }
+    }
+  }
+  return matches;
+}
+
+export function missingSeedRanges(
+  signature: SeedSignature,
+  matches: ReadonlyMap<number, SeedBlockMatch>,
+): SeedByteRange[] {
+  const ranges: SeedByteRange[] = [];
+  let startBlock: number | undefined;
+  for (let index = 0; index <= signature.blocks.length; index++) {
+    const missing = index < signature.blocks.length && !matches.has(index);
+    if (missing && startBlock === undefined) {
+      startBlock = index;
+    } else if (!missing && startBlock !== undefined) {
+      ranges.push({
+        start: startBlock * signature.blockSize,
+        end: Math.min(signature.fileSize, index * signature.blockSize) - 1,
+      });
+      startBlock = undefined;
+    }
+  }
+  return ranges;
+}
+
+async function copyMatchedBlocks(
+  output: fs.promises.FileHandle,
+  signature: SeedSignature,
+  matches: ReadonlyMap<number, SeedBlockMatch>,
+): Promise<void> {
+  const sourceHandles = new Map<string, fs.promises.FileHandle>();
+  try {
+    for (const [index, match] of matches) {
+      let source = sourceHandles.get(match.sourcePath);
+      if (!source) {
+        source = await fs.promises.open(match.sourcePath, 'r');
+        sourceHandles.set(match.sourcePath, source);
+      }
+      const targetOffset = index * signature.blockSize;
+      const length = Math.min(signature.blockSize, signature.fileSize - targetOffset);
+      const block = Buffer.allocUnsafe(length);
+      await readExactly(source, block, length, match.sourceOffset);
+      await writeExactly(output, block, targetOffset);
+    }
+  } finally {
+    await Promise.all([...sourceHandles.values()].map((handle) => handle.close()));
+  }
+}
+
+async function writeExactly(handle: fs.promises.FileHandle, buffer: Buffer, position: number): Promise<void> {
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const { bytesWritten } = await handle.write(
+      buffer,
+      offset,
+      buffer.byteLength - offset,
+      position + offset,
+    );
+    if (bytesWritten <= 0) {
+      throw new Error(`Unable to write reconstructed seed at offset ${position + offset}`);
+    }
+    offset += bytesWritten;
+  }
+}
+
+async function downloadRange(
+  seedUrl: string,
+  token: string,
+  range: SeedByteRange,
+  fileSize: number,
+  output: fs.promises.FileHandle,
+  reportBytes: (bytes: number) => void,
+): Promise<void> {
+  const response = await nodeProxyTransport.fetch(seedUrl, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Range: `bytes=${range.start}-${range.end}`,
+    },
+  });
+  if (response.status !== 206 || !response.body) {
+    const body = await response.text();
+    throw new Error(`Seed range download failed: ${response.status} ${body}`);
+  }
+  const expectedContentRange = `bytes ${range.start}-${range.end}/${fileSize}`;
+  if (response.headers.get('content-range') !== expectedContentRange) {
+    throw new Error(
+      `Invalid Content-Range for seed: ${response.headers.get('content-range') ?? '<missing>'}`,
+    );
+  }
+
+  const expectedLength = range.end - range.start + 1;
+  let received = 0;
+  const source = Readable.fromWeb(response.body as any);
+  for await (const value of source) {
+    const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value as Uint8Array);
+    if (received + chunk.byteLength > expectedLength) {
+      throw new Error('Seed range response exceeded the requested length');
+    }
+    await writeExactly(output, chunk, range.start + received);
+    received += chunk.byteLength;
+    reportBytes(chunk.byteLength);
+  }
+  if (received !== expectedLength) {
+    throw new Error(`Seed range response was truncated: got ${received}, expected ${expectedLength}`);
+  }
+}
+
+export async function reconstructSeedFromLocalFiles(options: ReconstructSeedOptions): Promise<{
+  downloadedBytes: number;
+  totalDownloadBytes: number;
+  matchedBlocks: number;
+}> {
+  const expectedSha256 = options.expectedSha256.toLowerCase();
+  const signature = await fetchSeedSignature(options.signatureUrl, options.token, expectedSha256);
+  const uniqueSources = [...new Set(options.sourcePaths.map((sourcePath) => path.resolve(sourcePath)))];
+  const matches = await findSeedBlockMatches(uniqueSources, signature);
+  const ranges = missingSeedRanges(signature, matches);
+  const totalDownloadBytes = ranges.reduce((total, range) => total + range.end - range.start + 1, 0);
+  let downloadedBytes = 0;
+  options.onProgress?.(0, totalDownloadBytes);
+
+  await fs.promises.mkdir(path.dirname(options.outputPath), { recursive: true });
+  const temporaryPath = `${options.outputPath}.reconstruct-${process.pid}-${crypto
+    .randomBytes(6)
+    .toString('hex')}`;
+  const output = await fs.promises.open(temporaryPath, 'wx');
+  let outputClosed = false;
+  let installed = false;
+  try {
+    await output.truncate(signature.fileSize);
+    await copyMatchedBlocks(output, signature, matches);
+    for (const range of ranges) {
+      await downloadRange(options.seedUrl, options.token, range, signature.fileSize, output, (bytes) => {
+        downloadedBytes += bytes;
+        options.onProgress?.(downloadedBytes, totalDownloadBytes);
+      });
+    }
+    await output.close();
+    outputClosed = true;
+
+    const actualSha256 = await sha256FileHex(temporaryPath);
+    if (actualSha256 !== expectedSha256) {
+      throw new Error(`Reconstructed seed SHA-256 mismatch: got ${actualSha256}, expected ${expectedSha256}`);
+    }
+    await fs.promises.rm(options.outputPath, { force: true });
+    await fs.promises.rename(temporaryPath, options.outputPath);
+    installed = true;
+  } finally {
+    if (!outputClosed) {
+      await output.close().catch(() => undefined);
+    }
+    if (!installed) {
+      await fs.promises.rm(temporaryPath, { force: true });
+    }
+  }
+
+  return { downloadedBytes, totalDownloadBytes, matchedBlocks: matches.size };
+}

--- a/src/internal/seed-reconstruct.ts
+++ b/src/internal/seed-reconstruct.ts
@@ -9,6 +9,8 @@ const SIGNATURE_VERSION = 1;
 const STRONG_HASH_HEX_LENGTH = 32;
 const SCAN_CHUNK_SIZE = 1024 * 1024;
 const MAX_ALIGNED_MISS_BYTES = 32 * 1024 * 1024;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
+const STRONG_HASH_PATTERN = /^[0-9a-f]{32}$/i;
 
 export type SeedSignatureBlock = {
   w: number;
@@ -33,6 +35,16 @@ export type SeedByteRange = {
   end: number;
 };
 
+type BlockSpan = {
+  offset: number;
+  length: number;
+};
+
+type SourceFile = {
+  path: string;
+  size: number;
+};
+
 type ReconstructSeedOptions = {
   signatureUrl: string;
   seedUrl: string;
@@ -45,6 +57,14 @@ type ReconstructSeedOptions = {
 
 function strongHash(buffer: Uint8Array): string {
   return crypto.createHash('sha256').update(buffer).digest('hex').slice(0, STRONG_HASH_HEX_LENGTH);
+}
+
+function blockSpan(signature: SeedSignature, index: number): BlockSpan {
+  const offset = index * signature.blockSize;
+  return {
+    offset,
+    length: Math.min(signature.blockSize, signature.fileSize - offset),
+  };
 }
 
 async function sha256FileHex(filePath: string): Promise<string> {
@@ -84,7 +104,7 @@ function validateSignature(value: unknown, expectedSha256: string): SeedSignatur
   }
   if (
     typeof candidate.sha256 !== 'string' ||
-    !/^[0-9a-f]{64}$/i.test(candidate.sha256) ||
+    !SHA256_PATTERN.test(candidate.sha256) ||
     candidate.sha256.toLowerCase() !== expectedSha256.toLowerCase()
   ) {
     throw new Error('Seed signature sha256 does not match the requested seed');
@@ -105,7 +125,7 @@ function validateSignature(value: unknown, expectedSha256: string): SeedSignatur
       block.w < 0 ||
       block.w > 0xffffffff ||
       typeof block.s !== 'string' ||
-      !new RegExp(`^[0-9a-f]{${STRONG_HASH_HEX_LENGTH}}$`, 'i').test(block.s)
+      !STRONG_HASH_PATTERN.test(block.s)
     ) {
       throw new Error(`Invalid seed signature block at index ${index}`);
     }
@@ -152,18 +172,17 @@ async function readExactly(
   }
 }
 
-async function scanSourceForBlockLength(
-  sourcePath: string,
-  blockLength: number,
+async function scanSourceForFullBlocks(
+  source: SourceFile,
   candidatesByWeak: Map<number, number[]>,
   signature: SeedSignature,
   matches: Map<number, SeedBlockMatch>,
   unmatched: Set<number>,
 ): Promise<void> {
-  const handle = await fs.promises.open(sourcePath, 'r');
+  const blockLength = signature.blockSize;
+  const handle = await fs.promises.open(source.path, 'r');
   try {
-    const sourceSize = (await handle.stat()).size;
-    if (sourceSize < blockLength || unmatched.size === 0) {
+    if (source.size < blockLength || unmatched.size === 0) {
       return;
     }
 
@@ -186,7 +205,7 @@ async function scanSourceForBlockLength(
       const strong = strongHash(candidateBuffer);
       for (const index of candidateIndexes) {
         if (unmatched.has(index) && signature.blocks[index]!.s === strong) {
-          matches.set(index, { sourcePath, sourceOffset });
+          matches.set(index, { sourcePath: source.path, sourceOffset });
           unmatched.delete(index);
         }
       }
@@ -198,8 +217,8 @@ async function scanSourceForBlockLength(
     }
     const incoming = Buffer.allocUnsafe(SCAN_CHUNK_SIZE);
     let readPosition = blockLength;
-    while (readPosition < sourceSize && unmatched.size > 0) {
-      const requested = Math.min(incoming.byteLength, sourceSize - readPosition);
+    while (readPosition < source.size && unmatched.size > 0) {
+      const requested = Math.min(incoming.byteLength, source.size - readPosition);
       const { bytesRead } = await handle.read(incoming, 0, requested, readPosition);
       if (bytesRead <= 0) {
         break;
@@ -227,128 +246,131 @@ async function scanSourceForBlockLength(
   }
 }
 
-export async function findSeedBlockMatches(
-  sourcePaths: string[],
-  signature: SeedSignature,
-): Promise<Map<number, SeedBlockMatch>> {
-  const matches = new Map<number, SeedBlockMatch>();
-
-  // APK rebuilds commonly preserve ZIP entry offsets. Check blocks at their
-  // target offsets first using native SHA-256, which is dramatically faster
-  // than a byte-by-byte rolling scan for large files.
+async function existingSourceFiles(sourcePaths: string[]): Promise<SourceFile[]> {
+  const sources: SourceFile[] = [];
   for (const sourcePath of sourcePaths) {
     const stat = await fs.promises.stat(sourcePath).catch(() => undefined);
-    if (!stat?.isFile()) {
-      continue;
+    if (stat?.isFile()) {
+      sources.push({ path: sourcePath, size: stat.size });
     }
-    const handle = await fs.promises.open(sourcePath, 'r');
+  }
+  return sources;
+}
+
+async function matchAlignedBlocks(
+  sources: SourceFile[],
+  signature: SeedSignature,
+  matches: Map<number, SeedBlockMatch>,
+): Promise<void> {
+  for (const source of sources) {
+    const handle = await fs.promises.open(source.path, 'r');
     const block = Buffer.allocUnsafe(signature.blockSize);
     try {
       for (let index = 0; index < signature.blocks.length; index++) {
         if (matches.has(index)) {
           continue;
         }
-        const sourceOffset = index * signature.blockSize;
-        const length = Math.min(signature.blockSize, signature.fileSize - sourceOffset);
-        if (sourceOffset + length > stat.size) {
+        const span = blockSpan(signature, index);
+        if (span.offset + span.length > source.size) {
           continue;
         }
-        await readExactly(handle, block, length, sourceOffset);
-        if (strongHash(block.subarray(0, length)) === signature.blocks[index]!.s) {
-          matches.set(index, { sourcePath, sourceOffset });
+        await readExactly(handle, block, span.length, span.offset);
+        if (strongHash(block.subarray(0, span.length)) === signature.blocks[index]!.s) {
+          matches.set(index, { sourcePath: source.path, sourceOffset: span.offset });
         }
       }
     } finally {
       await handle.close();
     }
   }
+}
 
-  const alignedMissBytes = signature.blocks.reduce((total, _block, index) => {
-    if (matches.has(index)) {
-      return total;
-    }
-    const offset = index * signature.blockSize;
-    return total + Math.min(signature.blockSize, signature.fileSize - offset);
-  }, 0);
-  const alignedMatchRatio = signature.blocks.length === 0 ? 1 : matches.size / signature.blocks.length;
-  if (alignedMatchRatio >= 0.8 && alignedMissBytes <= MAX_ALIGNED_MISS_BYTES) {
-    return matches;
+async function matchTrailingPartialBlock(
+  sources: SourceFile[],
+  signature: SeedSignature,
+  matches: Map<number, SeedBlockMatch>,
+): Promise<void> {
+  if (signature.fileSize === 0 || signature.fileSize % signature.blockSize === 0) {
+    return;
   }
+  const index = signature.blocks.length - 1;
+  if (matches.has(index)) {
+    return;
+  }
+  const span = blockSpan(signature, index);
+  const expectedStrongHash = signature.blocks[index]!.s;
+  const block = Buffer.allocUnsafe(span.length);
+  for (const source of sources) {
+    if (source.size < span.length) {
+      continue;
+    }
+    const sourceOffset = source.size - span.length;
+    if (sourceOffset === span.offset) {
+      continue; // The aligned pass already checked this offset.
+    }
+    const handle = await fs.promises.open(source.path, 'r');
+    try {
+      await readExactly(handle, block, span.length, sourceOffset);
+      if (strongHash(block) === expectedStrongHash) {
+        matches.set(index, { sourcePath: source.path, sourceOffset });
+        return;
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+}
 
-  const indexesByLength = new Map<number, number[]>();
+function shouldSkipRollingScan(
+  signature: SeedSignature,
+  matches: ReadonlyMap<number, SeedBlockMatch>,
+): boolean {
+  let missingBytes = 0;
   for (let index = 0; index < signature.blocks.length; index++) {
+    if (!matches.has(index)) {
+      missingBytes += blockSpan(signature, index).length;
+    }
+  }
+  const matchRatio = signature.blocks.length === 0 ? 1 : matches.size / signature.blocks.length;
+  return matchRatio >= 0.8 && missingBytes <= MAX_ALIGNED_MISS_BYTES;
+}
+
+async function matchShiftedFullBlocks(
+  sources: SourceFile[],
+  signature: SeedSignature,
+  matches: Map<number, SeedBlockMatch>,
+): Promise<void> {
+  const fullBlockCount = Math.floor(signature.fileSize / signature.blockSize);
+  const unmatched = new Set<number>();
+  const candidatesByWeak = new Map<number, number[]>();
+  for (let index = 0; index < fullBlockCount; index++) {
     if (matches.has(index)) {
       continue;
     }
-    const offset = index * signature.blockSize;
-    const length = Math.min(signature.blockSize, signature.fileSize - offset);
-    const indexes = indexesByLength.get(length) ?? [];
-    indexes.push(index);
-    indexesByLength.set(length, indexes);
+    unmatched.add(index);
+    const weak = signature.blocks[index]!.w;
+    const candidates = candidatesByWeak.get(weak) ?? [];
+    candidates.push(index);
+    candidatesByWeak.set(weak, candidates);
   }
+  for (const source of sources) {
+    if (unmatched.size === 0) {
+      return;
+    }
+    await scanSourceForFullBlocks(source, candidatesByWeak, signature, matches, unmatched);
+  }
+}
 
-  for (const [blockLength, indexes] of indexesByLength) {
-    // A trailing partial block is worth at most one block of transfer savings.
-    // Avoid a second byte-by-byte scan of the whole APK: check the seed's
-    // expected offset and the end of each source, which cover unchanged layout
-    // and suffix-aligned rebuilds respectively.
-    if (blockLength !== signature.blockSize) {
-      const index = indexes[0]!;
-      const expected = signature.blocks[index]!;
-      for (const sourcePath of sourcePaths) {
-        const stat = await fs.promises.stat(sourcePath).catch(() => undefined);
-        if (!stat?.isFile() || stat.size < blockLength) {
-          continue;
-        }
-        const offsets = new Set([index * signature.blockSize, stat.size - blockLength]);
-        const handle = await fs.promises.open(sourcePath, 'r');
-        try {
-          for (const sourceOffset of offsets) {
-            if (sourceOffset < 0 || sourceOffset + blockLength > stat.size) {
-              continue;
-            }
-            const block = Buffer.allocUnsafe(blockLength);
-            await readExactly(handle, block, blockLength, sourceOffset);
-            if (weakRollingChecksum(block) === expected.w && strongHash(block) === expected.s) {
-              matches.set(index, { sourcePath, sourceOffset });
-              break;
-            }
-          }
-        } finally {
-          await handle.close();
-        }
-        if (matches.has(index)) {
-          break;
-        }
-      }
-      continue;
-    }
-
-    const candidatesByWeak = new Map<number, number[]>();
-    for (const index of indexes) {
-      const weak = signature.blocks[index]!.w;
-      const candidates = candidatesByWeak.get(weak) ?? [];
-      candidates.push(index);
-      candidatesByWeak.set(weak, candidates);
-    }
-    const unmatched = new Set(indexes);
-    for (const sourcePath of sourcePaths) {
-      const stat = await fs.promises.stat(sourcePath).catch(() => undefined);
-      if (!stat?.isFile()) {
-        continue;
-      }
-      await scanSourceForBlockLength(
-        sourcePath,
-        blockLength,
-        candidatesByWeak,
-        signature,
-        matches,
-        unmatched,
-      );
-      if (unmatched.size === 0) {
-        break;
-      }
-    }
+export async function findSeedBlockMatches(
+  sourcePaths: string[],
+  signature: SeedSignature,
+): Promise<Map<number, SeedBlockMatch>> {
+  const sources = await existingSourceFiles(sourcePaths);
+  const matches = new Map<number, SeedBlockMatch>();
+  await matchAlignedBlocks(sources, signature, matches);
+  await matchTrailingPartialBlock(sources, signature, matches);
+  if (!shouldSkipRollingScan(signature, matches)) {
+    await matchShiftedFullBlocks(sources, signature, matches);
   }
   return matches;
 }
@@ -364,9 +386,11 @@ export function missingSeedRanges(
     if (missing && startBlock === undefined) {
       startBlock = index;
     } else if (!missing && startBlock !== undefined) {
+      const first = blockSpan(signature, startBlock);
+      const last = blockSpan(signature, index - 1);
       ranges.push({
-        start: startBlock * signature.blockSize,
-        end: Math.min(signature.fileSize, index * signature.blockSize) - 1,
+        start: first.offset,
+        end: last.offset + last.length - 1,
       });
       startBlock = undefined;
     }
@@ -387,11 +411,10 @@ async function copyMatchedBlocks(
         source = await fs.promises.open(match.sourcePath, 'r');
         sourceHandles.set(match.sourcePath, source);
       }
-      const targetOffset = index * signature.blockSize;
-      const length = Math.min(signature.blockSize, signature.fileSize - targetOffset);
-      const block = Buffer.allocUnsafe(length);
-      await readExactly(source, block, length, match.sourceOffset);
-      await writeExactly(output, block, targetOffset);
+      const span = blockSpan(signature, index);
+      const block = Buffer.allocUnsafe(span.length);
+      await readExactly(source, block, span.length, match.sourceOffset);
+      await writeExactly(output, block, span.offset);
     }
   } finally {
     await Promise.all([...sourceHandles.values()].map((handle) => handle.close()));

--- a/tests/android-basis-cache.test.ts
+++ b/tests/android-basis-cache.test.ts
@@ -6,11 +6,27 @@ import path from 'path';
 import type { AddressInfo } from 'net';
 
 import { bootstrapAndroidBasisCache, type AndroidSyncState } from '../src/internal/android-basis-cache';
+import { type SeedSignature, weakRollingChecksum } from '../src/internal/seed-reconstruct';
 
 const noopLog = () => {};
 
 function sha256Hex(buf: Buffer): string {
   return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function signatureFor(seed: Buffer, blockSize: number): SeedSignature {
+  const blocks = [];
+  for (let offset = 0; offset < seed.byteLength; offset += blockSize) {
+    const block = seed.subarray(offset, Math.min(offset + blockSize, seed.byteLength));
+    blocks.push({ w: weakRollingChecksum(block), s: sha256Hex(block).slice(0, 32) });
+  }
+  return {
+    version: 1,
+    blockSize,
+    fileSize: seed.byteLength,
+    sha256: sha256Hex(seed),
+    blocks,
+  };
 }
 
 function tempDir(): string {
@@ -22,6 +38,7 @@ type TestServer = { url: string; requests: string[]; close: () => Promise<void> 
 async function startServer(
   state: AndroidSyncState,
   seedBodies: Record<string, Buffer> = {},
+  signatures: Record<string, SeedSignature> = {},
 ): Promise<TestServer> {
   const requests: string[] = [];
   const server = http.createServer((req, res) => {
@@ -31,11 +48,29 @@ async function startServer(
       res.end(JSON.stringify(state));
       return;
     }
+    const signatureMatch = req.url?.match(/^\/sync\/seeds\/([0-9a-f]{64})\.sig$/);
+    const signature = signatureMatch ? signatures[signatureMatch[1]!] : undefined;
+    if (signature) {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(signature));
+      return;
+    }
     const match = req.url?.match(/^\/sync\/seeds\/([0-9a-f]{64})$/);
     const body = match ? seedBodies[match[1]!] : undefined;
     if (body) {
-      res.setHeader('content-length', String(body.length));
-      res.end(body);
+      const rangeMatch = /^bytes=(\d+)-(\d+)$/.exec(req.headers.range ?? '');
+      if (rangeMatch) {
+        const start = Number(rangeMatch[1]);
+        const end = Number(rangeMatch[2]);
+        const rangeBody = body.subarray(start, end + 1);
+        res.statusCode = 206;
+        res.setHeader('content-range', `bytes ${start}-${end}/${body.byteLength}`);
+        res.setHeader('content-length', String(rangeBody.length));
+        res.end(rangeBody);
+      } else {
+        res.setHeader('content-length', String(body.length));
+        res.end(body);
+      }
       return;
     }
     res.statusCode = 404;
@@ -117,6 +152,37 @@ describe('bootstrapAndroidBasisCache', () => {
     // Initial (0, expectedSize) announcement, then byte progress ending at the full size.
     expect(progress[0]).toEqual([0, seedBytes.length]);
     expect(progress[progress.length - 1]).toEqual([seedBytes.length, seedBytes.length]);
+  });
+
+  test('reconstructs a basis seed from shifted local APK blocks', async () => {
+    const blockSize = 8;
+    const seedBytes = Buffer.from('abcdefghABCDEFGHijklmnopIJKLMNOP');
+    const insertionOffset = blockSize + 3;
+    const localBytes = Buffer.concat([
+      seedBytes.subarray(0, insertionOffset),
+      Buffer.from('shift'),
+      seedBytes.subarray(insertionOffset),
+    ]);
+    fs.writeFileSync(apkPath, localBytes);
+    const seedSha = sha256Hex(seedBytes);
+    const server = await startServer(
+      { seeds: [{ sha256: seedSha, size: seedBytes.length }] },
+      { [seedSha]: seedBytes },
+      { [seedSha]: signatureFor(seedBytes, blockSize) },
+    );
+    const progress: Array<[number, number]> = [];
+    try {
+      await bootstrapAndroidBasisCache(apkPath, basisCacheDir, server.url, 'tok', noopLog, (done, total) =>
+        progress.push([done, total]),
+      );
+    } finally {
+      await server.close();
+    }
+
+    expect(fs.readFileSync(basisPath)).toEqual(seedBytes);
+    expect(server.requests).toEqual(['/sync/state', `/sync/seeds/${seedSha}.sig`, `/sync/seeds/${seedSha}`]);
+    expect(progress[0]).toEqual([0, blockSize]);
+    expect(progress[progress.length - 1]).toEqual([blockSize, blockSize]);
   });
 
   test('drops a stale local basis when the instance has nothing usable', async () => {

--- a/tests/seed-reconstruct.test.ts
+++ b/tests/seed-reconstruct.test.ts
@@ -1,0 +1,219 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import http from 'http';
+import os from 'os';
+import path from 'path';
+import type { AddressInfo } from 'net';
+
+import {
+  findSeedBlockMatches,
+  missingSeedRanges,
+  reconstructSeedFromLocalFiles,
+  type SeedSignature,
+  weakRollingChecksum,
+} from '../src/internal/seed-reconstruct';
+
+function sha256Hex(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function signatureFor(seed: Buffer, blockSize: number): SeedSignature {
+  const blocks = [];
+  for (let offset = 0; offset < seed.byteLength; offset += blockSize) {
+    const block = seed.subarray(offset, Math.min(seed.byteLength, offset + blockSize));
+    blocks.push({
+      w: weakRollingChecksum(block),
+      s: sha256Hex(block).slice(0, 32),
+    });
+  }
+  return {
+    version: 1,
+    blockSize,
+    fileSize: seed.byteLength,
+    sha256: sha256Hex(seed),
+    blocks,
+  };
+}
+
+function pseudoRandomBytes(length: number): Buffer {
+  const result = Buffer.allocUnsafe(length);
+  let state = 0x12345678;
+  for (let i = 0; i < length; i++) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    result[i] = state >>> 24;
+  }
+  return result;
+}
+
+type SeedServer = {
+  url: string;
+  requests: string[];
+  ranges: string[];
+  close: () => Promise<void>;
+};
+
+async function startSeedServer(seed: Buffer, signature: SeedSignature): Promise<SeedServer> {
+  const requests: string[] = [];
+  const ranges: string[] = [];
+  const server = http.createServer((request, response) => {
+    requests.push(request.url ?? '');
+    if (request.url === '/seed.sig') {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify(signature));
+      return;
+    }
+    if (request.url === '/seed') {
+      const range = request.headers.range;
+      if (!range) {
+        response.setHeader('content-length', seed.byteLength);
+        response.end(seed);
+        return;
+      }
+      const match = /^bytes=(\d+)-(\d+)$/.exec(range);
+      if (!match) {
+        response.statusCode = 416;
+        response.end();
+        return;
+      }
+      const start = Number(match[1]);
+      const end = Number(match[2]);
+      ranges.push(range);
+      const body = seed.subarray(start, end + 1);
+      response.statusCode = 206;
+      response.setHeader('content-range', `bytes ${start}-${end}/${seed.byteLength}`);
+      response.setHeader('content-length', body.byteLength);
+      response.end(body);
+      return;
+    }
+    response.statusCode = 404;
+    response.end('not found');
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    requests,
+    ranges,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function reconstruct(
+  server: SeedServer,
+  signature: SeedSignature,
+  sourcePath: string,
+  outputPath: string,
+  onProgress?: (done: number, total: number) => void,
+) {
+  return await reconstructSeedFromLocalFiles({
+    signatureUrl: `${server.url}/seed.sig`,
+    seedUrl: `${server.url}/seed`,
+    token: 'test-token',
+    sourcePaths: [sourcePath],
+    outputPath,
+    expectedSha256: signature.sha256,
+    ...(onProgress ? { onProgress } : {}),
+  });
+}
+
+describe('seed reconstruction', () => {
+  const blockSize = 64;
+  const seed = pseudoRandomBytes(blockSize * 8);
+  const signature = signatureFor(seed, blockSize);
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-seed-reconstruct-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test('uses the same weak checksum layout as the daemon', () => {
+    // a = 1+2+3 = 6; b = 3*1 + 2*2 + 1*3 = 10.
+    expect(weakRollingChecksum(Buffer.from([1, 2, 3]))).toBe(10 * 0x10000 + 6);
+  });
+
+  test.each([
+    [
+      'inserted',
+      Buffer.concat([
+        seed.subarray(0, blockSize * 2 + 20),
+        Buffer.from('inserted'),
+        seed.subarray(blockSize * 2 + 20),
+      ]),
+    ],
+    ['deleted', Buffer.concat([seed.subarray(0, blockSize * 2 + 20), seed.subarray(blockSize * 2 + 27)])],
+  ])('finds blocks shifted by %s bytes', async (_kind, localBytes) => {
+    const sourcePath = path.join(workDir, 'local.apk');
+    fs.writeFileSync(sourcePath, localBytes);
+
+    const matches = await findSeedBlockMatches([sourcePath], signature);
+
+    expect(matches.size).toBe(7);
+    expect(missingSeedRanges(signature, matches)).toEqual([{ start: blockSize * 2, end: blockSize * 3 - 1 }]);
+  });
+
+  test('reconstructs an identical seed without downloading APK bytes', async () => {
+    const sourcePath = path.join(workDir, 'local.apk');
+    const outputPath = path.join(workDir, 'basis.apk');
+    fs.writeFileSync(sourcePath, seed);
+    const server = await startSeedServer(seed, signature);
+    try {
+      const result = await reconstruct(server, signature, sourcePath, outputPath);
+
+      expect(result).toEqual({ downloadedBytes: 0, totalDownloadBytes: 0, matchedBlocks: 8 });
+      expect(fs.readFileSync(outputPath)).toEqual(seed);
+      expect(server.requests).toEqual(['/seed.sig']);
+      expect(server.ranges).toEqual([]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('downloads only the block containing an insertion', async () => {
+    const insertionOffset = blockSize * 2 + 20;
+    const localBytes = Buffer.concat([
+      seed.subarray(0, insertionOffset),
+      Buffer.from('inserted'),
+      seed.subarray(insertionOffset),
+    ]);
+    const sourcePath = path.join(workDir, 'local.apk');
+    const outputPath = path.join(workDir, 'basis.apk');
+    fs.writeFileSync(sourcePath, localBytes);
+    const progress: Array<[number, number]> = [];
+    const server = await startSeedServer(seed, signature);
+    try {
+      const result = await reconstruct(server, signature, sourcePath, outputPath, (done, total) => {
+        progress.push([done, total]);
+      });
+
+      expect(result.downloadedBytes).toBe(blockSize);
+      expect(result.matchedBlocks).toBe(7);
+      expect(fs.readFileSync(outputPath)).toEqual(seed);
+      expect(server.ranges).toEqual([`bytes=${blockSize * 2}-${blockSize * 3 - 1}`]);
+      expect(progress[0]).toEqual([0, blockSize]);
+      expect(progress[progress.length - 1]).toEqual([blockSize, blockSize]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('coalesces an unrelated file into one full-file range', async () => {
+    const sourcePath = path.join(workDir, 'local.apk');
+    const outputPath = path.join(workDir, 'basis.apk');
+    fs.writeFileSync(sourcePath, Buffer.alloc(seed.byteLength, 0xff));
+    const server = await startSeedServer(seed, signature);
+    try {
+      const result = await reconstruct(server, signature, sourcePath, outputPath);
+
+      expect(result.downloadedBytes).toBe(seed.byteLength);
+      expect(result.matchedBlocks).toBe(0);
+      expect(server.ranges).toEqual([`bytes=0-${seed.byteLength - 1}`]);
+      expect(fs.readFileSync(outputPath)).toEqual(seed);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/tests/seed-reconstruct.test.ts
+++ b/tests/seed-reconstruct.test.ts
@@ -52,7 +52,11 @@ type SeedServer = {
   close: () => Promise<void>;
 };
 
-async function startSeedServer(seed: Buffer, signature: SeedSignature): Promise<SeedServer> {
+async function startSeedServer(
+  seed: Buffer,
+  signature: SeedSignature,
+  servedSeed = seed,
+): Promise<SeedServer> {
   const requests: string[] = [];
   const ranges: string[] = [];
   const server = http.createServer((request, response) => {
@@ -65,8 +69,8 @@ async function startSeedServer(seed: Buffer, signature: SeedSignature): Promise<
     if (request.url === '/seed') {
       const range = request.headers.range;
       if (!range) {
-        response.setHeader('content-length', seed.byteLength);
-        response.end(seed);
+        response.setHeader('content-length', servedSeed.byteLength);
+        response.end(servedSeed);
         return;
       }
       const match = /^bytes=(\d+)-(\d+)$/.exec(range);
@@ -78,7 +82,7 @@ async function startSeedServer(seed: Buffer, signature: SeedSignature): Promise<
       const start = Number(match[1]);
       const end = Number(match[2]);
       ranges.push(range);
-      const body = seed.subarray(start, end + 1);
+      const body = servedSeed.subarray(start, end + 1);
       response.statusCode = 206;
       response.setHeader('content-range', `bytes ${start}-${end}/${seed.byteLength}`);
       response.setHeader('content-length', body.byteLength);
@@ -155,6 +159,42 @@ describe('seed reconstruction', () => {
     expect(missingSeedRanges(signature, matches)).toEqual([{ start: blockSize * 2, end: blockSize * 3 - 1 }]);
   });
 
+  test('uses aligned matches when only a few blocks differ', async () => {
+    const localBytes = Buffer.from(seed);
+    const changedOffset = blockSize * 3 + 5;
+    localBytes[changedOffset] = localBytes[changedOffset]! ^ 0xff;
+    const sourcePath = path.join(workDir, 'local.apk');
+    fs.writeFileSync(sourcePath, localBytes);
+
+    const matches = await findSeedBlockMatches([sourcePath], signature);
+
+    expect(matches.size).toBe(7);
+    expect(missingSeedRanges(signature, matches)).toEqual([{ start: blockSize * 3, end: blockSize * 4 - 1 }]);
+  });
+
+  test('matches a shifted trailing partial block at the source end', async () => {
+    const partialSeed = pseudoRandomBytes(blockSize * 3 + 17);
+    const partialSignature = signatureFor(partialSeed, blockSize);
+    const sourcePath = path.join(workDir, 'local.apk');
+    fs.writeFileSync(sourcePath, Buffer.concat([Buffer.from('shifted'), partialSeed]));
+
+    const matches = await findSeedBlockMatches([sourcePath], partialSignature);
+
+    expect(matches.size).toBe(partialSignature.blocks.length);
+    expect(missingSeedRanges(partialSignature, matches)).toEqual([]);
+  });
+
+  test('coalesces adjacent missing blocks into ranges', () => {
+    const matches = new Map(
+      [0, 1, 4, 5, 7].map((index) => [index, { sourcePath: 'local.apk', sourceOffset: index * blockSize }]),
+    );
+
+    expect(missingSeedRanges(signature, matches)).toEqual([
+      { start: blockSize * 2, end: blockSize * 4 - 1 },
+      { start: blockSize * 6, end: blockSize * 7 - 1 },
+    ]);
+  });
+
   test('reconstructs an identical seed without downloading APK bytes', async () => {
     const sourcePath = path.join(workDir, 'local.apk');
     const outputPath = path.join(workDir, 'basis.apk');
@@ -212,6 +252,23 @@ describe('seed reconstruction', () => {
       expect(result.matchedBlocks).toBe(0);
       expect(server.ranges).toEqual([`bytes=0-${seed.byteLength - 1}`]);
       expect(fs.readFileSync(outputPath)).toEqual(seed);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('rejects a reconstructed seed that fails final SHA-256 verification', async () => {
+    const sourcePath = path.join(workDir, 'local.apk');
+    const outputPath = path.join(workDir, 'basis.apk');
+    fs.writeFileSync(sourcePath, Buffer.alloc(seed.byteLength, 0xff));
+    const corruptedSeed = Buffer.from(seed);
+    corruptedSeed[10] = corruptedSeed[10]! ^ 0xff;
+    const server = await startSeedServer(seed, signature, corruptedSeed);
+    try {
+      await expect(reconstruct(server, signature, sourcePath, outputPath)).rejects.toThrow(
+        'Reconstructed seed SHA-256 mismatch',
+      );
+      expect(fs.existsSync(outputPath)).toBe(false);
     } finally {
       await server.close();
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches APK delta-sync bootstrap and new ranged HTTP reconstruction logic; failures degrade to full download and SHA-256 checks guard output integrity.
> 
> **Overview**
> **Basis cache seeding** no longer always pulls the full instance seed when the local basis is stale. `bootstrapAndroidBasisCache` keeps the stale basis as an extra source, fetches `/sync/seeds/{sha}.sig`, and builds the target seed by reusing matching blocks from the local APK (and stale cache) while **HTTP Range**-downloading only missing byte ranges; reconstruction failure still **falls back** to a full seed download.
> 
> A new **`seed-reconstruct`** module implements signature validation, aligned and rolling weak-hash block matching (including shifted inserts), range coalescing, temp-file assembly, and final SHA-256 verification before replacing the basis file.
> 
> `syncApp`’s **`onBasisDownloadProgress`** docs now describe progress against **required differential bytes**, with totals resetting on full-download fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9853a69a278f77f935ed4d2f42b590713dfc853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->