### PR TITLE
xcode: add build-log list endpoints to the client

### DIFF
--- a/api.md
+++ b/api.md
@@ -51,6 +51,8 @@ Methods:
 - <code title="get /v1/xcode_instances">client.xcodeInstances.<a href="./src/resources/xcode-instances.ts">list</a>({ ...params }) -> XcodeInstancesItems</code>
 - <code title="delete /v1/xcode_instances/{id}">client.xcodeInstances.<a href="./src/resources/xcode-instances.ts">delete</a>(id) -> void</code>
 - <code title="get /v1/xcode_instances/{id}">client.xcodeInstances.<a href="./src/resources/xcode-instances.ts">get</a>(id) -> XcodeInstance</code>
+- <code title="get /v1/xcode_instances/{id}/build_logs">client.xcodeInstances.<a href="./src/resources/xcode-instances-helpers.ts">listBuildLogs</a>(id) -> XcodeBuildLog[]</code>
+- <code title="get /v1/xcode_instances/{id}/bazel_build_logs">client.xcodeInstances.<a href="./src/resources/xcode-instances-helpers.ts">listBazelBuildLogs</a>(id) -> BazelBuildLog[]</code>
 
 # GradleInstances
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -80,6 +80,8 @@ import {
   SimulatorAttachment,
   SimulatorDeviceInfo,
   SimulatorInstallState,
+  XcodeBuildLog,
+  BazelBuildLog,
 } from './resources/xcode-instances-helpers';
 import { type Fetch } from './internal/builtin-types';
 import { HeadersLike, NullableHeaders, buildHeaders } from './internal/headers';
@@ -896,6 +898,8 @@ export declare namespace Limrun {
     type SimulatorAttachment as SimulatorAttachment,
     type SimulatorDeviceInfo as SimulatorDeviceInfo,
     type SimulatorInstallState as SimulatorInstallState,
+    type XcodeBuildLog as XcodeBuildLog,
+    type BazelBuildLog as BazelBuildLog,
   };
 
   export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ export {
   type SimulatorAttachment,
   type SimulatorDeviceInfo,
   type SimulatorInstallState,
+  type XcodeBuildLog,
+  type BazelBuildLog,
 } from './resources/xcode-instances-helpers';
 export {
   type GradleCreateClientParams,

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -62,6 +62,8 @@ export {
   type SimulatorDeviceInfo,
   type SimulatorInstallState,
   type RbeInstallResult,
+  type XcodeBuildLog,
+  type BazelBuildLog,
 } from './xcode-instances-helpers';
 export {
   GradleInstances,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -1,5 +1,8 @@
 import { XcodeInstances as GeneratedXcodeInstances, type XcodeInstance } from './xcode-instances';
 import { type IosInstance } from './ios-instances';
+import { APIPromise } from '../core/api-promise';
+import { RequestOptions } from '../internal/request-options';
+import { path } from '../internal/utils/path';
 import { exec, type ExecChildProcess, type ExecRequest, type TestflightUploadConfig } from '../exec-client';
 
 export type { TestflightUploadConfig } from '../exec-client';
@@ -491,7 +494,75 @@ async function readJsonResponse<T>(res: Response, operation: string): Promise<T>
   return JSON.parse(text) as T;
 }
 
+// XcodeBuildLog is one persisted build record from the director's
+// GET /v1/xcode_instances/{id}/build_logs (operationId listXcodeInstanceBuildLogs).
+// Hand-written against api/public/director/openapiv3.yaml; if a Stainless
+// regeneration ever picks that path up, reconcile with the generated surface
+// instead of duplicating it.
+export interface XcodeBuildLog {
+  /** Exec ID assigned by limbuild, e.g. build-1776140344112378000. */
+  id: string;
+
+  /** Terminal status reported by limbuild (e.g. SUCCEEDED, FAILED, CANCELLED). */
+  status: string;
+
+  /** Exit code of xcodebuild, if the build reached completion. */
+  exitCode?: number;
+
+  startedAt?: string;
+
+  finishedAt?: string;
+
+  /** Time spent running xcodebuild, in milliseconds. */
+  buildDurationMs?: number;
+
+  /** Error message captured by limbuild on failure, if any. */
+  error?: string;
+
+  /** Short-lived presigned URL for fetching the full .jsonl log from object storage. */
+  downloadUrl: string;
+}
+
+// BazelBuildLog is one persisted Bazel RBE invocation record from the
+// director's GET /v1/xcode_instances/{id}/bazel_build_logs (operationId
+// listBazelInstanceBuildLogs). Same hand-written caveat as XcodeBuildLog.
+export interface BazelBuildLog {
+  /** Bazel invocation ID (UUID) from the build event stream. */
+  id: string;
+
+  /** Terminal status (SUCCEEDED, FAILED, CANCELLED, INCOMPLETE). */
+  status: string;
+
+  /** The build target patterns, if captured. */
+  pattern?: string[];
+
+  startedAt?: string;
+
+  /** Wall-clock duration of the invocation, in milliseconds. */
+  durationMs?: number;
+
+  /** Error message captured on failure, if any. */
+  error?: string;
+
+  /** Short-lived presigned URL for fetching the full .jsonl record from object storage. */
+  downloadUrl: string;
+}
+
 export class XcodeInstances extends GeneratedXcodeInstances {
+  /**
+   * List the instance's persisted build logs.
+   */
+  listBuildLogs(id: string, options?: RequestOptions): APIPromise<XcodeBuildLog[]> {
+    return this._client.get(path`/v1/xcode_instances/${id}/build_logs`, options);
+  }
+
+  /**
+   * List the instance's persisted Bazel RBE invocation logs.
+   */
+  listBazelBuildLogs(id: string, options?: RequestOptions): APIPromise<BazelBuildLog[]> {
+    return this._client.get(path`/v1/xcode_instances/${id}/bazel_build_logs`, options);
+  }
+
   async createClient(params: XcodeCreateClientParams): Promise<XcodeClient> {
     let apiUrl: string;
     let token: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive GET-only client methods and types with no changes to auth, builds, or instance lifecycle.
> 
> **Overview**
> Adds **read-only director API support** on `client.xcodeInstances` for listing persisted **xcodebuild** and **Bazel RBE** build history for an instance.
> 
> Two hand-written methods on the extended `XcodeInstances` helper class call `GET /v1/xcode_instances/{id}/build_logs` and `GET /v1/xcode_instances/{id}/bazel_build_logs`, returning typed arrays with status, timing, errors, and **presigned `downloadUrl`** fields for full `.jsonl` logs. New **`XcodeBuildLog`** and **`BazelBuildLog`** types are exported from the package entrypoints and documented in `api.md` (noted as manual until Stainless picks up the OpenAPI paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd910f8db6332bba2994ef5075f3fb28f71ed487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->