### PR TITLE
cli: do not auto-create an instance on get

### DIFF
--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -513,7 +513,9 @@ export abstract class BaseCommand extends Command {
     if (!['ios', 'android', 'xcode', 'gradle'].includes(noun)) {
       return false;
     }
-    if (['create', 'delete', 'list'].includes(verb)) {
+    // `get` is a read: reporting that a remembered instance is gone is the
+    // right answer, not silently creating (and billing) a replacement.
+    if (['create', 'delete', 'list', 'get'].includes(verb)) {
       return false;
     }
     return true;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single guard change in shared auth/retry logic; reduces surprise billing on read-only `get` with no security or data-path impact.
> 
> **Overview**
> **`lim * get` no longer auto-creates a replacement** when the remembered instance returns 404. `shouldAutoCreateOnNotFound()` in `base-command.ts` now treats `get` like `create`, `delete`, and `list`: local cache/daemon cleanup still runs, but the command fails with the existing “instance was not found” message instead of provisioning (and billing) a new instance.
> 
> Mutating commands that resolve a missing instance can still auto-replace when `--create` is enabled (default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65053af41208790e4ed68e18046245c9f099d75b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->