### PR TITLE
cli: open simulators in browser directly after creation

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.18.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "0.39.8",
+        "@limrun/api": "0.40.0",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.39.8",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.39.8.tgz",
-      "integrity": "sha512-zkSKRLYGn290/fUAVpkxGg4cZuTMMVnJAXvc/UXtnUhOFU72KQJmQgytsx5iV6PE0OveMRmagI1/YThA/hYsgw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.40.0.tgz",
+      "integrity": "sha512-0kglthreWfAdh6vSzNOt0GLKr4Z9WfltMeI3+mxQhPPnWppzpHqAvIqq/flyYR0J6ExTFk+62GehqN8EuDr76w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@limrun/xdelta3-wasm": "0.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.39.8",
+    "@limrun/api": "0.40.0",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -191,6 +191,21 @@ export abstract class BaseCommand extends Command {
     this.output(JSON.stringify(data, null, 2));
   }
 
+  /**
+   * Runs the sibling `list` command (e.g. `ios:list` for `ios get`), forwarding
+   * the base output/auth flags. Used by `get` commands to degrade to a listing
+   * when no ID was given and no recent instance is remembered.
+   */
+  protected async runListFallback(commandId: string): Promise<void> {
+    const flags = this.parsedFlags ?? {};
+    const argv: string[] = [];
+    if (flags['json']) argv.push('--json');
+    if (flags['quiet']) argv.push('--quiet');
+    if (typeof flags['api-key'] === 'string') argv.push('--api-key', flags['api-key'] as string);
+    if (typeof flags['workspace'] === 'string') argv.push('--workspace', flags['workspace'] as string);
+    await this.config.runCommand(commandId, argv);
+  }
+
   protected consoleStreamUrl(instanceId: string): string {
     const baseUrl = readConfig().consoleEndpoint.replace(/\/+$/, '');
     return `${baseUrl}/stream/${instanceId}`;

--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -4,6 +4,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { parseLabels } from '../../lib/formatting';
 import { registerCreatedInstance } from '../../lib/config';
+import { openInBrowser } from '../../lib/browser';
 import { type AndroidInstanceCreateParams } from '@limrun/api/resources/android-instances';
 
 export default class AndroidCreate extends BaseCommand {
@@ -68,6 +69,12 @@ export default class AndroidCreate extends BaseCommand {
       description:
         'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. Defaults to no expiry.',
     }),
+    open: Flags.boolean({
+      description:
+        'Open the signed stream URL in your browser once the instance is ready. Use --no-open to skip.',
+      default: true,
+      allowNo: true,
+    }),
   };
 
   async run(): Promise<void> {
@@ -128,6 +135,12 @@ export default class AndroidCreate extends BaseCommand {
       this.info(`Console URL: ${this.consoleStreamUrl(instance.metadata.id)}`);
       if (signedStreamUrl) {
         this.info(`Signed Stream URL: ${signedStreamUrl}`);
+      }
+
+      if (flags.open && signedStreamUrl && !this.shouldSuppressInfo()) {
+        if (await openInBrowser(signedStreamUrl)) {
+          this.info('Opened the stream in your browser.');
+        }
       }
 
       if (flags.rm) {

--- a/packages/cli/src/commands/android/get.ts
+++ b/packages/cli/src/commands/android/get.ts
@@ -1,15 +1,17 @@
 import { Args } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
+import { loadLastAndroidInstance } from '../../lib/config';
 
 export default class AndroidGet extends BaseCommand {
   static summary = 'Get details for a specific Android instance';
   static description =
-    'Fetch detailed metadata for a single Android instance, including region, state, and display name. Use `--json` to inspect the full API response.';
+    'Fetch detailed metadata for a single Android instance, including region, state, and display name. Falls back to listing all Android instances when no ID is given and no recent instance is remembered. Use `--json` to inspect the full API response.';
   static examples = ['<%= config.bin %> android get', '<%= config.bin %> android get <ID> --json'];
 
   static args = {
     id: Args.string({
-      description: 'Android instance ID to fetch. Defaults to the last created Android instance.',
+      description:
+        'Android instance ID to fetch. Defaults to the last created Android instance; lists all instances when none is remembered.',
       required: false,
     }),
   };
@@ -19,6 +21,12 @@ export default class AndroidGet extends BaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(AndroidGet);
     this.setParsedFlags(flags);
+
+    if (!args.id && !loadLastAndroidInstance()) {
+      this.info('No recent Android instance found. Listing Android instances instead.');
+      await this.runListFallback('android:list');
+      return;
+    }
 
     await this.withAuth(async () => {
       const resolvedInstance = this.resolveAndroidInstance(args.id);

--- a/packages/cli/src/commands/asset/list.ts
+++ b/packages/cli/src/commands/asset/list.ts
@@ -4,11 +4,11 @@ import { BaseCommand } from '../../base-command';
 export default class AssetList extends BaseCommand {
   static summary = 'List assets or get a specific one';
   static description =
-    'List uploaded assets in your account or fetch a single asset by ID. You can optionally include signed download or upload URLs when preparing follow-up automation steps.';
-  static aliases = ['assets:list'];
+    'List uploaded assets in your account or fetch a single asset by ID. You can optionally include signed download or upload URLs when preparing follow-up automation steps. Also available as `asset get`.';
+  static aliases = ['assets:list', 'asset:get'];
   static examples = [
     '<%= config.bin %> asset list',
-    '<%= config.bin %> asset list <ID>',
+    '<%= config.bin %> asset get <ID>',
     '<%= config.bin %> asset list --name MyApp --download-url',
     '<%= config.bin %> asset list --name-prefix builds/',
     '<%= config.bin %> asset list --include-app-store',

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -3,6 +3,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { parseLabels } from '../../lib/formatting';
 import { registerCreatedInstance } from '../../lib/config';
+import { openInBrowser } from '../../lib/browser';
 import { xcodeSandboxIdFromUrl } from '../../lib/xcode-sandbox';
 import { formatSimulatorAttachResult, simulatorAttachJson } from '../../lib/simulator-attach';
 import { formatDurationMs } from '../../lib/duration';
@@ -94,6 +95,12 @@ export default class IosCreate extends BaseCommand {
     attach: Flags.boolean({
       description: 'Attach the created simulator to an existing Xcode target',
       default: false,
+    }),
+    open: Flags.boolean({
+      description:
+        'Open the signed stream URL in your browser once the instance is ready. Use --no-open to skip.',
+      default: true,
+      allowNo: true,
     }),
   };
 
@@ -252,6 +259,12 @@ export default class IosCreate extends BaseCommand {
           this.info(`Attach/install completed in ${formatDurationMs(attachDurationMs)}.`);
         }
         this.info(formatSimulatorAttachResult(instance.metadata.id, attachTarget.id, attachResult));
+      }
+
+      if (flags.open && signedStreamUrl && !this.shouldSuppressInfo()) {
+        if (await openInBrowser(signedStreamUrl)) {
+          this.info('Opened the stream in your browser.');
+        }
       }
 
       if (flags.json) {

--- a/packages/cli/src/commands/ios/get.ts
+++ b/packages/cli/src/commands/ios/get.ts
@@ -1,15 +1,17 @@
 import { Args } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
+import { loadLastIosInstance } from '../../lib/config';
 
 export default class IosGet extends BaseCommand {
   static summary = 'Get details for a specific iOS instance';
   static description =
-    'Fetch detailed metadata for a single iOS instance, including region, state, and display name. Use `--json` to inspect the full API response.';
+    'Fetch detailed metadata for a single iOS instance, including region, state, and display name. Falls back to listing all iOS instances when no ID is given and no recent instance is remembered. Use `--json` to inspect the full API response.';
   static examples = ['<%= config.bin %> ios get', '<%= config.bin %> ios get <ID> --json'];
 
   static args = {
     id: Args.string({
-      description: 'iOS instance ID to fetch. Defaults to the last created iOS instance.',
+      description:
+        'iOS instance ID to fetch. Defaults to the last created iOS instance; lists all instances when none is remembered.',
       required: false,
     }),
   };
@@ -19,6 +21,12 @@ export default class IosGet extends BaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(IosGet);
     this.setParsedFlags(flags);
+
+    if (!args.id && !loadLastIosInstance()) {
+      this.info('No recent iOS instance found. Listing iOS instances instead.');
+      await this.runListFallback('ios:list');
+      return;
+    }
 
     await this.withAuth(async () => {
       const resolvedInstance = this.resolveIosInstance(args.id);

--- a/packages/cli/src/commands/xcode/get.ts
+++ b/packages/cli/src/commands/xcode/get.ts
@@ -1,16 +1,18 @@
 import { Args } from '@oclif/core';
 import { type SimulatorBuildStatus, type SimulatorStatus } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
+import { loadLastXcodeInstance } from '../../lib/config';
 
 export default class XcodeGet extends BaseCommand {
   static summary = 'Get details for a specific Xcode instance';
   static description =
-    'Fetch detailed metadata for a single Xcode sandbox instance, including region, state, and display name. Use `--json` to inspect the full API response.';
+    'Fetch detailed metadata for a single Xcode sandbox instance, including region, state, and display name. Falls back to listing all Xcode instances when no ID is given and no recent target is remembered. Use `--json` to inspect the full API response.';
   static examples = ['<%= config.bin %> xcode get', '<%= config.bin %> xcode get <ID> --json'];
 
   static args = {
     id: Args.string({
-      description: 'Xcode instance ID to fetch. Defaults to the last created Xcode target.',
+      description:
+        'Xcode instance ID to fetch. Defaults to the last created Xcode target; lists all instances when none is remembered.',
       required: false,
     }),
   };
@@ -20,6 +22,12 @@ export default class XcodeGet extends BaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(XcodeGet);
     this.setParsedFlags(flags);
+
+    if (!args.id && !loadLastXcodeInstance()) {
+      this.info('No recent Xcode target found. Listing Xcode instances instead.');
+      await this.runListFallback('xcode:list');
+      return;
+    }
 
     await this.withAuth(async () => {
       const target = await this.resolveXcodeTarget(args.id);

--- a/packages/cli/src/lib/browser.ts
+++ b/packages/cli/src/lib/browser.ts
@@ -1,0 +1,18 @@
+/**
+ * Best-effort open of a URL in the user's default browser. Returns false
+ * instead of throwing when the browser cannot be launched (e.g. headless
+ * environments), so callers can fall back to just printing the URL.
+ */
+export async function openInBrowser(url: string): Promise<boolean> {
+  try {
+    // Dynamic ESM import because `open` is ESM-only and the CLI compiles to CJS.
+    const importEsm = new Function('specifier', 'return import(specifier)') as (
+      specifier: string,
+    ) => Promise<typeof import('open')>;
+    const { default: open } = await importEsm('open');
+    await open(url);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI UX and dependency bump only; browser launch is best-effort with no change to auth or instance lifecycle beyond optional auto-open.
> 
> **Overview**
> **iOS and Android `create`** now open the signed stream URL in the default browser once the instance is ready, via a new **`--open`** flag (on by default; use **`--no-open`** to skip). A small **`openInBrowser`** helper loads the ESM `open` package from CJS and fails silently in headless environments so URLs are still printed.
> 
> **`ios get`**, **`android get`**, and **`xcode get`** no longer error when there is no ID and no remembered instance—they print a short message and run the matching **`list`** command, with **`runListFallback`** on **`BaseCommand`** forwarding **`--json`**, **`--quiet`**, **`--api-key`**, and **`--workspace`**.
> 
> **`asset list`** gains the **`asset:get`** alias and doc tweaks. **`@limrun/api`** is bumped to **0.40.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4334ba6a12db92f25e64ddc4d1ea86086d41fad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->