### PR TITLE
ui: add headless play-publish flow (Google sign-in + registry publish)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/ui",
-  "version": "0.14.0-rc.1",
+  "version": "0.14.0-rc.3",
   "publishConfig": {
     "access": "public"
   },
@@ -42,6 +42,16 @@
       "types": "./dist/device-install/react.d.ts",
       "import": "./dist/device-install/react.js",
       "require": "./dist/device-install/react.cjs"
+    },
+    "./play-publish": {
+      "types": "./dist/play-publish/index.d.ts",
+      "import": "./dist/play-publish/index.js",
+      "require": "./dist/play-publish/index.cjs"
+    },
+    "./play-publish/react": {
+      "types": "./dist/play-publish/react.d.ts",
+      "import": "./dist/play-publish/react.js",
+      "require": "./dist/play-publish/react.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,8 @@
   "name": "@limrun/ui",
   "version": "0.14.0-rc.3",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "next"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/ui/src/app-store-relay/index.test.ts
+++ b/packages/ui/src/app-store-relay/index.test.ts
@@ -21,12 +21,12 @@ describe('Registry relay primitives', () => {
     expect(relay.request.mock.calls[0]).toMatchObject([
       'provisioning',
       {
-      method: 'POST',
-      path: '/account/ios/profile/deleteProvisioningProfile.action',
-      payload: {
-        teamId: 'TEAM',
-        provisioningProfileId: 'PROFILE',
-      },
+        method: 'POST',
+        path: '/account/ios/profile/deleteProvisioningProfile.action',
+        payload: {
+          teamId: 'TEAM',
+          provisioningProfileId: 'PROFILE',
+        },
       },
     ]);
   });

--- a/packages/ui/src/app-store-relay/react.ts
+++ b/packages/ui/src/app-store-relay/react.ts
@@ -29,7 +29,11 @@ export type UseAppleIDLoginResult = {
   close: () => Promise<void>;
 };
 
-export function useAppleIDLogin({ registryApiUrl, token, organizationId }: UseAppleIDLoginOptions): UseAppleIDLoginResult {
+export function useAppleIDLogin({
+  registryApiUrl,
+  token,
+  organizationId,
+}: UseAppleIDLoginOptions): UseAppleIDLoginResult {
   const [status, setStatus] = useState<AppleIDLoginStatus>('idle');
   const [session, setSession] = useState<AppleIDLoginResult | undefined>();
   const [completeResponse, setCompleteResponse] = useState<AppleRelayResponse | undefined>();

--- a/packages/ui/src/app-store-relay/react.ts
+++ b/packages/ui/src/app-store-relay/react.ts
@@ -5,6 +5,7 @@ import {
   type AppleIDLoginResult,
   type AppleRelayResponse,
 } from './index';
+import { errorMessage } from '../core/errors';
 
 export type UseAppleIDLoginOptions = Pick<AppleIDLoginInput, 'registryApiUrl' | 'token' | 'organizationId'>;
 
@@ -127,8 +128,4 @@ export function useAppleIDLogin({
     finalize,
     close,
   };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/ui/src/core/device-install/apple/client.ts
+++ b/packages/ui/src/core/device-install/apple/client.ts
@@ -99,12 +99,7 @@ export async function startBrowserOwnedAppleIDLogin({
       finishTwoFactor: async (code) => {
         const response =
           twoFactorMethod.type === 'phone' ?
-            await proxyPhoneTwoFactorCode(
-              relay,
-              twoFactorMethod.phoneNumberId,
-              code,
-              twoFactorMethod.mode,
-            )
+            await proxyPhoneTwoFactorCode(relay, twoFactorMethod.phoneNumberId, code, twoFactorMethod.mode)
           : await proxyTwoFactorCode(relay, code);
         if (response.status < 200 || response.status >= 300) {
           throw new Error(

--- a/packages/ui/src/core/device-install/apple/relay.ts
+++ b/packages/ui/src/core/device-install/apple/relay.ts
@@ -104,10 +104,7 @@ export async function openAppleRelayWebSocket(apiUrl: string, token?: string, or
   return client;
 }
 
-export async function proxySrpInit(
-  relay: AppleRelayWebSocketClient,
-  payload: AppleSRPInitRequest,
-) {
+export async function proxySrpInit(relay: AppleRelayWebSocketClient, payload: AppleSRPInitRequest) {
   return relay.request<AppleSRPInitResponse>('srpInit', payload);
 }
 

--- a/packages/ui/src/core/device-install/operations/operations.ts
+++ b/packages/ui/src/core/device-install/operations/operations.ts
@@ -4,6 +4,7 @@ import type { DeviceHello, DeviceInstallLog, PairRecordPayload } from '../types'
 import { RelayClient } from './relay-client';
 import { closeUsbmuxSession, createUsbmuxSession, type UsbmuxSession } from './usbmux';
 import { claimUsbmux, findUsbmuxCandidates, requestAppleDevice, type UsbmuxCandidate } from './webusb';
+import { errorMessage } from '../../errors';
 
 export type DeviceRelayTarget = {
   device: USBDevice;
@@ -208,10 +209,6 @@ export function deviceRelayWebSocketUrl(registryApiUrl: string, token?: string, 
     url.searchParams.set('organization', organizationId);
   }
   return url.toString();
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }
 
 async function resetUSBDevice(target: DeviceRelayTarget) {

--- a/packages/ui/src/core/device-install/operations/operations.ts
+++ b/packages/ui/src/core/device-install/operations/operations.ts
@@ -46,7 +46,13 @@ export async function requestUSBAccess({ log }: RequestUSBAccessOptions) {
   return target;
 }
 
-export async function startPairingRelay({ registryApiUrl, token, organizationId, log, target }: StartPairingRelayOptions) {
+export async function startPairingRelay({
+  registryApiUrl,
+  token,
+  organizationId,
+  log,
+  target,
+}: StartPairingRelayOptions) {
   const deviceRelayUrl = deviceRelayWebSocketUrl(registryApiUrl, token, organizationId);
   let relay: RelayClient | undefined;
   try {

--- a/packages/ui/src/core/errors.ts
+++ b/packages/ui/src/core/errors.ts
@@ -1,0 +1,3 @@
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ui/src/core/play-publish/google.ts
+++ b/packages/ui/src/core/play-publish/google.ts
@@ -93,9 +93,9 @@ export async function requestGoogleAccessToken({
       },
       error_callback: (error) => {
         const fallback =
-          error?.type === 'popup_failed_to_open'
-            ? 'Google sign-in popup was blocked by the browser.'
-            : 'Google sign-in was cancelled.';
+          error?.type === 'popup_failed_to_open' ?
+            'Google sign-in popup was blocked by the browser.'
+          : 'Google sign-in was cancelled.';
         reject(new Error(error?.message || fallback));
       },
     });

--- a/packages/ui/src/core/play-publish/google.ts
+++ b/packages/ui/src/core/play-publish/google.ts
@@ -71,11 +71,20 @@ export type RequestGoogleAccessTokenInput = {
  * call loadGoogleIdentityServices beforehand (e.g. when the surrounding
  * dialog opens) to keep this call synchronous with the click.
  */
-export async function requestGoogleAccessToken({
+export function requestGoogleAccessToken(input: RequestGoogleAccessTokenInput): Promise<string> {
+  // When GSI is already loaded the popup must open inside the caller's
+  // click turn: even an await of a resolved promise yields a microtask,
+  // which the strictest popup blockers treat as leaving the gesture.
+  if (googleOAuth2()) {
+    return openTokenPopup(input);
+  }
+  return loadGoogleIdentityServices().then(() => openTokenPopup(input));
+}
+
+function openTokenPopup({
   clientId,
   scope = ANDROID_PUBLISHER_SCOPE,
 }: RequestGoogleAccessTokenInput): Promise<string> {
-  await loadGoogleIdentityServices();
   return new Promise<string>((resolve, reject) => {
     const client = googleOAuth2()!.initTokenClient({
       client_id: clientId,

--- a/packages/ui/src/core/play-publish/google.ts
+++ b/packages/ui/src/core/play-publish/google.ts
@@ -1,0 +1,104 @@
+const GSI_SRC = 'https://accounts.google.com/gsi/client';
+
+export const ANDROID_PUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';
+
+type TokenResponse = { access_token?: string; error?: string; error_description?: string };
+type TokenClient = { requestAccessToken: () => void };
+type GoogleOAuth2 = {
+  initTokenClient: (config: {
+    client_id: string;
+    scope: string;
+    callback: (response: TokenResponse) => void;
+    error_callback?: (error: { type?: string; message?: string }) => void;
+  }) => TokenClient;
+};
+
+function googleOAuth2(): GoogleOAuth2 | undefined {
+  return (globalThis as { google?: { accounts?: { oauth2?: GoogleOAuth2 } } }).google?.accounts?.oauth2;
+}
+
+let gsiLoad: Promise<void> | undefined;
+
+export function loadGoogleIdentityServices(): Promise<void> {
+  if (googleOAuth2()) {
+    return Promise.resolve();
+  }
+  if (typeof document === 'undefined') {
+    return Promise.reject(new Error('Google sign-in requires a browser environment.'));
+  }
+  if (!gsiLoad) {
+    gsiLoad = new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = GSI_SRC;
+      script.async = true;
+      script.addEventListener(
+        'load',
+        () => {
+          if (googleOAuth2()) {
+            resolve();
+          } else {
+            reject(new Error('Google sign-in script loaded without the OAuth client.'));
+          }
+        },
+        { once: true },
+      );
+      script.addEventListener(
+        'error',
+        () => {
+          script.remove();
+          reject(new Error('Failed to load the Google sign-in script.'));
+        },
+        { once: true },
+      );
+      document.head.appendChild(script);
+    });
+    // A failed load (offline, blocked CDN) must not poison retries.
+    gsiLoad.catch(() => {
+      gsiLoad = undefined;
+    });
+  }
+  return gsiLoad;
+}
+
+export type RequestGoogleAccessTokenInput = {
+  clientId: string;
+  scope?: string;
+};
+
+/**
+ * Opens the Google consent popup and resolves with a short-lived OAuth
+ * access token. Call from a user gesture so popup blockers allow it, and
+ * call loadGoogleIdentityServices beforehand (e.g. when the surrounding
+ * dialog opens) to keep this call synchronous with the click.
+ */
+export async function requestGoogleAccessToken({
+  clientId,
+  scope = ANDROID_PUBLISHER_SCOPE,
+}: RequestGoogleAccessTokenInput): Promise<string> {
+  await loadGoogleIdentityServices();
+  return new Promise<string>((resolve, reject) => {
+    const client = googleOAuth2()!.initTokenClient({
+      client_id: clientId,
+      scope,
+      callback: (response) => {
+        if (response.error) {
+          reject(new Error(response.error_description || response.error));
+          return;
+        }
+        if (!response.access_token) {
+          reject(new Error('Google returned no access token.'));
+          return;
+        }
+        resolve(response.access_token);
+      },
+      error_callback: (error) => {
+        const fallback =
+          error?.type === 'popup_failed_to_open'
+            ? 'Google sign-in popup was blocked by the browser.'
+            : 'Google sign-in was cancelled.';
+        reject(new Error(error?.message || fallback));
+      },
+    });
+    client.requestAccessToken();
+  });
+}

--- a/packages/ui/src/core/play-publish/publish.test.ts
+++ b/packages/ui/src/core/play-publish/publish.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlaystorePublishError, publishToPlaystore } from './publish';
+
+function mockFetch(status: number, body: string) {
+  const fetchMock = vi.fn(async () => new Response(body, { status }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('publishToPlaystore', () => {
+  it('posts to the publish path with auth and org headers and returns the versionCode', async () => {
+    const fetchMock = mockFetch(200, JSON.stringify({ versionCode: 42 }));
+    const result = await publishToPlaystore({
+      registryApiUrl: 'https://registry-staging.limrun.dev',
+      token: 'limrun-token',
+      organizationId: 'org_x',
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetName: 'app-release.aab',
+    });
+    expect(result.versionCode).toBe(42);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://registry-staging.limrun.dev/android/playstore/publish');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer limrun-token');
+    expect(headers['X-Limrun-Organization']).toBe('org_x');
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetName: 'app-release.aab',
+    });
+  });
+
+  it('surfaces the registry error message and code', async () => {
+    mockFetch(409, JSON.stringify({ message: 'Version code 2 has already been used', code: 'versionCodeExists' }));
+    const error = await publishToPlaystore({
+      registryApiUrl: 'https://registry-staging.limrun.dev',
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetName: 'app-release.aab',
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(PlaystorePublishError);
+    const publishError = error as PlaystorePublishError;
+    expect(publishError.code).toBe('versionCodeExists');
+    expect(publishError.status).toBe(409);
+    expect(publishError.message).toContain('already been used');
+  });
+
+  it('handles non-JSON error bodies', async () => {
+    mockFetch(502, '<html>bad gateway</html>');
+    const error = await publishToPlaystore({
+      registryApiUrl: 'https://registry-staging.limrun.dev',
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetId: 'asset_1',
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(PlaystorePublishError);
+    expect((error as PlaystorePublishError).message).toContain('HTTP 502');
+  });
+});

--- a/packages/ui/src/core/play-publish/publish.test.ts
+++ b/packages/ui/src/core/play-publish/publish.test.ts
@@ -37,7 +37,10 @@ describe('publishToPlaystore', () => {
   });
 
   it('surfaces the registry error message and code', async () => {
-    mockFetch(409, JSON.stringify({ message: 'Version code 2 has already been used', code: 'versionCodeExists' }));
+    mockFetch(
+      409,
+      JSON.stringify({ message: 'Version code 2 has already been used', code: 'versionCodeExists' }),
+    );
     const error = await publishToPlaystore({
       registryApiUrl: 'https://registry-staging.limrun.dev',
       accessToken: 'google-token',

--- a/packages/ui/src/core/play-publish/publish.ts
+++ b/packages/ui/src/core/play-publish/publish.ts
@@ -1,0 +1,89 @@
+export type PlaystorePublishInput = {
+  registryApiUrl: string;
+  /** Limrun API token authenticating the registry call. */
+  token?: string;
+  /** Organization tid; required when it differs from the token's default organization. */
+  organizationId?: string;
+  /** Google OAuth access token with the androidpublisher scope. Sent per request, never stored. */
+  accessToken: string;
+  packageName: string;
+  assetId?: string;
+  assetName?: string;
+  /** Play track ID, defaults to internal on the server. */
+  track?: string;
+  /** Required by the server when track is production. */
+  releaseStatus?: 'draft' | 'completed';
+};
+
+export type PlaystorePublishResult = {
+  versionCode: number;
+};
+
+/**
+ * Registry publish failure. `code` carries the registry's machine-readable
+ * error code when available: invalidRequest, assetNotFound, internal, busy,
+ * listingNotFound, permissionDenied, versionCodeExists, uploadKeyMismatch
+ * or unknown; the set grows additively.
+ */
+export class PlaystorePublishError extends Error {
+  readonly code?: string;
+  readonly status?: number;
+
+  constructor(message: string, options: { code?: string; status?: number } = {}) {
+    super(message);
+    this.name = 'PlaystorePublishError';
+    this.code = options.code;
+    this.status = options.status;
+  }
+}
+
+export async function publishToPlaystore(input: PlaystorePublishInput): Promise<PlaystorePublishResult> {
+  const { registryApiUrl, token, organizationId, ...body } = input;
+  let url: URL;
+  try {
+    url = new URL(registryApiUrl);
+  } catch {
+    throw new PlaystorePublishError(`Invalid registry URL: ${registryApiUrl}`);
+  }
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/android/playstore/publish`;
+  url.search = '';
+  url.hash = '';
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  if (organizationId) {
+    headers['X-Limrun-Organization'] = organizationId;
+  }
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+  } catch (caught) {
+    throw new PlaystorePublishError(
+      `Cannot reach the registry: ${caught instanceof Error ? caught.message : String(caught)}`,
+    );
+  }
+  const raw = await response.text();
+  let parsed: { versionCode?: number; message?: string; code?: string } | undefined;
+  try {
+    parsed = raw ? (JSON.parse(raw) as typeof parsed) : undefined;
+  } catch {
+    parsed = undefined;
+  }
+  if (!response.ok) {
+    throw new PlaystorePublishError(parsed?.message || `Play publish failed with HTTP ${response.status}`, {
+      code: parsed?.code,
+      status: response.status,
+    });
+  }
+  if (typeof parsed?.versionCode !== 'number') {
+    throw new PlaystorePublishError('Play publish response is missing versionCode.', {
+      status: response.status,
+    });
+  }
+  return { versionCode: parsed.versionCode };
+}

--- a/packages/ui/src/device-build/react.ts
+++ b/packages/ui/src/device-build/react.ts
@@ -8,6 +8,7 @@ import {
   type IOSOTAInstall,
   type StoredSigningAssets,
 } from './index';
+import { errorMessage } from '../core/errors';
 
 export type UseDeviceBuildOptions = {
   apiUrl?: string;
@@ -126,8 +127,4 @@ export function useDeviceBuild({
     startBuild,
     reset,
   };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/ui/src/device-install/demo/demo.tsx
+++ b/packages/ui/src/device-install/demo/demo.tsx
@@ -29,6 +29,7 @@ import {
 import { useDeviceBuild } from '../../device-build/react';
 import { useDeviceInstallRelay } from '../react';
 import './demo.css';
+import { errorMessage } from '../../core/errors';
 
 type ActivityLine = {
   id: number;
@@ -1051,10 +1052,6 @@ function useLocalStorage(key: string, initialValue: string) {
     localStorage.setItem(key, value);
   }, [key, value]);
   return [value, setValue] as const;
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/packages/ui/src/device-install/demo/demo.tsx
+++ b/packages/ui/src/device-install/demo/demo.tsx
@@ -295,10 +295,7 @@ function App() {
     }
   }
 
-  async function loadAppleResources(
-    teamId = developerTeamId,
-    relay = appleLogin.session?.relay,
-  ) {
+  async function loadAppleResources(teamId = developerTeamId, relay = appleLogin.session?.relay) {
     if (!apiUrl.trim() || !relay || !teamId) return;
     const base = {
       relay,

--- a/packages/ui/src/device-install/react.ts
+++ b/packages/ui/src/device-install/react.ts
@@ -136,33 +136,36 @@ export function useDeviceInstallRelay({
     }
   }, [apiUrl, cleanupDeviceAccess, device, organizationId, token]);
 
-  const startInstallation = useCallback(async (installSource: InstallSource) => {
-    if (!apiUrl || !device || !pairRecord) {
-      throw new Error('Select and pair a USB device before starting installation.');
-    }
-    setBusyAction('install');
-    setError(undefined);
-    try {
-      await cleanupDeviceAccess();
-      relayRef.current = await startDeviceInstall({
-        registryApiUrl: apiUrl,
-        token,
-        organizationId,
-        log: logRef.current,
-        target: device,
-        pairRecord,
-        installSource,
-      });
-      logRef.current('Device install started', 'Installation will continue through the connected iPhone.');
-      return relayRef.current;
-    } catch (caught) {
-      await closeDeviceRelayTarget(device, logRef.current);
-      setError(errorMessage(caught));
-      return undefined;
-    } finally {
-      setBusyAction(undefined);
-    }
-  }, [apiUrl, cleanupDeviceAccess, device, organizationId, pairRecord, token]);
+  const startInstallation = useCallback(
+    async (installSource: InstallSource) => {
+      if (!apiUrl || !device || !pairRecord) {
+        throw new Error('Select and pair a USB device before starting installation.');
+      }
+      setBusyAction('install');
+      setError(undefined);
+      try {
+        await cleanupDeviceAccess();
+        relayRef.current = await startDeviceInstall({
+          registryApiUrl: apiUrl,
+          token,
+          organizationId,
+          log: logRef.current,
+          target: device,
+          pairRecord,
+          installSource,
+        });
+        logRef.current('Device install started', 'Installation will continue through the connected iPhone.');
+        return relayRef.current;
+      } catch (caught) {
+        await closeDeviceRelayTarget(device, logRef.current);
+        setError(errorMessage(caught));
+        return undefined;
+      } finally {
+        setBusyAction(undefined);
+      }
+    },
+    [apiUrl, cleanupDeviceAccess, device, organizationId, pairRecord, token],
+  );
 
   const stopRelay = useCallback(() => {
     void cleanupDeviceAccess();

--- a/packages/ui/src/device-install/react.ts
+++ b/packages/ui/src/device-install/react.ts
@@ -12,6 +12,7 @@ import {
   type RelayClient,
   type StoredPairRecord,
 } from './index';
+import { errorMessage } from '../core/errors';
 
 export type DeviceInstallRelayBusyAction = 'usb' | 'pair' | 'install';
 
@@ -191,8 +192,4 @@ export function useDeviceInstallRelay({
 
 function noopLog() {
   // Intentionally empty. Consumers can pass a logger for progress messages.
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/ui/src/play-publish/README.md
+++ b/packages/ui/src/play-publish/README.md
@@ -39,9 +39,9 @@ await play.publish({ assetName: 'app-release.aab', packageName: 'com.example.app
 // Render from state: play.status, play.versionCode, play.error, play.errorCode
 ```
 
-`errorCode` values: `invalidRequest`, `assetNotFound`, `internal`, `busy`,
-`listingNotFound`, `permissionDenied`, `versionCodeExists`,
-`uploadKeyMismatch`, `unknown`. The set grows additively.
+`errorCode` carries the registry's machine-readable error code; the
+canonical value list lives on `PlaystorePublishError`'s doc comment and
+grows additively.
 
 Google access tokens expire after about an hour. A `permissionDenied`
 error long after sign-in usually means the token expired; offer "Sign in

--- a/packages/ui/src/play-publish/README.md
+++ b/packages/ui/src/play-publish/README.md
@@ -1,0 +1,65 @@
+# @limrun/ui/play-publish
+
+Headless building blocks for publishing an AAB asset from the Limrun
+registry to Google Play, with a browser-owned Google sign-in. No UI ships
+here; embedders render their own buttons and dialogs around the hook,
+same as `device-install`.
+
+The Google access token is minted in the browser via Google Identity
+Services (token model, no client secret) and sent to the registry once
+per publish. Limrun never stores it.
+
+## Requirements
+
+- A Google OAuth **Web application** client ID whose authorized
+  JavaScript origins include your app's origin.
+- The signed-in Google account needs release permission for the target
+  app in Play Console, and the app listing must already exist.
+- The asset must be an AAB signed with the app's Play upload key.
+
+## React
+
+```tsx
+import { usePlaystorePublish } from '@limrun/ui/play-publish/react';
+
+const play = usePlaystorePublish({
+  registryApiUrl: 'https://registry.limrun.com',
+  token: limrunToken,
+  organizationId: organizationTid,
+  googleClientId: GOOGLE_OAUTH_CLIENT_ID,
+});
+
+// On dialog open, warm the sign-in script so the click stays popup-safe:
+play.preloadGoogle();
+
+// Button handlers:
+await play.signInWithGoogle();
+await play.publish({ assetName: 'app-release.aab', packageName: 'com.example.app' });
+
+// Render from state: play.status, play.versionCode, play.error, play.errorCode
+```
+
+`errorCode` values: `invalidRequest`, `assetNotFound`, `internal`, `busy`,
+`listingNotFound`, `permissionDenied`, `versionCodeExists`,
+`uploadKeyMismatch`, `unknown`. The set grows additively.
+
+Google access tokens expire after about an hour. A `permissionDenied`
+error long after sign-in usually means the token expired; offer "Sign in
+with Google" again rather than pointing users at Play Console
+permissions.
+
+## Without React
+
+```ts
+import { requestGoogleAccessToken, publishToPlaystore } from '@limrun/ui/play-publish';
+
+const accessToken = await requestGoogleAccessToken({ clientId: GOOGLE_OAUTH_CLIENT_ID });
+const { versionCode } = await publishToPlaystore({
+  registryApiUrl,
+  token,
+  organizationId,
+  accessToken,
+  assetName: 'app-release.aab',
+  packageName: 'com.example.app',
+});
+```

--- a/packages/ui/src/play-publish/README.md
+++ b/packages/ui/src/play-publish/README.md
@@ -29,7 +29,8 @@ const play = usePlaystorePublish({
   googleClientId: GOOGLE_OAUTH_CLIENT_ID,
 });
 
-// On dialog open, warm the sign-in script so the click stays popup-safe:
+// On dialog open, warm the sign-in script so the click stays popup-safe.
+// Optionally await the returned promise (true = ready) to gate the button:
 play.preloadGoogle();
 
 // Button handlers:

--- a/packages/ui/src/play-publish/index.ts
+++ b/packages/ui/src/play-publish/index.ts
@@ -1,0 +1,12 @@
+export {
+  ANDROID_PUBLISHER_SCOPE,
+  loadGoogleIdentityServices,
+  requestGoogleAccessToken,
+  type RequestGoogleAccessTokenInput,
+} from '../core/play-publish/google';
+export {
+  publishToPlaystore,
+  PlaystorePublishError,
+  type PlaystorePublishInput,
+  type PlaystorePublishResult,
+} from '../core/play-publish/publish';

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -1,0 +1,168 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  loadGoogleIdentityServices,
+  PlaystorePublishError,
+  publishToPlaystore,
+  requestGoogleAccessToken,
+  type PlaystorePublishInput,
+  type PlaystorePublishResult,
+} from './index';
+
+export type UsePlaystorePublishOptions = Partial<
+  Pick<PlaystorePublishInput, 'registryApiUrl' | 'token' | 'organizationId'>
+> & {
+  /** Google OAuth Web application client ID used for sign-in. */
+  googleClientId?: string;
+};
+
+export type PlaystorePublishStatus = 'idle' | 'signing-in' | 'ready' | 'publishing' | 'published' | 'error';
+
+export type PlaystorePublishRequest = Omit<
+  PlaystorePublishInput,
+  'registryApiUrl' | 'token' | 'organizationId' | 'accessToken'
+>;
+
+export type UsePlaystorePublishResult = {
+  status: PlaystorePublishStatus;
+  isSignedIn: boolean;
+  versionCode?: number;
+  error?: string;
+  /** Registry error code driving per-cause UX, e.g. versionCodeExists. */
+  errorCode?: string;
+  /** Warm up the Google sign-in script (e.g. on dialog open) so signInWithGoogle stays synchronous with the click. */
+  preloadGoogle: () => void;
+  signInWithGoogle: () => Promise<boolean>;
+  publish: (request: PlaystorePublishRequest) => Promise<PlaystorePublishResult | undefined>;
+  reset: () => void;
+};
+
+export function usePlaystorePublish({
+  registryApiUrl,
+  token,
+  organizationId,
+  googleClientId,
+}: UsePlaystorePublishOptions): UsePlaystorePublishResult {
+  const [status, setStatus] = useState<PlaystorePublishStatus>('idle');
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  const [versionCode, setVersionCode] = useState<number | undefined>();
+  const [error, setError] = useState<string | undefined>();
+  const [errorCode, setErrorCode] = useState<string | undefined>();
+  // The token lives in a ref so publish() right after signInWithGoogle()
+  // in one handler sees it before React re-renders.
+  const accessTokenRef = useRef<string | undefined>(undefined);
+  // reset() bumps the generation so an abandoned in-flight call cannot
+  // overwrite the state it settles into.
+  const generationRef = useRef(0);
+  const busyRef = useRef(false);
+
+  const preloadGoogle = useCallback(() => {
+    void loadGoogleIdentityServices().catch(() => undefined);
+  }, []);
+
+  const signInWithGoogle = useCallback(async () => {
+    if (busyRef.current) {
+      return false;
+    }
+    if (!googleClientId) {
+      setError('Google OAuth client ID is not configured.');
+      setStatus('error');
+      return false;
+    }
+    busyRef.current = true;
+    const generation = generationRef.current;
+    setStatus('signing-in');
+    setError(undefined);
+    setErrorCode(undefined);
+    try {
+      const nextToken = await requestGoogleAccessToken({ clientId: googleClientId });
+      accessTokenRef.current = nextToken;
+      if (generation === generationRef.current) {
+        setIsSignedIn(true);
+        setStatus('ready');
+      }
+      return true;
+    } catch (caught) {
+      if (generation === generationRef.current) {
+        setError(errorMessage(caught));
+        setStatus('error');
+      }
+      return false;
+    } finally {
+      busyRef.current = false;
+    }
+  }, [googleClientId]);
+
+  const publish = useCallback(
+    async (request: PlaystorePublishRequest) => {
+      if (busyRef.current) {
+        return undefined;
+      }
+      if (!registryApiUrl) {
+        setError('Registry URL is not configured.');
+        setStatus('error');
+        return undefined;
+      }
+      const accessToken = accessTokenRef.current;
+      if (!accessToken) {
+        setError('Sign in with Google before publishing.');
+        setStatus('error');
+        return undefined;
+      }
+      busyRef.current = true;
+      const generation = generationRef.current;
+      setStatus('publishing');
+      setError(undefined);
+      setErrorCode(undefined);
+      try {
+        const result = await publishToPlaystore({
+          registryApiUrl,
+          token,
+          organizationId,
+          accessToken,
+          ...request,
+        });
+        if (generation === generationRef.current) {
+          setVersionCode(result.versionCode);
+          setStatus('published');
+        }
+        return result;
+      } catch (caught) {
+        if (generation === generationRef.current) {
+          setError(errorMessage(caught));
+          if (caught instanceof PlaystorePublishError) {
+            setErrorCode(caught.code);
+          }
+          setStatus('error');
+        }
+        return undefined;
+      } finally {
+        busyRef.current = false;
+      }
+    },
+    [registryApiUrl, token, organizationId],
+  );
+
+  const reset = useCallback(() => {
+    generationRef.current += 1;
+    setVersionCode(undefined);
+    setError(undefined);
+    setErrorCode(undefined);
+    setStatus(accessTokenRef.current ? 'ready' : 'idle');
+  }, []);
+
+  return {
+    status,
+    isSignedIn,
+    versionCode,
+    error,
+    errorCode,
+    preloadGoogle,
+    signInWithGoogle,
+    publish,
+    reset,
+  };
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -30,8 +30,13 @@ export type UsePlaystorePublishResult = {
   error?: string;
   /** Registry error code driving per-cause UX, e.g. versionCodeExists. */
   errorCode?: string;
-  /** Warm up the Google sign-in script (e.g. on dialog open) so signInWithGoogle stays synchronous with the click. */
-  preloadGoogle: () => void;
+  /**
+   * Warm up the Google sign-in script (e.g. on dialog open) so
+   * signInWithGoogle stays synchronous with the click. Resolves true once
+   * the script is ready; await it to gate the sign-in button, or ignore
+   * the result and rely on the blocked-popup error plus retry.
+   */
+  preloadGoogle: () => Promise<boolean>;
   signInWithGoogle: () => Promise<boolean>;
   publish: (request: PlaystorePublishRequest) => Promise<PlaystorePublishResult | undefined>;
   /**
@@ -63,9 +68,14 @@ export function usePlaystorePublish({
   const generationRef = useRef(0);
   const busyRef = useRef(false);
 
-  const preloadGoogle = useCallback(() => {
-    void loadGoogleIdentityServices().catch(() => undefined);
-  }, []);
+  const preloadGoogle = useCallback(
+    () =>
+      loadGoogleIdentityServices().then(
+        () => true,
+        () => false,
+      ),
+    [],
+  );
 
   // Guard failures replace the whole outcome, like the main paths do: a
   // stale errorCode or versionCode must not render beside the new error.

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -124,12 +124,15 @@ export function usePlaystorePublish({
       // attempt's success next to an error state.
       setVersionCode(undefined);
       try {
+        // Hook-owned fields spread last: excess-property checking does not
+        // protect wider-typed request objects from smuggling in same-named
+        // credential fields.
         const result = await publishToPlaystore({
+          ...request,
           registryApiUrl,
           token,
           organizationId,
           accessToken,
-          ...request,
         });
         if (generation === generationRef.current) {
           setVersionCode(result.versionCode);

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { errorMessage } from '../core/errors';
 import {
   loadGoogleIdentityServices,
   PlaystorePublishError,
@@ -48,7 +49,9 @@ export function usePlaystorePublish({
   googleClientId,
 }: UsePlaystorePublishOptions): UsePlaystorePublishResult {
   const [status, setStatus] = useState<PlaystorePublishStatus>('idle');
-  const [isSignedIn, setIsSignedIn] = useState(false);
+  // isSignedIn derives from token possession so the two can never diverge,
+  // even when a reset() during the popup makes the flow's status stale.
+  const [accessToken, setAccessToken] = useState<string | undefined>();
   const [versionCode, setVersionCode] = useState<number | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [errorCode, setErrorCode] = useState<string | undefined>();
@@ -81,9 +84,7 @@ export function usePlaystorePublish({
     try {
       const nextToken = await requestGoogleAccessToken({ clientId: googleClientId });
       accessTokenRef.current = nextToken;
-      // isSignedIn mirrors token possession, so it is set even when a
-      // reset() during the popup made the flow's status stale.
-      setIsSignedIn(true);
+      setAccessToken(nextToken);
       if (generation === generationRef.current) {
         setStatus('ready');
       }
@@ -109,8 +110,8 @@ export function usePlaystorePublish({
         setStatus('error');
         return undefined;
       }
-      const accessToken = accessTokenRef.current;
-      if (!accessToken) {
+      const googleToken = accessTokenRef.current;
+      if (!googleToken) {
         setError('Sign in with Google before publishing.');
         setStatus('error');
         return undefined;
@@ -124,15 +125,19 @@ export function usePlaystorePublish({
       // attempt's success next to an error state.
       setVersionCode(undefined);
       try {
-        // Hook-owned fields spread last: excess-property checking does not
-        // protect wider-typed request objects from smuggling in same-named
-        // credential fields.
+        // Fields picked explicitly: spreading a wider-typed request object
+        // could smuggle same-named credential fields or excess properties
+        // into the request body.
         const result = await publishToPlaystore({
-          ...request,
           registryApiUrl,
           token,
           organizationId,
-          accessToken,
+          accessToken: googleToken,
+          packageName: request.packageName,
+          assetId: request.assetId,
+          assetName: request.assetName,
+          track: request.track,
+          releaseStatus: request.releaseStatus,
         });
         if (generation === generationRef.current) {
           setVersionCode(result.versionCode);
@@ -163,19 +168,20 @@ export function usePlaystorePublish({
     setStatus(accessTokenRef.current ? 'ready' : 'idle');
   }, []);
 
-  return {
-    status,
-    isSignedIn,
-    versionCode,
-    error,
-    errorCode,
-    preloadGoogle,
-    signInWithGoogle,
-    publish,
-    reset,
-  };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
+  // Memoized so the result works as a prop or dependency without
+  // re-rendering consumers on unrelated parent renders.
+  return useMemo(
+    () => ({
+      status,
+      isSignedIn: accessToken !== undefined,
+      versionCode,
+      error,
+      errorCode,
+      preloadGoogle,
+      signInWithGoogle,
+      publish,
+      reset,
+    }),
+    [status, accessToken, versionCode, error, errorCode, preloadGoogle, signInWithGoogle, publish, reset],
+  );
 }

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -67,13 +67,21 @@ export function usePlaystorePublish({
     void loadGoogleIdentityServices().catch(() => undefined);
   }, []);
 
+  // Guard failures replace the whole outcome, like the main paths do: a
+  // stale errorCode or versionCode must not render beside the new error.
+  const failGuard = useCallback((message: string) => {
+    setError(message);
+    setErrorCode(undefined);
+    setVersionCode(undefined);
+    setStatus('error');
+  }, []);
+
   const signInWithGoogle = useCallback(async () => {
     if (busyRef.current) {
       return false;
     }
     if (!googleClientId) {
-      setError('Google OAuth client ID is not configured.');
-      setStatus('error');
+      failGuard('Google OAuth client ID is not configured.');
       return false;
     }
     busyRef.current = true;
@@ -87,6 +95,11 @@ export function usePlaystorePublish({
       setAccessToken(nextToken);
       if (generation === generationRef.current) {
         setStatus('ready');
+      } else {
+        // A reset() during the popup ran before the token landed and left
+        // idle; upgrade it so status agrees with isSignedIn. Anything but
+        // idle belongs to a newer flow and must not be stomped.
+        setStatus((current) => (current === 'idle' ? 'ready' : current));
       }
       return true;
     } catch (caught) {
@@ -106,14 +119,12 @@ export function usePlaystorePublish({
         return undefined;
       }
       if (!registryApiUrl) {
-        setError('Registry URL is not configured.');
-        setStatus('error');
+        failGuard('Registry URL is not configured.');
         return undefined;
       }
       const googleToken = accessTokenRef.current;
       if (!googleToken) {
-        setError('Sign in with Google before publishing.');
-        setStatus('error');
+        failGuard('Sign in with Google before publishing.');
         return undefined;
       }
       busyRef.current = true;

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -33,6 +33,11 @@ export type UsePlaystorePublishResult = {
   preloadGoogle: () => void;
   signInWithGoogle: () => Promise<boolean>;
   publish: (request: PlaystorePublishRequest) => Promise<PlaystorePublishResult | undefined>;
+  /**
+   * Clears the outcome state (keeps the Google session). Does not cancel an
+   * in-flight sign-in or publish: their completion is ignored status-wise
+   * and new calls stay refused until the in-flight one settles.
+   */
   reset: () => void;
 };
 
@@ -76,8 +81,10 @@ export function usePlaystorePublish({
     try {
       const nextToken = await requestGoogleAccessToken({ clientId: googleClientId });
       accessTokenRef.current = nextToken;
+      // isSignedIn mirrors token possession, so it is set even when a
+      // reset() during the popup made the flow's status stale.
+      setIsSignedIn(true);
       if (generation === generationRef.current) {
-        setIsSignedIn(true);
         setStatus('ready');
       }
       return true;
@@ -113,6 +120,9 @@ export function usePlaystorePublish({
       setStatus('publishing');
       setError(undefined);
       setErrorCode(undefined);
+      // A stale code from an earlier publish must not render as this
+      // attempt's success next to an error state.
+      setVersionCode(undefined);
       try {
         const result = await publishToPlaystore({
           registryApiUrl,

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
         'device-build/react': resolve(__dirname, 'src/device-build/react.ts'),
         'device-install/index': resolve(__dirname, 'src/device-install/index.ts'),
         'device-install/react': resolve(__dirname, 'src/device-install/react.ts'),
+        'play-publish/index': resolve(__dirname, 'src/play-publish/index.ts'),
+        'play-publish/react': resolve(__dirname, 'src/play-publish/react.ts'),
       },
       name: 'LimrunUI',
       formats: ['es', 'cjs'],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New OAuth and publish path forwards short-lived Google tokens to the registry; mistakes in token handling or publish payloads could affect release flows, though scope is limited to the new module and shared error helper.
> 
> **Overview**
> Adds **`@limrun/ui/play-publish`** so embedders can sign in with Google in the browser and publish a registry AAB to Play via the registry **`POST /android/playstore/publish`** endpoint. The Google **androidpublisher** token is obtained with Google Identity Services (token client, popup-safe preload) and sent on each publish; Limrun auth uses the existing bearer + org headers.
> 
> Ships a headless **`publishToPlaystore`** / **`PlaystorePublishError`** (with registry **`errorCode`**) and **`usePlaystorePublish`** for status, **`versionCode`**, **`preloadGoogle`**, sign-in, publish, and **`reset`** with generation guards for in-flight races. Package **0.14.0-rc.3** adds **`publishConfig.tag: next`** and new **exports** / Vite lib entries.
> 
> Also extracts shared **`errorMessage`** into **`core/errors`** and wires existing Apple/device-install hooks to it (mostly formatting elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2d977572900801efc9a4dd621e29a5759177f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->