### PR TITLE
ui: add generic media receiver to cover android as well

### DIFF
--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -18,6 +18,7 @@ import {
   createSetClipboardMessage,
   createTwoFingerTouchControlMessage,
 } from '../core/webrtc-messages';
+import { getMediaRelaySupport } from '../core/media-relay';
 import { AxFetcher, AxStatus } from '../core/ax-fetcher';
 import { AxElement, AxSnapshot, axElementAtPoint, axSnapshotsEqual } from '../core/ax-tree';
 import { InspectOverlay, InspectOverlayGeometry, InspectMode } from './inspect-overlay';
@@ -155,19 +156,18 @@ interface RemoteControlProps {
   axMaxBackoffMs?: number;
 
   /**
-   * Fires whenever the iOS simulator's camera demand state changes —
-   * i.e. an app inside the sim called
-   * `[AVCaptureSession startRunning]` or `[stopRunning]`. The
+   * Fires whenever an app inside the remote device starts or stops
+   * demanding camera frames. The
    * component handles the `navigator.mediaDevices.getUserMedia` prompt
    * and SDP plumbing internally; this callback is purely so the host
-   * UI can render a status indicator ("simulator is using your
+   * UI can render a status indicator ("device is using your
    * camera", etc.).
    *
-   * `active` reflects whether the sim is currently asking for
+   * `active` reflects whether the remote device is currently asking for
    * frames. `granted` is set only on the call that follows a
    * `getUserMedia` attempt: `true` when the user accepted the
    * browser prompt, `false` when they denied or the call failed
-   * (in which case the limulator side switches to a black-frame
+   * (in which case the remote side switches to a black-frame
    * fallback so the app keeps ticking).
    *
    * `camera` (optional, only meaningful when `granted === true`)
@@ -175,9 +175,6 @@ interface RemoteControlProps {
    * active capture: resolution, framerate, device label, facing
    * mode. Use it to render a richer status indicator (e.g.
    * "Camera · 1920×1080 · 30 fps · FaceTime HD").
-   *
-   * Only iOS instances ever fire this callback; Android instances
-   * have no camera-injector path and stay silent.
    */
   onCameraDemandChange?: (active: boolean, granted?: boolean, camera?: CameraCaptureInfo) => void;
 
@@ -190,7 +187,7 @@ interface RemoteControlProps {
    * decide whether to show "Bandwidth limited" or "CPU limited"
    * banners).
    *
-   * Only fires while the simulator is actively pulling the
+   * Only fires while the remote device is actively pulling the
    * camera AND `getUserMedia` was granted. `null` is emitted
    * once when the stream goes back to idle so consumers can
    * clear their UI without having to maintain their own
@@ -205,7 +202,7 @@ interface RemoteControlProps {
    * - `'auto'` (default): no extra constraint. The browser captures
    *   at its webcam's native max; WebRTC's quality scaler may step
    *   down resolution on the encoder side under bandwidth pressure
-   *   while still feeding the simulator at the pool's native size.
+   *   while still feeding the remote camera surface at its native size.
    * - `'1080p'` / `'720p'` / `'480p'`: hard cap applied via
    *   `getUserMedia` constraints (for new captures) and
    *   `track.applyConstraints` (for the currently-active track),
@@ -253,7 +250,7 @@ export type CameraAspect = '16:9' | '4:3' | '1:1' | '9:16';
 /**
  * Snapshot of the browser's webcam capture, mirrored from
  * `MediaStreamTrack.getSettings()`. Forwarded to the host alongside
- * `cameraResult` and exposed to the host app via
+ * `mediaResult` and exposed to the host app via
  * `onCameraDemandChange` so it can render a status indicator without
  * having to call `getStats()` itself.
  */
@@ -542,10 +539,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // Mirrored to a ref so stale closures in event handlers see the latest value.
     const autoReconnectRef = useRef(autoReconnect);
     autoReconnectRef.current = autoReconnect;
-    // Demand-driven outbound camera state.
-    //
-    // The limulator side broadcasts a `cameraRequest` WS message whenever
-    // an app inside the simulator opens/closes an `AVCaptureSession`.
+    // Demand-driven outbound camera state. All capable servers use the
+    // versioned `mediaRequest` protocol.
     // We respond by calling `navigator.mediaDevices.getUserMedia(...)`
     // and `replaceTrack`ing the result onto a pre-allocated sendonly
     // video transceiver. Pre-allocating the transceiver lets us
@@ -560,7 +555,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // green light.
     const outboundCameraSenderRef = useRef<RTCRtpSender | null>(null);
     const outboundLocalStreamRef = useRef<MediaStream | null>(null);
-    // Bumped on every `cameraRequest` so a handler suspended on an
+    // Bumped on every camera demand update so a handler suspended on an
     // await (e.g. the getUserMedia prompt) can detect it was superseded
     // by a newer request and bail instead of re-attaching the camera.
     const cameraRequestGenerationRef = useRef(0);
@@ -1842,6 +1837,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       // Drop any active outbound camera before the PC dies so the
       // browser doesn't leave the camera indicator lit between
       // reconnects.
+      cameraRequestGenerationRef.current += 1;
       stopCameraStatsPoller();
       stopOutboundLocalStream();
       outboundCameraSenderRef.current = null;
@@ -2107,7 +2103,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         };
 
         // Request RTCConfiguration
-        const rtcConfigPromise = new Promise<RTCConfiguration>((resolve, reject) => {
+        const rtcConfigPromise = new Promise<{
+          rtcConfiguration: RTCConfiguration;
+          relaySupport: ReturnType<typeof getMediaRelaySupport>;
+        }>((resolve, reject) => {
           const timeoutId = window.setTimeout(() => reject(new Error('RTCConfiguration timeout')), 30000);
 
           const messageHandler = (event: MessageEvent) => {
@@ -2116,7 +2115,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               if (message.type === 'rtcConfiguration') {
                 window.clearTimeout(timeoutId);
                 ws.removeEventListener('message', messageHandler);
-                resolve(message.rtcConfiguration);
+                resolve({
+                  rtcConfiguration: message.rtcConfiguration,
+                  relaySupport: getMediaRelaySupport(message),
+                });
               }
             } catch (e) {
               window.clearTimeout(timeoutId);
@@ -2135,10 +2137,15 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           );
         });
 
-        const rtcConfig = await rtcConfigPromise;
+        const { rtcConfiguration: rtcConfig, relaySupport } = await rtcConfigPromise;
         if (!isCurrentAttempt() || wsRef.current !== ws) {
           return;
         }
+        // eslint-disable-next-line no-console
+        console.info('[RemoteControl] media relay capabilities', {
+          platform,
+          camera: relaySupport.camera,
+        });
 
         const peerConnection = new RTCPeerConnection(rtcConfig);
         peerConnectionRef.current = peerConnection;
@@ -2152,10 +2159,11 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         // `AVCaptureSession` — the codec/SSRC negotiation happens
         // once, here, and turning the camera on/off later is just a
         // `replaceTrack`.
-        // iOS only: Android has no camera consumer, and the extra
-        // m=video line crashes Android 14's scrcpy/libwebrtc.
+        // Camera transport is platform-neutral: every server must explicitly
+        // advertise the versioned relay capability before we add the extra
+        // sendonly m=video section.
         const outboundCameraTransceiver =
-          platform === 'ios' ?
+          relaySupport.camera ?
             peerConnection.addTransceiver('video', {
               direction: 'sendonly',
             })
@@ -2440,6 +2448,39 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           }
         };
 
+        let videoResult: {
+          granted: boolean;
+          width?: number;
+          height?: number;
+          camera?: CameraCaptureInfo;
+        } = { granted: false };
+
+        const sendMediaResult = (
+          granted: boolean,
+          camera?: CameraCaptureInfo,
+        ) => {
+          videoResult = {
+            granted,
+            ...(camera ?
+              {
+                width: camera.width,
+                height: camera.height,
+                camera,
+              }
+            : {}),
+          };
+          if (wsRef.current !== ws || ws.readyState !== WebSocket.OPEN) {
+            return;
+          }
+          ws.send(
+            JSON.stringify({
+              type: 'mediaResult',
+              version: 1,
+              video: videoResult,
+            }),
+          );
+        };
+
         // Handle incoming messages
         ws.onmessage = async (event) => {
           if (!isCurrentAttempt() || wsRef.current !== ws) {
@@ -2543,16 +2584,27 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               pendingScreenshotResolversRef.current.delete(message.id);
               pendingScreenshotRejectersRef.current.delete(message.id);
               break;
-            case 'cameraRequest': {
-              // Only iOS sessions allocate the sendonly outbound-camera
-              // transceiver; without it there is nothing to feed the sim, so
-              // ignore camera requests entirely — no getUserMedia prompt and
-              // no onCameraDemandChange callbacks. Android intentionally stays
-              // silent, as the API docs promise.
-              if (platform !== 'ios' || !outboundCameraSenderRef.current) {
+            case 'mediaRequest': {
+              // eslint-disable-next-line no-console
+              console.info('[RemoteControl] mediaRequest received', {
+                video: message.video,
+                cameraRelay: relaySupport.camera,
+                hasCameraSender: outboundCameraSenderRef.current !== null,
+              });
+              if (
+                !relaySupport.camera ||
+                typeof message.video !== 'boolean' ||
+                !outboundCameraSenderRef.current
+              ) {
                 break;
               }
-              const active = message.active === true;
+              const active = message.video === true;
+              const sendVideoResult = (
+                granted: boolean,
+                camera?: CameraCaptureInfo,
+              ) => {
+                sendMediaResult(granted, camera);
+              };
               // Bump up front so any earlier in-flight handler bails.
               const cameraGeneration = ++cameraRequestGenerationRef.current;
               const isCurrentCameraRequest = () =>
@@ -2561,12 +2613,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 cameraGeneration === cameraRequestGenerationRef.current;
               // Log unconditionally — this is one of the few places we
               // hand control to the browser's permission UI, and a
-              // silent failure here looks identical to "limulator
+              // silent failure here looks identical to "the remote device
               // never asked" from the user's point of view.
               // eslint-disable-next-line no-console
-              console.info('[RemoteControl] cameraRequest received, active=', active);
+              console.info('[RemoteControl] camera media demand active=', active);
               if (!active) {
-                // Sim no longer wants frames. Drop our local track and
+                // The device no longer wants frames. Drop our local track and
                 // shut the browser's camera green light off.
                 const sender = outboundCameraSenderRef.current;
                 if (sender) {
@@ -2578,12 +2630,13 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 }
                 stopCameraStatsPoller();
                 stopOutboundLocalStream();
+                sendVideoResult(false);
                 safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, false);
                 break;
               }
               // Sim is asking for camera. Ask the browser; the user's
               // prompt response is reported back to the host via a
-              // `cameraResult` message so it can swap to a
+              // `mediaResult` message so it can swap to a
               // black-frame fallback on denial.
               safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, true);
               if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
@@ -2595,9 +2648,9 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 console.warn(
                   '[RemoteControl] navigator.mediaDevices.getUserMedia unavailable. ' +
                     'getUserMedia requires a secure context (https or http://localhost). ' +
-                    'Replying cameraResult granted=false so limulator falls back to black frames.',
+                    'Replying mediaResult video.granted=false so the server falls back to black frames.',
                 );
-                ws.send(JSON.stringify({ type: 'cameraResult', granted: false }));
+                sendVideoResult(false);
                 safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, true, false);
                 break;
               }
@@ -2627,12 +2680,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 return;
               }
               if (!stream) {
-                ws.send(JSON.stringify({ type: 'cameraResult', granted: false }));
+                sendVideoResult(false);
                 safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, true, false);
                 break;
               }
-              // Replace any previous local stream (e.g. an earlier
-              // cameraRequest that resolved with a different device)
+              // Replace any previous local stream (e.g. an earlier media
+              // request that resolved with a different device)
               // before we install the new tracks.
               stopOutboundLocalStream();
               outboundLocalStreamRef.current = stream;
@@ -2641,7 +2694,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               if (!sender || !videoTrack) {
                 if (stream) stopMediaStream(stream);
                 outboundLocalStreamRef.current = null;
-                ws.send(JSON.stringify({ type: 'cameraResult', granted: false }));
+                sendVideoResult(false);
                 safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, true, false);
                 break;
               }
@@ -2651,7 +2704,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 debugWarn('replaceTrack(videoTrack) failed:', err);
                 stopMediaStream(stream);
                 outboundLocalStreamRef.current = null;
-                ws.send(JSON.stringify({ type: 'cameraResult', granted: false }));
+                sendVideoResult(false);
                 safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, true, false);
                 break;
               }
@@ -2741,7 +2794,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 stopCameraStatsPoller();
                 stopOutboundLocalStream();
                 if (wsRef.current === ws && ws.readyState === WebSocket.OPEN) {
-                  ws.send(JSON.stringify({ type: 'cameraResult', granted: false }));
+                  sendVideoResult(false);
                 }
                 safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, true, false);
               };
@@ -2759,16 +2812,9 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
                 }
                 return;
               }
-              ws.send(
-                JSON.stringify({
-                  type: 'cameraResult',
-                  granted: true,
-                  // Forward what the browser actually captured so the
-                  // host can size its IOSurface pool, log the device,
-                  // and (eventually) surface a status pill / picker.
-                  camera: cameraMetadata,
-                }),
-              );
+              // Forward what the browser actually captured so the remote
+              // side can size its surface and log the selected device.
+              sendVideoResult(true, cameraMetadata);
               safeInvoke('onCameraDemandChange', onCameraDemandChangeRef.current, true, true, cameraMetadata);
               // Kick off the per-second outbound stats sampler. We do
               // this *after* `setParameters` so the first sample

--- a/packages/ui/src/core/media-relay.test.ts
+++ b/packages/ui/src/core/media-relay.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMediaRelaySupport } from './media-relay';
+
+describe('getMediaRelaySupport', () => {
+  it('enables only an explicitly versioned camera capability', () => {
+    expect(
+      getMediaRelaySupport({
+        rtcConfiguration: { iceServers: [] },
+        capabilities: {
+          cameraRelay: { version: 1 },
+        },
+      }),
+    ).toEqual({ camera: true });
+  });
+
+  it('keeps legacy responses on the receive-only SDP shape', () => {
+    expect(getMediaRelaySupport({ rtcConfiguration: { iceServers: [] } })).toEqual({
+      camera: false,
+    });
+    expect(
+      getMediaRelaySupport({
+        rtcConfiguration: { iceServers: [] },
+        capabilities: { cameraRelay: true },
+      }),
+    ).toEqual({ camera: false });
+  });
+
+  it('accepts a camera capability directly on rtcConfiguration', () => {
+    expect(
+      getMediaRelaySupport({
+        rtcConfiguration: {
+          iceServers: [],
+          cameraRelay: { version: 1 },
+        },
+      }),
+    ).toEqual({ camera: true });
+  });
+});

--- a/packages/ui/src/core/media-relay.ts
+++ b/packages/ui/src/core/media-relay.ts
@@ -1,0 +1,30 @@
+type UnknownRecord = Record<string, unknown>;
+
+export interface MediaRelaySupport {
+  camera: boolean;
+}
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const supportsVersionOne = (value: unknown): boolean => isRecord(value) && value.version === 1;
+
+/**
+ * Reads the platform-neutral camera relay capability from an
+ * rtcConfiguration response. Servers that omit or version-mismatch the
+ * capability keep the legacy receive-only SDP shape.
+ */
+export const getMediaRelaySupport = (response: unknown): MediaRelaySupport => {
+  if (!isRecord(response)) {
+    return { camera: false };
+  }
+  const rtcConfiguration = isRecord(response.rtcConfiguration) ? response.rtcConfiguration : undefined;
+  const capabilitySources = [
+    isRecord(response.capabilities) ? response.capabilities : undefined,
+    isRecord(rtcConfiguration?.capabilities) ? rtcConfiguration.capabilities : undefined,
+    rtcConfiguration,
+  ];
+  return {
+    camera: capabilitySources.some((capabilities) => supportsVersionOne(capabilities?.cameraRelay)),
+  };
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,11 @@
 export { RemoteControl } from './components/remote-control';
-export type { RemoteControlHandle } from './components/remote-control';
+export type {
+  CameraAspect,
+  CameraCaptureInfo,
+  CameraResolutionCap,
+  CameraStreamStats,
+  RemoteControlHandle,
+} from './components/remote-control';
 
 // Accessibility / inspect-mode types and helpers. Exported so customers can
 // build their own side panels, search UIs, or agent-driven inspectors on top

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -118,6 +118,15 @@ export type InstanceClient = {
    */
   playOnMicrophone: (path: string, options?: PlayOnMicrophoneOptions) => Promise<PlayOnMicrophoneResult>;
   /**
+   * Use an absolute on-device MP4 path as synchronized camera and microphone
+   * input. Playback loops unless `once` is true.
+   */
+  setMediaInput: (path: string, options?: MediaInputOptions) => Promise<MediaInputResult>;
+  /**
+   * Clear combined MP4 input and resume any demanded live browser media.
+   */
+  clearMediaInput: () => Promise<void>;
+  /**
    * Set Android Wi-Fi bandwidth limits in Kbps. Omit a direction to leave it unchanged;
    * pass `0` to clear that direction's limit.
    */
@@ -348,6 +357,22 @@ export type PlayOnMicrophoneResult = {
   generation: number;
 };
 
+export type MediaInputOptions = {
+  once?: boolean;
+};
+
+export type MediaInputResult = {
+  path: string;
+  /** Common media duration in microseconds. */
+  duration: number;
+  once: boolean;
+  generation: number;
+  width: number;
+  height: number;
+  /** Whether the MP4 contains an audio track; absent audio produces silence. */
+  hasAudio: boolean;
+};
+
 export type WifiBandwidthOptions = {
   downKbps?: number;
   upKbps?: number;
@@ -449,6 +474,20 @@ type PlayOnMicrophoneResultMessage = {
   error?: CommandError;
 };
 
+type SetMediaInputResultMessage = {
+  type: 'setMediaInputResult';
+  id: string;
+  payload?: MediaInputResult;
+  error?: CommandError;
+};
+
+type ClearMediaInputResultMessage = {
+  type: 'clearMediaInputResult';
+  id: string;
+  payload?: EmptyCommandResult;
+  error?: CommandError;
+};
+
 type SetWifiBandwidthResultMessage = {
   type: 'setWifiBandwidthResult';
   id: string;
@@ -481,6 +520,8 @@ type KnownCommandResultMessage =
   | ScrollElementResultMessage
   | OpenUrlResultMessage
   | PlayOnMicrophoneResultMessage
+  | SetMediaInputResultMessage
+  | ClearMediaInputResultMessage
   | SetWifiBandwidthResultMessage
   | StartVideoRecordingResultMessage
   | StopVideoRecordingResultMessage;
@@ -503,6 +544,8 @@ type CommandRequestMap = {
   scrollElement: AndroidElementTarget & { direction: ScrollDirection; amount?: number };
   openUrl: { url: string };
   playOnMicrophone: { path: string; once?: boolean };
+  setMediaInput: { path: string; once?: boolean };
+  clearMediaInput: {};
   setWifiBandwidth: WifiBandwidthOptions;
   startRecording: { quality?: RecordingQuality };
   stopRecording: { upload?: { presignedUrl: string } };
@@ -519,6 +562,8 @@ type CommandResultMap = {
   scrollElement: ScrollResult;
   openUrl: OpenUrlResult;
   playOnMicrophone: PlayOnMicrophoneResult;
+  setMediaInput: MediaInputResult;
+  clearMediaInput: EmptyCommandResult;
   setWifiBandwidth: EmptyCommandResult;
   startRecording: EmptyCommandResult;
   stopRecording: EmptyCommandResult;
@@ -686,6 +731,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         case 'scrollElementResult':
         case 'openUrlResult':
         case 'playOnMicrophoneResult':
+        case 'setMediaInputResult':
+        case 'clearMediaInputResult':
         case 'setWifiBandwidthResult':
         case 'startRecordingResult':
         case 'stopRecordingResult':
@@ -927,6 +974,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             scrollElement,
             openUrl,
             playOnMicrophone,
+            setMediaInput,
+            clearMediaInput,
             setWifiBandwidth,
             startRecording,
             stopRecording,
@@ -1032,6 +1081,26 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         path: inputPath,
         ...(microphoneOptions?.once === undefined ? {} : { once: microphoneOptions.once }),
       });
+    };
+
+    const setMediaInput = async (
+      inputPath: string,
+      mediaOptions?: MediaInputOptions,
+    ): Promise<MediaInputResult> => {
+      if (!inputPath) {
+        throw new Error('path must be a non-empty string');
+      }
+      if (!path.posix.isAbsolute(inputPath)) {
+        throw new Error('path must be an absolute on-device path');
+      }
+      return sendRequest('setMediaInput', {
+        path: inputPath,
+        ...(mediaOptions?.once === undefined ? {} : { once: mediaOptions.once }),
+      });
+    };
+
+    const clearMediaInput = async (): Promise<void> => {
+      await sendRequest('clearMediaInput', {});
     };
 
     const setWifiBandwidth = async (bandwidthOptions: WifiBandwidthOptions): Promise<void> => {

--- a/tests/instance-client-media-input.test.ts
+++ b/tests/instance-client-media-input.test.ts
@@ -1,0 +1,135 @@
+const sentMessages: Record<string, unknown>[] = [];
+
+jest.mock('ws', () => {
+  const { EventEmitter } = require('events');
+
+  class MockWebSocket extends EventEmitter {
+    static CONNECTING = 0;
+    static OPEN = 1;
+
+    readyState = MockWebSocket.OPEN;
+
+    constructor() {
+      super();
+      process.nextTick(() => this['emit']('open'));
+    }
+
+    send(data: string, callback?: (err?: Error) => void): void {
+      const message = JSON.parse(data);
+      sentMessages.push(message);
+      if (message.type === 'setMediaInput') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'setMediaInputResult',
+                id: message.id,
+                payload: {
+                  path: message.path,
+                  duration: 4_200_000,
+                  once: message.once ?? false,
+                  generation: 7,
+                  width: 1280,
+                  height: 720,
+                  hasAudio: true,
+                },
+              }),
+            ),
+          );
+        });
+      } else if (message.type === 'clearMediaInput') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'clearMediaInputResult',
+                id: message.id,
+                payload: {},
+              }),
+            ),
+          );
+        });
+      }
+      callback?.();
+    }
+
+    ping(): void {}
+
+    close(): void {
+      this.readyState = 3;
+      this['emit']('close');
+    }
+  }
+
+  return { WebSocket: MockWebSocket };
+});
+
+describe('Android combined media input', () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+  });
+
+  it('serializes setMediaInput and resolves its typed result payload', async () => {
+    const { createInstanceClient } = await import('../src/instance-client');
+    const client = await createInstanceClient({
+      apiUrl: 'https://example.test/v1/android_123/api',
+      token: 'token',
+      logLevel: 'none',
+    });
+
+    const result = await client.setMediaInput('/data/local/tmp/camera.mp4', { once: true });
+
+    expect(sentMessages.find((message) => message['type'] === 'setMediaInput')).toMatchObject({
+      type: 'setMediaInput',
+      path: '/data/local/tmp/camera.mp4',
+      once: true,
+      payload: {
+        path: '/data/local/tmp/camera.mp4',
+        once: true,
+      },
+    });
+    expect(result).toEqual({
+      path: '/data/local/tmp/camera.mp4',
+      duration: 4_200_000,
+      once: true,
+      generation: 7,
+      width: 1280,
+      height: 720,
+      hasAudio: true,
+    });
+    client.disconnect();
+  });
+
+  it('serializes clearMediaInput and resolves void', async () => {
+    const { createInstanceClient } = await import('../src/instance-client');
+    const client = await createInstanceClient({
+      apiUrl: 'https://example.test/v1/android_123/api',
+      token: 'token',
+      logLevel: 'none',
+    });
+
+    await expect(client.clearMediaInput()).resolves.toBeUndefined();
+    expect(sentMessages.find((message) => message['type'] === 'clearMediaInput')).toMatchObject({
+      type: 'clearMediaInput',
+    });
+    client.disconnect();
+  });
+
+  it('rejects relative media paths before sending', async () => {
+    const { createInstanceClient } = await import('../src/instance-client');
+    const client = await createInstanceClient({
+      apiUrl: 'https://example.test/v1/android_123/api',
+      token: 'token',
+      logLevel: 'none',
+    });
+    sentMessages.length = 0;
+
+    await expect(client.setMediaInput('relative.mp4')).rejects.toThrow(
+      'path must be an absolute on-device path',
+    );
+    expect(sentMessages).toEqual([]);
+    client.disconnect();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes WebRTC SDP shape and signaling for camera relay—servers must advertise v1 capability and speak the new messages or clients stay on legacy receive-only behavior. Android MP4 media input is new surface area on the control WebSocket.
> 
> **Overview**
> **RemoteControl** no longer gates outbound camera WebRTC on `platform === 'ios'`. It reads **`cameraRelay: { version: 1 }`** from the `rtcConfiguration` response via new **`getMediaRelaySupport`**, and only then adds the extra sendonly video transceiver—legacy servers stay receive-only SDP (important for older Android stacks).
> 
> Camera demand uses **`mediaRequest`** (`video: boolean`) instead of **`cameraRequest`**, and acknowledgements use versioned **`mediaResult`** with a structured **`video`** payload instead of **`cameraResult`**. Teardown bumps the camera request generation so in-flight `getUserMedia` handlers cannot re-attach after disconnect.
> 
> **`packages/ui`** exports camera-related types from the public index. **`instance-client`** adds **`setMediaInput`** / **`clearMediaInput`** for looping (or one-shot) on-device MP4 as synchronized camera + mic, with absolute-path validation and typed results; tests cover wire format and client behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4538a3b927eac9484bb80c892509461be9122a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->