### PR TITLE
ui: pluggable signing secret store and apple credential escrow helpers

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/ui",
-  "version": "0.14.0-rc.3",
+  "version": "0.14.0-rc.4",
   "publishConfig": {
     "access": "public",
     "tag": "next"
@@ -23,6 +23,11 @@
       "types": "./dist/app-store-relay/react.d.ts",
       "import": "./dist/app-store-relay/react.js",
       "require": "./dist/app-store-relay/react.cjs"
+    },
+    "./apple-credentials": {
+      "types": "./dist/apple-credentials/index.d.ts",
+      "import": "./dist/apple-credentials/index.js",
+      "require": "./dist/apple-credentials/index.cjs"
     },
     "./device-build": {
       "types": "./dist/device-build/index.d.ts",

--- a/packages/ui/src/apple-credentials/index.test.ts
+++ b/packages/ui/src/apple-credentials/index.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, test } from 'vitest';
 import type { AppleRelayWebSocketClient } from '../core/device-install/apple';
 import {
   APPLE_CERTIFICATE_SECRET_TYPE,
+  appleCertificateSecretName,
   ensureAppleCertificateSecret,
-  withRetries,
   type SigningSecret,
   type SigningSecretMetadata,
   type SigningSecretStore,
@@ -95,68 +95,43 @@ function portalOK(body: Record<string, unknown>) {
 
 describe('ensureAppleCertificateSecret', () => {
   const teamId = 'TEAM1';
+  const secretName = appleCertificateSecretName(teamId, 'DEVELOPMENT');
 
-  test('failed store write parks the key locally and a retry recovers it without minting again', async () => {
+  test('surfaces an actionable error when the store write fails after minting', async () => {
     const state: PortalState = {
       mintedCertificateIds: [],
       certificateBase64: selfSignedCertificateBase64(),
     };
-    const relay = fakePortalRelay(state);
-    const fallback = memorySecretStore();
     const broken = memorySecretStore({ failPuts: () => true });
 
     await expect(
       ensureAppleCertificateSecret({
-        relay,
+        relay: fakePortalRelay(state),
         teamId,
         secretStore: broken.store,
-        localFallbackStore: fallback.store,
-        storeAttempts: 2,
       }),
-    ).rejects.toThrow(/kept safely in this browser/);
-
-    // Exactly one certificate was minted and its p12 survived the failure.
+    ).rejects.toThrow(/revoke certificate CERT1/);
     expect(state.mintedCertificateIds).toEqual(['CERT1']);
-    const parked = await fallback.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId);
-    expect(parked?.data.certificateID).toBe('CERT1');
-    expect(parked?.data.certificateP12Base64).toBeTruthy();
-
-    // Once the store works again the parked key is promoted, not re-minted.
-    const working = memorySecretStore();
-    const result = await ensureAppleCertificateSecret({
-      relay,
-      teamId,
-      secretStore: working.store,
-      localFallbackStore: fallback.store,
-      storeAttempts: 2,
-    });
-    expect(state.mintedCertificateIds).toEqual(['CERT1']);
-    expect(result.recovered).toBe(true);
-    expect(result.created).toBe(false);
-    expect(result.certificateId).toBe('CERT1');
-    expect(result.secret.data.certificateP12Base64).toBe(parked?.data.certificateP12Base64);
-    // The parked copy is cleaned up after promotion.
-    expect(await fallback.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId)).toBeUndefined();
   });
 
-  test('mints, parks, stores and cleans up the parked copy on success', async () => {
+  test('mints and stores the certificate with its type in the secret name', async () => {
     const state: PortalState = {
       mintedCertificateIds: [],
       certificateBase64: selfSignedCertificateBase64(),
     };
-    const fallback = memorySecretStore();
     const org = memorySecretStore();
 
     const result = await ensureAppleCertificateSecret({
       relay: fakePortalRelay(state),
       teamId,
       secretStore: org.store,
-      localFallbackStore: fallback.store,
     });
     expect(result.created).toBe(true);
     expect(result.certificateId).toBe('CERT1');
-    expect((await org.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId))?.data.certificateID).toBe('CERT1');
-    expect(await fallback.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId)).toBeUndefined();
+    const stored = await org.store.get(APPLE_CERTIFICATE_SECRET_TYPE, secretName);
+    expect(stored?.data.certificateID).toBe('CERT1');
+    expect(stored?.data.certificateType).toBe('DEVELOPMENT');
+    expect(stored?.data.certificateP12Base64).toBeTruthy();
   });
 
   test('reuses the stored certificate when it is still on the team', async () => {
@@ -165,7 +140,7 @@ describe('ensureAppleCertificateSecret', () => {
       certificateBase64: selfSignedCertificateBase64(),
     };
     const org = memorySecretStore();
-    await org.store.put(APPLE_CERTIFICATE_SECRET_TYPE, teamId, {
+    await org.store.put(APPLE_CERTIFICATE_SECRET_TYPE, secretName, {
       certificateP12Base64: 'cDEy',
       certificateID: 'CERT1',
       teamID: teamId,
@@ -175,39 +150,9 @@ describe('ensureAppleCertificateSecret', () => {
       relay: fakePortalRelay(state),
       teamId,
       secretStore: org.store,
-      localFallbackStore: memorySecretStore().store,
     });
     expect(result.created).toBe(false);
-    expect(result.recovered).toBe(false);
     expect(result.certificateId).toBe('CERT1');
     expect(state.mintedCertificateIds).toEqual(['CERT1']);
-  });
-});
-
-describe('withRetries', () => {
-  test('returns after a transient failure and reports attempts', async () => {
-    const attempts: number[] = [];
-    let calls = 0;
-    const value = await withRetries(
-      async () => {
-        calls += 1;
-        if (calls < 3) throw new Error('transient');
-        return 'ok';
-      },
-      { attempts: 3, initialDelayMs: 1, onAttempt: (attempt) => attempts.push(attempt) },
-    );
-    expect(value).toBe('ok');
-    expect(attempts).toEqual([1, 2, 3]);
-  });
-
-  test('throws the last error when all attempts fail', async () => {
-    await expect(
-      withRetries(
-        async () => {
-          throw new Error('permanent');
-        },
-        { attempts: 2, initialDelayMs: 1 },
-      ),
-    ).rejects.toThrow('permanent');
   });
 });

--- a/packages/ui/src/apple-credentials/index.test.ts
+++ b/packages/ui/src/apple-credentials/index.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment node
+
+import forge from 'node-forge';
+import { describe, expect, test } from 'vitest';
+import type { AppleRelayWebSocketClient } from '../core/device-install/apple';
+import {
+  APPLE_CERTIFICATE_SECRET_TYPE,
+  ensureAppleCertificateSecret,
+  withRetries,
+  type SigningSecret,
+  type SigningSecretMetadata,
+  type SigningSecretStore,
+  type SigningSecretType,
+} from './index';
+
+/**
+ * A self-signed certificate is enough for exportAppleCertificateP12: the
+ * p12 bundling never verifies that the key matches the certificate.
+ */
+function selfSignedCertificateBase64() {
+  const keys = forge.pki.rsa.generateKeyPair(1024);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const attrs = [{ name: 'commonName', value: 'Apple Development Test' }];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey);
+  return forge.util.encode64(forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes());
+}
+
+function memorySecretStore(options: { failPuts?: () => boolean } = {}) {
+  const entries = new Map<string, SigningSecret>();
+  const store: SigningSecretStore = {
+    async put(type: SigningSecretType, name: string, data: Record<string, string>) {
+      if (options.failPuts?.()) {
+        throw new Error('secret store unavailable');
+      }
+      const secret: SigningSecret = { type, name, data, createdAt: new Date().toISOString() };
+      entries.set(`${type}:${name}`, secret);
+      return secret;
+    },
+    async get(type: SigningSecretType, name: string) {
+      return entries.get(`${type}:${name}`);
+    },
+    async list() {
+      return [...entries.values()].map(({ data: _data, ...metadata }): SigningSecretMetadata => metadata);
+    },
+    async delete(type: SigningSecretType, name: string) {
+      entries.delete(`${type}:${name}`);
+    },
+  };
+  return { store, entries };
+}
+
+type PortalState = { mintedCertificateIds: string[]; certificateBase64: string };
+
+/**
+ * Fakes the relay's provisioning proxy: minting appends to
+ * mintedCertificateIds, listing reflects what has been minted so far.
+ */
+function fakePortalRelay(state: PortalState): AppleRelayWebSocketClient {
+  return {
+    async request(_type: string, payload: unknown) {
+      const request = payload as { path: string };
+      if (request.path.includes('listCertRequests')) {
+        return portalOK({
+          certRequests: state.mintedCertificateIds.map((certificateId) => ({ certificateId })),
+        });
+      }
+      if (request.path.includes('submitCertificateRequest')) {
+        const certificateId = `CERT${state.mintedCertificateIds.length + 1}`;
+        state.mintedCertificateIds.push(certificateId);
+        return portalOK({
+          certRequest: {
+            certificateId,
+            serialNum: '01',
+            expirationDateString: '2027-01-01',
+          },
+        });
+      }
+      if (request.path.includes('downloadCertificateContent')) {
+        return { status: 200, statusText: 'OK', rawBodyBase64: state.certificateBase64 };
+      }
+      throw new Error(`unexpected portal path: ${request.path}`);
+    },
+  } as unknown as AppleRelayWebSocketClient;
+}
+
+function portalOK(body: Record<string, unknown>) {
+  return { status: 200, statusText: 'OK', body: { resultCode: 0, ...body } };
+}
+
+describe('ensureAppleCertificateSecret', () => {
+  const teamId = 'TEAM1';
+
+  test('failed store write parks the key locally and a retry recovers it without minting again', async () => {
+    const state: PortalState = {
+      mintedCertificateIds: [],
+      certificateBase64: selfSignedCertificateBase64(),
+    };
+    const relay = fakePortalRelay(state);
+    const fallback = memorySecretStore();
+    const broken = memorySecretStore({ failPuts: () => true });
+
+    await expect(
+      ensureAppleCertificateSecret({
+        relay,
+        teamId,
+        secretStore: broken.store,
+        localFallbackStore: fallback.store,
+        storeAttempts: 2,
+      }),
+    ).rejects.toThrow(/kept safely in this browser/);
+
+    // Exactly one certificate was minted and its p12 survived the failure.
+    expect(state.mintedCertificateIds).toEqual(['CERT1']);
+    const parked = await fallback.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId);
+    expect(parked?.data.certificateID).toBe('CERT1');
+    expect(parked?.data.certificateP12Base64).toBeTruthy();
+
+    // Once the store works again the parked key is promoted, not re-minted.
+    const working = memorySecretStore();
+    const result = await ensureAppleCertificateSecret({
+      relay,
+      teamId,
+      secretStore: working.store,
+      localFallbackStore: fallback.store,
+      storeAttempts: 2,
+    });
+    expect(state.mintedCertificateIds).toEqual(['CERT1']);
+    expect(result.recovered).toBe(true);
+    expect(result.created).toBe(false);
+    expect(result.certificateId).toBe('CERT1');
+    expect(result.secret.data.certificateP12Base64).toBe(parked?.data.certificateP12Base64);
+    // The parked copy is cleaned up after promotion.
+    expect(await fallback.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId)).toBeUndefined();
+  });
+
+  test('mints, parks, stores and cleans up the parked copy on success', async () => {
+    const state: PortalState = {
+      mintedCertificateIds: [],
+      certificateBase64: selfSignedCertificateBase64(),
+    };
+    const fallback = memorySecretStore();
+    const org = memorySecretStore();
+
+    const result = await ensureAppleCertificateSecret({
+      relay: fakePortalRelay(state),
+      teamId,
+      secretStore: org.store,
+      localFallbackStore: fallback.store,
+    });
+    expect(result.created).toBe(true);
+    expect(result.certificateId).toBe('CERT1');
+    expect((await org.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId))?.data.certificateID).toBe('CERT1');
+    expect(await fallback.store.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId)).toBeUndefined();
+  });
+
+  test('reuses the stored certificate when it is still on the team', async () => {
+    const state: PortalState = {
+      mintedCertificateIds: ['CERT1'],
+      certificateBase64: selfSignedCertificateBase64(),
+    };
+    const org = memorySecretStore();
+    await org.store.put(APPLE_CERTIFICATE_SECRET_TYPE, teamId, {
+      certificateP12Base64: 'cDEy',
+      certificateID: 'CERT1',
+      teamID: teamId,
+    });
+
+    const result = await ensureAppleCertificateSecret({
+      relay: fakePortalRelay(state),
+      teamId,
+      secretStore: org.store,
+      localFallbackStore: memorySecretStore().store,
+    });
+    expect(result.created).toBe(false);
+    expect(result.recovered).toBe(false);
+    expect(result.certificateId).toBe('CERT1');
+    expect(state.mintedCertificateIds).toEqual(['CERT1']);
+  });
+});
+
+describe('withRetries', () => {
+  test('returns after a transient failure and reports attempts', async () => {
+    const attempts: number[] = [];
+    let calls = 0;
+    const value = await withRetries(
+      async () => {
+        calls += 1;
+        if (calls < 3) throw new Error('transient');
+        return 'ok';
+      },
+      { attempts: 3, initialDelayMs: 1, onAttempt: (attempt) => attempts.push(attempt) },
+    );
+    expect(value).toBe('ok');
+    expect(attempts).toEqual([1, 2, 3]);
+  });
+
+  test('throws the last error when all attempts fail', async () => {
+    await expect(
+      withRetries(
+        async () => {
+          throw new Error('permanent');
+        },
+        { attempts: 2, initialDelayMs: 1 },
+      ),
+    ).rejects.toThrow('permanent');
+  });
+});

--- a/packages/ui/src/apple-credentials/index.ts
+++ b/packages/ui/src/apple-credentials/index.ts
@@ -1,0 +1,192 @@
+/**
+ * Headless helpers that turn an authenticated Apple relay session into
+ * signing credentials persisted in a SigningSecretStore. The Apple relay
+ * only proxies: certificate and profile bytes always land in the browser
+ * first, and the browser writes them into the configured store (Limrun's
+ * org secret store by default, or a customer-provided one).
+ */
+import {
+  createAppleCertificate,
+  downloadAppleCertificate,
+  downloadAppleProfile,
+  exportAppleCertificateP12,
+  generateAppleSigningKeyAndCSR,
+  listAppleCertificates,
+  listAppleProfiles,
+} from '../app-store-relay';
+import type { AppleRelayWebSocketClient } from '../core/device-install/apple';
+import { parseProvisioningProfileBase64 } from '../core/device-install/storage/browser-storage';
+import {
+  APPLE_CERTIFICATE_SECRET_TYPE,
+  putAppleCertificateSecret,
+  putAppleProvisioningProfileSecret,
+  type SigningSecret,
+  type SigningSecretStore,
+} from '../core/device-install/storage/secret-store';
+
+export {
+  APPLE_CERTIFICATE_SECRET_TYPE,
+  APPLE_PROVISIONING_PROFILE_SECRET_TYPE,
+  createBrowserSecretStore,
+  createLimrunSecretStore,
+  putAppleCertificateSecret,
+  putAppleProvisioningProfileSecret,
+  type AppleCertificateSecretData,
+  type AppleProvisioningProfileSecretData,
+  type LimrunSecretStoreOptions,
+  type SigningSecret,
+  type SigningSecretMetadata,
+  type SigningSecretStore,
+  type SigningSecretType,
+} from '../core/device-install/storage/secret-store';
+
+export type EnsureAppleCertificateInput = {
+  relay: AppleRelayWebSocketClient;
+  teamId: string;
+  secretStore: SigningSecretStore;
+  /** Common name used when minting a new certificate. */
+  commonName?: string;
+  log?: (message: string, detail?: string) => void;
+};
+
+export type EnsureAppleCertificateResult = {
+  secret: SigningSecret;
+  certificateId: string;
+  /** True when a new certificate was minted instead of reusing the stored one. */
+  created: boolean;
+};
+
+/**
+ * Returns a usable development certificate secret for the team, reusing the
+ * stored one when its certificate is still on the team and minting a new
+ * one otherwise. Apple caps development certificates at 2 and never returns
+ * private keys, so reuse of the stored p12 is strongly preferred.
+ */
+export async function ensureAppleCertificateSecret({
+  relay,
+  teamId,
+  secretStore,
+  commonName,
+  log = () => {},
+}: EnsureAppleCertificateInput): Promise<EnsureAppleCertificateResult> {
+  const current = await listAppleCertificates({ relay, teamId, certificateKind: 'development' });
+  const stored = await secretStore.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId);
+  const storedCertificateId = stored?.data.certificateID;
+  if (stored && storedCertificateId && stored.data.certificateP12Base64) {
+    // The stored value may be a certRequestId; resolve the canonical
+    // certificateId the profile API expects. If the cert is no longer on
+    // the team (revoked), fall through and mint a new one.
+    const matched = current.find(
+      (item) =>
+        stringField(item, 'certificateId') === storedCertificateId ||
+        stringField(item, 'certRequestId') === storedCertificateId,
+    );
+    if (matched) {
+      const certificateId = stringField(matched, 'certificateId') ?? storedCertificateId;
+      log('Reusing stored Apple certificate', certificateId);
+      return { secret: stored, certificateId, created: false };
+    }
+    log('Stored certificate is no longer on the team', 'Minting a new one.');
+  }
+
+  // The private key is generated and kept in this browser; Apple only ever
+  // sees the CSR. Without this key the downloaded cert cannot sign anything.
+  const key = await generateAppleSigningKeyAndCSR({ commonName: commonName ?? `Limrun ${teamId}` });
+  const certificate = await createAppleCertificate({
+    relay,
+    teamId,
+    certificateKind: 'development',
+    csrPEM: key.csrPEM,
+  });
+  const certificateId =
+    stringField(certificate, 'certificateId') ?? stringField(certificate, 'certRequestId');
+  if (!certificateId) {
+    throw new Error('Apple certificate creation did not return a certificate ID.');
+  }
+  const downloaded = await downloadAppleCertificate({
+    relay,
+    teamId,
+    certificateKind: 'development',
+    certificateId,
+  });
+  if (!downloaded.rawBodyBase64) {
+    throw new Error('Apple certificate download returned no bytes.');
+  }
+  const certificateP12Base64 = exportAppleCertificateP12({
+    privateKeyPKCS8Base64: key.privateKeyPKCS8Base64,
+    certificateBase64: downloaded.rawBodyBase64,
+    password: '',
+    friendlyName: `Apple Development ${teamId}`,
+  });
+  const listed = current.find(
+    (item) =>
+      stringField(item, 'certificateId') === certificateId ||
+      stringField(item, 'certRequestId') === certificateId,
+  );
+  const secret = await putAppleCertificateSecret(secretStore, teamId, {
+    certificateP12Base64,
+    teamID: teamId,
+    certificateID: certificateId,
+    serialNumber: stringField(listed, 'serialNum') ?? stringField(certificate, 'serialNum'),
+    expirationDate:
+      stringField(listed, 'expirationDateString') ?? stringField(certificate, 'expirationDateString'),
+  });
+  log('Apple certificate stored', certificateId);
+  return { secret, certificateId, created: true };
+}
+
+export type SaveAppleProfileInput = {
+  relay: AppleRelayWebSocketClient;
+  teamId: string;
+  profileId: string;
+  secretStore: SigningSecretStore;
+  log?: (message: string, detail?: string) => void;
+};
+
+/**
+ * Downloads the provisioning profile and stores it as an
+ * appleProvisioningProfile secret named `${teamId}/${bundleID}` (falling
+ * back to the profile UUID when the bundle ID cannot be parsed).
+ */
+export async function saveAppleProfileSecret({
+  relay,
+  teamId,
+  profileId,
+  secretStore,
+  log = () => {},
+}: SaveAppleProfileInput): Promise<SigningSecret> {
+  const downloaded = await downloadAppleProfile({ relay, teamId, profileId });
+  if (!downloaded.rawBodyBase64) {
+    throw new Error('Apple provisioning profile download returned no bytes.');
+  }
+  const info = parseProvisioningProfileBase64(downloaded.rawBodyBase64);
+  const name = `${teamId}/${info.bundleID ?? info.uuid ?? profileId}`;
+  const secret = await putAppleProvisioningProfileSecret(secretStore, name, {
+    provisioningProfileBase64: downloaded.rawBodyBase64,
+    teamID: info.teamID ?? teamId,
+    bundleID: info.bundleID,
+    profileName: info.name,
+    uuid: info.uuid,
+    expirationDate: info.expirationDate,
+  });
+  log('Apple provisioning profile stored', name);
+  return secret;
+}
+
+export type ListTeamProfilesInput = {
+  relay: AppleRelayWebSocketClient;
+  teamId: string;
+};
+
+/** Lists the team's development provisioning profiles from the portal. */
+export async function listTeamAppleProfiles({ relay, teamId }: ListTeamProfilesInput) {
+  return listAppleProfiles({ relay, teamId, profileKind: 'development' });
+}
+
+/** Read a string-ish value from a loosely typed portal record. */
+export function stringField(record: Record<string, unknown> | undefined, key: string) {
+  const value = record?.[key];
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}

--- a/packages/ui/src/apple-credentials/index.ts
+++ b/packages/ui/src/apple-credentials/index.ts
@@ -18,8 +18,10 @@ import type { AppleRelayWebSocketClient } from '../core/device-install/apple';
 import { parseProvisioningProfileBase64 } from '../core/device-install/storage/browser-storage';
 import {
   APPLE_CERTIFICATE_SECRET_TYPE,
+  createBrowserSecretStore,
   putAppleCertificateSecret,
   putAppleProvisioningProfileSecret,
+  type AppleCertificateSecretData,
   type SigningSecret,
   type SigningSecretStore,
 } from '../core/device-install/storage/secret-store';
@@ -40,13 +42,39 @@ export {
   type SigningSecretType,
 } from '../core/device-install/storage/secret-store';
 
+export type AppleCredentialProgressStep =
+  | 'checkingExisting'
+  | 'recoveringSavedKey'
+  | 'generatingKey'
+  | 'creatingCertificate'
+  | 'downloadingCertificate'
+  | 'storingSecret'
+  | 'stored';
+
+export type AppleCredentialProgress = {
+  step: AppleCredentialProgressStep;
+  /** Set while retrying the secret-store write. */
+  attempt?: number;
+  attempts?: number;
+};
+
 export type EnsureAppleCertificateInput = {
   relay: AppleRelayWebSocketClient;
   teamId: string;
   secretStore: SigningSecretStore;
   /** Common name used when minting a new certificate. */
   commonName?: string;
+  /**
+   * Where the freshly exported p12 is parked before (and while) the write
+   * to secretStore is retried, so a failed write can never lose the only
+   * copy of the private key. Defaults to this browser's IndexedDB; pass
+   * undefined-returning stub only in non-browser environments.
+   */
+  localFallbackStore?: SigningSecretStore;
+  /** Number of attempts for the secret-store write. */
+  storeAttempts?: number;
   log?: (message: string, detail?: string) => void;
+  onProgress?: (progress: AppleCredentialProgress) => void;
 };
 
 export type EnsureAppleCertificateResult = {
@@ -54,44 +82,100 @@ export type EnsureAppleCertificateResult = {
   certificateId: string;
   /** True when a new certificate was minted instead of reusing the stored one. */
   created: boolean;
+  /** True when the p12 was recovered from the local fallback of a previously failed store write. */
+  recovered: boolean;
 };
+
+function defaultLocalFallbackStore(): SigningSecretStore | undefined {
+  // Non-browser callers (tests, SSR) have no IndexedDB; they must inject a
+  // fallback store explicitly to get the parking behavior.
+  return typeof indexedDB === 'undefined' ? undefined : createBrowserSecretStore();
+}
 
 /**
  * Returns a usable development certificate secret for the team, reusing the
  * stored one when its certificate is still on the team and minting a new
  * one otherwise. Apple caps development certificates at 2 and never returns
  * private keys, so reuse of the stored p12 is strongly preferred.
+ *
+ * Minting a certificate is an irreversible portal mutation, so the flow is
+ * built to never lose the private key afterwards: the exported p12 is
+ * parked in the local fallback store before the org-store write, the write
+ * is retried with backoff, and a later call recovers a parked key (as long
+ * as its certificate is still on the team) instead of minting again.
  */
 export async function ensureAppleCertificateSecret({
   relay,
   teamId,
   secretStore,
   commonName,
+  localFallbackStore = defaultLocalFallbackStore(),
+  storeAttempts = 5,
   log = () => {},
+  onProgress = () => {},
 }: EnsureAppleCertificateInput): Promise<EnsureAppleCertificateResult> {
+  onProgress({ step: 'checkingExisting' });
   const current = await listAppleCertificates({ relay, teamId, certificateKind: 'development' });
+  const findOnTeam = (certificateId: string | undefined) =>
+    certificateId === undefined ? undefined : (
+      current.find(
+        (item) =>
+          stringField(item, 'certificateId') === certificateId ||
+          stringField(item, 'certRequestId') === certificateId,
+      )
+    );
+
   const stored = await secretStore.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId);
-  const storedCertificateId = stored?.data.certificateID;
-  if (stored && storedCertificateId && stored.data.certificateP12Base64) {
+  if (stored?.data.certificateID && stored.data.certificateP12Base64) {
     // The stored value may be a certRequestId; resolve the canonical
     // certificateId the profile API expects. If the cert is no longer on
     // the team (revoked), fall through and mint a new one.
-    const matched = current.find(
-      (item) =>
-        stringField(item, 'certificateId') === storedCertificateId ||
-        stringField(item, 'certRequestId') === storedCertificateId,
-    );
+    const matched = findOnTeam(stored.data.certificateID);
     if (matched) {
-      const certificateId = stringField(matched, 'certificateId') ?? storedCertificateId;
+      const certificateId = stringField(matched, 'certificateId') ?? stored.data.certificateID;
       log('Reusing stored Apple certificate', certificateId);
-      return { secret: stored, certificateId, created: false };
+      return { secret: stored, certificateId, created: false, recovered: false };
     }
     log('Stored certificate is no longer on the team', 'Minting a new one.');
   }
 
+  const storeWithRetries = async (data: AppleCertificateSecretData) => {
+    return withRetries(() => putAppleCertificateSecret(secretStore, teamId, data), {
+      attempts: storeAttempts,
+      onAttempt: (attempt, error) => {
+        onProgress({ step: 'storingSecret', attempt, attempts: storeAttempts });
+        if (error) log('Retrying secret store write', errorText(error));
+      },
+    });
+  };
+
+  // A previous run may have minted a certificate and failed the org-store
+  // write; its p12 is parked locally. Promote it instead of minting again,
+  // which would burn another slot of Apple's two-certificate cap.
+  const parked = await localFallbackStore?.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId);
+  if (parked?.data.certificateID && parked.data.certificateP12Base64) {
+    const matched = findOnTeam(parked.data.certificateID);
+    if (matched) {
+      onProgress({ step: 'recoveringSavedKey' });
+      const certificateId = stringField(matched, 'certificateId') ?? parked.data.certificateID;
+      log('Recovering certificate key from this browser', certificateId);
+      const secret = await storeWithRetries({
+        ...(parked.data as AppleCertificateSecretData),
+        certificateID: certificateId,
+      });
+      await localFallbackStore?.delete(APPLE_CERTIFICATE_SECRET_TYPE, teamId).catch(() => undefined);
+      onProgress({ step: 'stored' });
+      return { secret, certificateId, created: false, recovered: true };
+    }
+    // The parked certificate was revoked on the portal; the key is useless.
+    await localFallbackStore?.delete(APPLE_CERTIFICATE_SECRET_TYPE, teamId).catch(() => undefined);
+  }
+
   // The private key is generated and kept in this browser; Apple only ever
   // sees the CSR. Without this key the downloaded cert cannot sign anything.
+  onProgress({ step: 'generatingKey' });
   const key = await generateAppleSigningKeyAndCSR({ commonName: commonName ?? `Limrun ${teamId}` });
+  onProgress({ step: 'creatingCertificate' });
   const certificate = await createAppleCertificate({
     relay,
     teamId,
@@ -103,43 +187,106 @@ export async function ensureAppleCertificateSecret({
   if (!certificateId) {
     throw new Error('Apple certificate creation did not return a certificate ID.');
   }
-  const downloaded = await downloadAppleCertificate({
-    relay,
-    teamId,
-    certificateKind: 'development',
-    certificateId,
-  });
-  if (!downloaded.rawBodyBase64) {
-    throw new Error('Apple certificate download returned no bytes.');
-  }
-  const certificateP12Base64 = exportAppleCertificateP12({
-    privateKeyPKCS8Base64: key.privateKeyPKCS8Base64,
-    certificateBase64: downloaded.rawBodyBase64,
-    password: '',
-    friendlyName: `Apple Development ${teamId}`,
-  });
-  const listed = current.find(
-    (item) =>
-      stringField(item, 'certificateId') === certificateId ||
-      stringField(item, 'certRequestId') === certificateId,
+  onProgress({ step: 'downloadingCertificate' });
+  // From here on the portal mutation already happened; download is a read
+  // and safe to retry so a transient relay hiccup cannot orphan the key.
+  const downloaded = await withRetries(
+    async () => {
+      const response = await downloadAppleCertificate({
+        relay,
+        teamId,
+        certificateKind: 'development',
+        certificateId,
+      });
+      if (!response.rawBodyBase64) {
+        throw new Error('Apple certificate download returned no bytes.');
+      }
+      return response;
+    },
+    { attempts: 3 },
   );
-  const secret = await putAppleCertificateSecret(secretStore, teamId, {
-    certificateP12Base64,
+  const data: AppleCertificateSecretData = {
+    certificateP12Base64: exportAppleCertificateP12({
+      privateKeyPKCS8Base64: key.privateKeyPKCS8Base64,
+      certificateBase64: downloaded.rawBodyBase64,
+      password: '',
+      friendlyName: `Apple Development ${teamId}`,
+    }),
     teamID: teamId,
     certificateID: certificateId,
-    serialNumber: stringField(listed, 'serialNum') ?? stringField(certificate, 'serialNum'),
-    expirationDate:
-      stringField(listed, 'expirationDateString') ?? stringField(certificate, 'expirationDateString'),
-  });
+    serialNumber: stringField(certificate, 'serialNum'),
+    expirationDate: stringField(certificate, 'expirationDateString'),
+  };
+
+  // Park the p12 locally before attempting the org-store write: the local
+  // put is the durability floor that makes a failed (or interrupted) write
+  // recoverable without minting another certificate.
+  await putAppleCertificateSecret(localFallbackStore ?? noopStore, teamId, data).catch((error) =>
+    log('Could not park certificate key locally', errorText(error)),
+  );
+
+  onProgress({ step: 'storingSecret', attempt: 1, attempts: storeAttempts });
+  let secret: SigningSecret;
+  try {
+    secret = await storeWithRetries(data);
+  } catch (error) {
+    throw new Error(
+      `Certificate ${certificateId} was created on the Apple Developer portal but saving it to the ` +
+        `secret store failed: ${errorText(error)}. The private key is kept safely in this browser; ` +
+        `retry to save it without creating another certificate.`,
+    );
+  }
+  await localFallbackStore?.delete(APPLE_CERTIFICATE_SECRET_TYPE, teamId).catch(() => undefined);
   log('Apple certificate stored', certificateId);
-  return { secret, certificateId, created: true };
+  onProgress({ step: 'stored' });
+  return { secret, certificateId, created: true, recovered: false };
 }
+
+export type WithRetriesOptions = {
+  attempts?: number;
+  initialDelayMs?: number;
+  onAttempt?: (attempt: number, previousError?: unknown) => void;
+};
+
+/** Runs fn with exponential backoff between attempts. */
+export async function withRetries<T>(
+  fn: () => Promise<T>,
+  { attempts = 5, initialDelayMs = 1000, onAttempt }: WithRetriesOptions = {},
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (attempt > 1) {
+      await new Promise((resolve) => setTimeout(resolve, initialDelayMs * 2 ** (attempt - 2)));
+    }
+    onAttempt?.(attempt, lastError);
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Sink for the local parking write when no fallback store is available. */
+const noopStore: SigningSecretStore = {
+  put: async (type, name, data) => ({ type, name, data }),
+  get: async () => undefined,
+  list: async () => [],
+  delete: async () => {},
+};
 
 export type SaveAppleProfileInput = {
   relay: AppleRelayWebSocketClient;
   teamId: string;
   profileId: string;
   secretStore: SigningSecretStore;
+  /** Number of attempts for the secret-store write. */
+  storeAttempts?: number;
   log?: (message: string, detail?: string) => void;
 };
 
@@ -153,22 +300,36 @@ export async function saveAppleProfileSecret({
   teamId,
   profileId,
   secretStore,
+  storeAttempts = 5,
   log = () => {},
 }: SaveAppleProfileInput): Promise<SigningSecret> {
   const downloaded = await downloadAppleProfile({ relay, teamId, profileId });
-  if (!downloaded.rawBodyBase64) {
+  const profileBase64 = downloaded.rawBodyBase64;
+  if (!profileBase64) {
     throw new Error('Apple provisioning profile download returned no bytes.');
   }
-  const info = parseProvisioningProfileBase64(downloaded.rawBodyBase64);
+  const info = parseProvisioningProfileBase64(profileBase64);
   const name = `${teamId}/${info.bundleID ?? info.uuid ?? profileId}`;
-  const secret = await putAppleProvisioningProfileSecret(secretStore, name, {
-    provisioningProfileBase64: downloaded.rawBodyBase64,
-    teamID: info.teamID ?? teamId,
-    bundleID: info.bundleID,
-    profileName: info.name,
-    uuid: info.uuid,
-    expirationDate: info.expirationDate,
-  });
+  // Unlike certificates, a failed profile write loses nothing (the profile
+  // can always be re-downloaded), but retrying keeps the whole save flow
+  // resilient to transient store errors.
+  const secret = await withRetries(
+    () =>
+      putAppleProvisioningProfileSecret(secretStore, name, {
+        provisioningProfileBase64: profileBase64,
+        teamID: info.teamID ?? teamId,
+        bundleID: info.bundleID,
+        profileName: info.name,
+        uuid: info.uuid,
+        expirationDate: info.expirationDate,
+      }),
+    {
+      attempts: storeAttempts,
+      onAttempt: (_attempt, error) => {
+        if (error) log('Retrying profile secret write', errorText(error));
+      },
+    },
+  );
   log('Apple provisioning profile stored', name);
   return secret;
 }

--- a/packages/ui/src/apple-credentials/index.ts
+++ b/packages/ui/src/apple-credentials/index.ts
@@ -15,13 +15,16 @@ import {
   listAppleProfiles,
 } from '../app-store-relay';
 import type { AppleRelayWebSocketClient } from '../core/device-install/apple';
-import { parseProvisioningProfileBase64 } from '../core/device-install/storage/browser-storage';
+import {
+  normalizeCertificateSerial,
+  parseProvisioningProfileBase64,
+} from '../core/device-install/storage/browser-storage';
 import {
   APPLE_CERTIFICATE_SECRET_TYPE,
-  createBrowserSecretStore,
   putAppleCertificateSecret,
   putAppleProvisioningProfileSecret,
   type AppleCertificateSecretData,
+  type AppleCertificateType,
   type SigningSecret,
   type SigningSecretStore,
 } from '../core/device-install/storage/secret-store';
@@ -34,29 +37,25 @@ export {
   putAppleCertificateSecret,
   putAppleProvisioningProfileSecret,
   type AppleCertificateSecretData,
+  type AppleCertificateType,
   type AppleProvisioningProfileSecretData,
   type LimrunSecretStoreOptions,
   type SigningSecret,
+  type SigningSecretData,
   type SigningSecretMetadata,
   type SigningSecretStore,
   type SigningSecretType,
 } from '../core/device-install/storage/secret-store';
+export { normalizeCertificateSerial } from '../core/device-install/storage/browser-storage';
 
-export type AppleCredentialProgressStep =
-  | 'checkingExisting'
-  | 'recoveringSavedKey'
-  | 'generatingKey'
-  | 'creatingCertificate'
-  | 'downloadingCertificate'
-  | 'storingSecret'
-  | 'stored';
-
-export type AppleCredentialProgress = {
-  step: AppleCredentialProgressStep;
-  /** Set while retrying the secret-store write. */
-  attempt?: number;
-  attempts?: number;
-};
+/**
+ * Conventional secret name of a team's certificate bundle. One bundle per
+ * team and Apple certificate type; the type is in the name so development
+ * and distribution material never collide.
+ */
+export function appleCertificateSecretName(teamId: string, certificateType: AppleCertificateType) {
+  return `${teamId}/${certificateType}`;
+}
 
 export type EnsureAppleCertificateInput = {
   relay: AppleRelayWebSocketClient;
@@ -64,17 +63,7 @@ export type EnsureAppleCertificateInput = {
   secretStore: SigningSecretStore;
   /** Common name used when minting a new certificate. */
   commonName?: string;
-  /**
-   * Where the freshly exported p12 is parked before (and while) the write
-   * to secretStore is retried, so a failed write can never lose the only
-   * copy of the private key. Defaults to this browser's IndexedDB; pass
-   * undefined-returning stub only in non-browser environments.
-   */
-  localFallbackStore?: SigningSecretStore;
-  /** Number of attempts for the secret-store write. */
-  storeAttempts?: number;
   log?: (message: string, detail?: string) => void;
-  onProgress?: (progress: AppleCredentialProgress) => void;
 };
 
 export type EnsureAppleCertificateResult = {
@@ -82,15 +71,7 @@ export type EnsureAppleCertificateResult = {
   certificateId: string;
   /** True when a new certificate was minted instead of reusing the stored one. */
   created: boolean;
-  /** True when the p12 was recovered from the local fallback of a previously failed store write. */
-  recovered: boolean;
 };
-
-function defaultLocalFallbackStore(): SigningSecretStore | undefined {
-  // Non-browser callers (tests, SSR) have no IndexedDB; they must inject a
-  // fallback store explicitly to get the parking behavior.
-  return typeof indexedDB === 'undefined' ? undefined : createBrowserSecretStore();
-}
 
 /**
  * Returns a usable development certificate secret for the team, reusing the
@@ -98,23 +79,21 @@ function defaultLocalFallbackStore(): SigningSecretStore | undefined {
  * one otherwise. Apple caps development certificates at 2 and never returns
  * private keys, so reuse of the stored p12 is strongly preferred.
  *
- * Minting a certificate is an irreversible portal mutation, so the flow is
- * built to never lose the private key afterwards: the exported p12 is
- * parked in the local fallback store before the org-store write, the write
- * is retried with backoff, and a later call recovers a parked key (as long
- * as its certificate is still on the team) instead of minting again.
+ * Durability of the stored material is the secret store's concern:
+ * implementors who want retries or fallbacks build them into their
+ * SigningSecretStore.
  */
 export async function ensureAppleCertificateSecret({
   relay,
   teamId,
   secretStore,
   commonName,
-  localFallbackStore = defaultLocalFallbackStore(),
-  storeAttempts = 5,
   log = () => {},
-  onProgress = () => {},
 }: EnsureAppleCertificateInput): Promise<EnsureAppleCertificateResult> {
-  onProgress({ step: 'checkingExisting' });
+  // The browser flow mints via the portal's development kind, which is
+  // the DEVELOPMENT certificate type in Apple's App Store Connect enum.
+  const certificateType: AppleCertificateType = 'DEVELOPMENT';
+  const secretName = appleCertificateSecretName(teamId, certificateType);
   const current = await listAppleCertificates({ relay, teamId, certificateKind: 'development' });
   const findOnTeam = (certificateId: string | undefined) =>
     certificateId === undefined ? undefined : (
@@ -125,57 +104,24 @@ export async function ensureAppleCertificateSecret({
       )
     );
 
-  const stored = await secretStore.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId);
-  if (stored?.data.certificateID && stored.data.certificateP12Base64) {
+  const stored = await secretStore.get(APPLE_CERTIFICATE_SECRET_TYPE, secretName);
+  const storedCertificateId = stringField(stored?.data, 'certificateID');
+  if (stored && storedCertificateId && stored.data.certificateP12Base64) {
     // The stored value may be a certRequestId; resolve the canonical
     // certificateId the profile API expects. If the cert is no longer on
     // the team (revoked), fall through and mint a new one.
-    const matched = findOnTeam(stored.data.certificateID);
+    const matched = findOnTeam(storedCertificateId);
     if (matched) {
-      const certificateId = stringField(matched, 'certificateId') ?? stored.data.certificateID;
+      const certificateId = stringField(matched, 'certificateId') ?? storedCertificateId;
       log('Reusing stored Apple certificate', certificateId);
-      return { secret: stored, certificateId, created: false, recovered: false };
+      return { secret: stored, certificateId, created: false };
     }
     log('Stored certificate is no longer on the team', 'Minting a new one.');
   }
 
-  const storeWithRetries = async (data: AppleCertificateSecretData) => {
-    return withRetries(() => putAppleCertificateSecret(secretStore, teamId, data), {
-      attempts: storeAttempts,
-      onAttempt: (attempt, error) => {
-        onProgress({ step: 'storingSecret', attempt, attempts: storeAttempts });
-        if (error) log('Retrying secret store write', errorText(error));
-      },
-    });
-  };
-
-  // A previous run may have minted a certificate and failed the org-store
-  // write; its p12 is parked locally. Promote it instead of minting again,
-  // which would burn another slot of Apple's two-certificate cap.
-  const parked = await localFallbackStore?.get(APPLE_CERTIFICATE_SECRET_TYPE, teamId);
-  if (parked?.data.certificateID && parked.data.certificateP12Base64) {
-    const matched = findOnTeam(parked.data.certificateID);
-    if (matched) {
-      onProgress({ step: 'recoveringSavedKey' });
-      const certificateId = stringField(matched, 'certificateId') ?? parked.data.certificateID;
-      log('Recovering certificate key from this browser', certificateId);
-      const secret = await storeWithRetries({
-        ...(parked.data as AppleCertificateSecretData),
-        certificateID: certificateId,
-      });
-      await localFallbackStore?.delete(APPLE_CERTIFICATE_SECRET_TYPE, teamId).catch(() => undefined);
-      onProgress({ step: 'stored' });
-      return { secret, certificateId, created: false, recovered: true };
-    }
-    // The parked certificate was revoked on the portal; the key is useless.
-    await localFallbackStore?.delete(APPLE_CERTIFICATE_SECRET_TYPE, teamId).catch(() => undefined);
-  }
-
   // The private key is generated and kept in this browser; Apple only ever
   // sees the CSR. Without this key the downloaded cert cannot sign anything.
-  onProgress({ step: 'generatingKey' });
   const key = await generateAppleSigningKeyAndCSR({ commonName: commonName ?? `Limrun ${teamId}` });
-  onProgress({ step: 'creatingCertificate' });
   const certificate = await createAppleCertificate({
     relay,
     teamId,
@@ -187,24 +133,15 @@ export async function ensureAppleCertificateSecret({
   if (!certificateId) {
     throw new Error('Apple certificate creation did not return a certificate ID.');
   }
-  onProgress({ step: 'downloadingCertificate' });
-  // From here on the portal mutation already happened; download is a read
-  // and safe to retry so a transient relay hiccup cannot orphan the key.
-  const downloaded = await withRetries(
-    async () => {
-      const response = await downloadAppleCertificate({
-        relay,
-        teamId,
-        certificateKind: 'development',
-        certificateId,
-      });
-      if (!response.rawBodyBase64) {
-        throw new Error('Apple certificate download returned no bytes.');
-      }
-      return response;
-    },
-    { attempts: 3 },
-  );
+  const downloaded = await downloadAppleCertificate({
+    relay,
+    teamId,
+    certificateKind: 'development',
+    certificateId,
+  });
+  if (!downloaded.rawBodyBase64) {
+    throw new Error('Apple certificate download returned no bytes.');
+  }
   const data: AppleCertificateSecretData = {
     certificateP12Base64: exportAppleCertificateP12({
       privateKeyPKCS8Base64: key.privateKeyPKCS8Base64,
@@ -212,95 +149,56 @@ export async function ensureAppleCertificateSecret({
       password: '',
       friendlyName: `Apple Development ${teamId}`,
     }),
+    certificateType,
     teamID: teamId,
     certificateID: certificateId,
-    serialNumber: stringField(certificate, 'serialNum'),
+    // Normalized so it equals the serials profiles reference.
+    serialNumber: normalizeCertificateSerial(stringField(certificate, 'serialNum')),
     expirationDate: stringField(certificate, 'expirationDateString'),
   };
 
-  // Park the p12 locally before attempting the org-store write: the local
-  // put is the durability floor that makes a failed (or interrupted) write
-  // recoverable without minting another certificate.
-  await putAppleCertificateSecret(localFallbackStore ?? noopStore, teamId, data).catch((error) =>
-    log('Could not park certificate key locally', errorText(error)),
-  );
-
-  onProgress({ step: 'storingSecret', attempt: 1, attempts: storeAttempts });
   let secret: SigningSecret;
   try {
-    secret = await storeWithRetries(data);
+    secret = await putAppleCertificateSecret(secretStore, secretName, data);
   } catch (error) {
+    // The key existed only in this browser's memory; once this throw
+    // unwinds it is gone, and the portal certificate is unusable.
     throw new Error(
-      `Certificate ${certificateId} was created on the Apple Developer portal but saving it to the ` +
-        `secret store failed: ${errorText(error)}. The private key is kept safely in this browser; ` +
-        `retry to save it without creating another certificate.`,
+      `Certificate ${certificateId} was created on the Apple Developer portal but saving its private ` +
+        `key to the secret store failed: ${errorText(error)}. The key cannot be recovered; revoke ` +
+        `certificate ${certificateId} at developer.apple.com before retrying, or the retry will mint ` +
+        `another certificate against Apple's limit.`,
     );
   }
-  await localFallbackStore?.delete(APPLE_CERTIFICATE_SECRET_TYPE, teamId).catch(() => undefined);
   log('Apple certificate stored', certificateId);
-  onProgress({ step: 'stored' });
-  return { secret, certificateId, created: true, recovered: false };
-}
-
-export type WithRetriesOptions = {
-  attempts?: number;
-  initialDelayMs?: number;
-  onAttempt?: (attempt: number, previousError?: unknown) => void;
-};
-
-/** Runs fn with exponential backoff between attempts. */
-export async function withRetries<T>(
-  fn: () => Promise<T>,
-  { attempts = 5, initialDelayMs = 1000, onAttempt }: WithRetriesOptions = {},
-): Promise<T> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    if (attempt > 1) {
-      await new Promise((resolve) => setTimeout(resolve, initialDelayMs * 2 ** (attempt - 2)));
-    }
-    onAttempt?.(attempt, lastError);
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  throw lastError;
+  return { secret, certificateId, created: true };
 }
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** Sink for the local parking write when no fallback store is available. */
-const noopStore: SigningSecretStore = {
-  put: async (type, name, data) => ({ type, name, data }),
-  get: async () => undefined,
-  list: async () => [],
-  delete: async () => {},
-};
-
 export type SaveAppleProfileInput = {
   relay: AppleRelayWebSocketClient;
   teamId: string;
   profileId: string;
   secretStore: SigningSecretStore;
-  /** Number of attempts for the secret-store write. */
-  storeAttempts?: number;
   log?: (message: string, detail?: string) => void;
 };
 
 /**
  * Downloads the provisioning profile and stores it as an
- * appleProvisioningProfile secret named `${teamId}/${bundleID}` (falling
- * back to the profile UUID when the bundle ID cannot be parsed).
+ * appleProvisioningProfile secret named `${teamId}/${uuid}`. The UUID is
+ * unique per profile, so a team can hold many profiles for the same
+ * bundle ID and certificate set; the reference fields (certificate
+ * serials, bundle IDs, device IDs parsed out of the profile) are what
+ * consumers filter on.
  */
 export async function saveAppleProfileSecret({
   relay,
   teamId,
   profileId,
   secretStore,
-  storeAttempts = 5,
   log = () => {},
 }: SaveAppleProfileInput): Promise<SigningSecret> {
   const downloaded = await downloadAppleProfile({ relay, teamId, profileId });
@@ -309,27 +207,17 @@ export async function saveAppleProfileSecret({
     throw new Error('Apple provisioning profile download returned no bytes.');
   }
   const info = parseProvisioningProfileBase64(profileBase64);
-  const name = `${teamId}/${info.bundleID ?? info.uuid ?? profileId}`;
-  // Unlike certificates, a failed profile write loses nothing (the profile
-  // can always be re-downloaded), but retrying keeps the whole save flow
-  // resilient to transient store errors.
-  const secret = await withRetries(
-    () =>
-      putAppleProvisioningProfileSecret(secretStore, name, {
-        provisioningProfileBase64: profileBase64,
-        teamID: info.teamID ?? teamId,
-        bundleID: info.bundleID,
-        profileName: info.name,
-        uuid: info.uuid,
-        expirationDate: info.expirationDate,
-      }),
-    {
-      attempts: storeAttempts,
-      onAttempt: (_attempt, error) => {
-        if (error) log('Retrying profile secret write', errorText(error));
-      },
-    },
-  );
+  const name = `${teamId}/${info.uuid ?? profileId}`;
+  const secret = await putAppleProvisioningProfileSecret(secretStore, name, {
+    provisioningProfileBase64: profileBase64,
+    certificateSerialNumbers: info.certificateSerialNumbers.join(','),
+    bundleIDs: info.bundleID,
+    deviceIDs: info.provisionedDevices.join(','),
+    teamID: info.teamID ?? teamId,
+    profileName: info.name,
+    uuid: info.uuid,
+    expirationDate: info.expirationDate,
+  });
   log('Apple provisioning profile stored', name);
   return secret;
 }

--- a/packages/ui/src/core/device-install/storage/browser-storage.test.ts
+++ b/packages/ui/src/core/device-install/storage/browser-storage.test.ts
@@ -1,0 +1,65 @@
+import forge from 'node-forge';
+import { describe, expect, test } from 'vitest';
+import { normalizeCertificateSerial, parseProvisioningProfileBase64 } from './browser-storage';
+
+function selfSignedCertificateBase64(serialNumber: string) {
+  const keys = forge.pki.rsa.generateKeyPair(1024);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = serialNumber;
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const attrs = [{ name: 'commonName', value: 'Apple Development Test' }];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey);
+  return forge.util.encode64(forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes());
+}
+
+function profileBase64(certificatesBase64: string[]) {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Name</key><string>Limrun Dev</string>
+  <key>UUID</key><string>11111111-2222-3333-4444-555555555555</string>
+  <key>TeamIdentifier</key><array><string>TEAM123</string></array>
+  <key>ProvisionedDevices</key><array><string>00008030-000A</string></array>
+  <key>DeveloperCertificates</key>
+  <array>${certificatesBase64.map((c) => `<data>${c}</data>`).join('')}</array>
+  <key>Entitlements</key>
+  <dict>
+    <key>application-identifier</key><string>TEAM123.com.example.app</string>
+    <key>com.apple.developer.team-identifier</key><string>TEAM123</string>
+  </dict>
+</dict>
+</plist>`;
+  return btoa(xml);
+}
+
+describe('parseProvisioningProfileBase64', () => {
+  test('extracts embedded certificate serial numbers in normalized form', () => {
+    const parsed = parseProvisioningProfileBase64(
+      profileBase64([selfSignedCertificateBase64('00ab12cd'), selfSignedCertificateBase64('7f')]),
+    );
+    expect(parsed.certificateSerialNumbers).toEqual(['AB12CD', '7F']);
+    expect(parsed.bundleID).toBe('com.example.app');
+    expect(parsed.teamID).toBe('TEAM123');
+    expect(parsed.provisionedDevices).toEqual(['00008030-000A']);
+  });
+
+  test('skips unparseable certificates instead of failing the profile', () => {
+    const parsed = parseProvisioningProfileBase64(
+      profileBase64([btoa('not a certificate'), selfSignedCertificateBase64('1a')]),
+    );
+    expect(parsed.certificateSerialNumbers).toEqual(['1A']);
+  });
+});
+
+describe('normalizeCertificateSerial', () => {
+  test('uppercases and strips leading zeros', () => {
+    expect(normalizeCertificateSerial('00ab12')).toBe('AB12');
+    expect(normalizeCertificateSerial('AB12')).toBe('AB12');
+    expect(normalizeCertificateSerial('')).toBeUndefined();
+    expect(normalizeCertificateSerial(undefined)).toBeUndefined();
+  });
+});

--- a/packages/ui/src/core/device-install/storage/browser-storage.ts
+++ b/packages/ui/src/core/device-install/storage/browser-storage.ts
@@ -1,3 +1,4 @@
+import forge from 'node-forge';
 import type {
   DeviceInstallSigningMode,
   ProvisioningProfileInfo,
@@ -198,9 +199,41 @@ export function parseProvisioningProfileBytes(bytes: Uint8Array) {
     applicationIdentifier,
     bundleID,
     provisionedDevices: stringArrayValue(value.ProvisionedDevices),
+    certificateSerialNumbers: certificateSerialNumbers(stringArrayValue(value.DeveloperCertificates)),
     getTaskAllow: booleanValue(entitlements['get-task-allow']),
     expirationDate: stringValue(value.ExpirationDate),
   } satisfies ProvisioningProfileInfo;
+}
+
+/**
+ * Normalizes a certificate serial number for comparison: uppercase hex
+ * without leading zeros, the format Apple's portal reports in serialNum.
+ */
+export function normalizeCertificateSerial(serial?: string) {
+  const normalized = (serial ?? '').replace(/^0+/, '').toUpperCase();
+  return normalized || undefined;
+}
+
+/**
+ * Reads the serial numbers of the DER certificates embedded in a profile's
+ * DeveloperCertificates array. Unparseable entries are skipped: a profile
+ * with an exotic certificate should degrade to weaker filtering, not fail
+ * the whole parse.
+ */
+function certificateSerialNumbers(developerCertificatesBase64: string[]) {
+  const serials: string[] = [];
+  for (const entry of developerCertificatesBase64) {
+    try {
+      // Plist <data> payloads wrap base64 across lines; atob rejects whitespace.
+      const der = atob(entry.replace(/\s+/g, ''));
+      const certificate = forge.pki.certificateFromAsn1(forge.asn1.fromDer(forge.util.createBuffer(der)));
+      const serial = normalizeCertificateSerial(certificate.serialNumber);
+      if (serial && !serials.includes(serial)) serials.push(serial);
+    } catch {
+      // Skip certificates forge cannot parse.
+    }
+  }
+  return serials;
 }
 
 async function getSigningAssetsByID(id?: string) {

--- a/packages/ui/src/core/device-install/storage/index.ts
+++ b/packages/ui/src/core/device-install/storage/index.ts
@@ -1,1 +1,2 @@
 export * from './browser-storage';
+export * from './secret-store';

--- a/packages/ui/src/core/device-install/storage/secret-store.ts
+++ b/packages/ui/src/core/device-install/storage/secret-store.ts
@@ -1,0 +1,260 @@
+/**
+ * A pluggable store for Apple signing secrets.
+ *
+ * Credential material always lands in the browser first (the Apple relay
+ * only proxies); the browser then writes it into a store implementing this
+ * interface. Limrun's org secret store is the default implementation, an
+ * IndexedDB-backed one keeps everything local, and customers can bring
+ * their own store by implementing the same interface.
+ */
+
+export const APPLE_CERTIFICATE_SECRET_TYPE = 'appleCertificate';
+export const APPLE_PROVISIONING_PROFILE_SECRET_TYPE = 'appleProvisioningProfile';
+
+export type SigningSecretType =
+  | typeof APPLE_CERTIFICATE_SECRET_TYPE
+  | typeof APPLE_PROVISIONING_PROFILE_SECRET_TYPE;
+
+export type SigningSecretMetadata = {
+  type: string;
+  name: string;
+  createdAt?: string;
+};
+
+export type SigningSecret = SigningSecretMetadata & {
+  data: Record<string, string>;
+};
+
+export interface SigningSecretStore {
+  /**
+   * Stores a secret. When a secret with the same type and name already
+   * exists its data is overwritten. Returns the stored secret; callers
+   * should use the returned data.
+   */
+  put(type: SigningSecretType, name: string, data: Record<string, string>): Promise<SigningSecret>;
+  /** Returns the secret including its data, or undefined when absent. */
+  get(type: SigningSecretType, name: string): Promise<SigningSecret | undefined>;
+  /** Lists metadata of all stored signing secrets, never their data. */
+  list(): Promise<SigningSecretMetadata[]>;
+  /** Deletes a secret; resolves even when the secret does not exist. */
+  delete(type: SigningSecretType, name: string): Promise<void>;
+}
+
+/** Data payload of an appleCertificate secret. */
+export type AppleCertificateSecretData = {
+  certificateP12Base64: string;
+  certificatePassword?: string;
+  teamID?: string;
+  certificateID?: string;
+  serialNumber?: string;
+  expirationDate?: string;
+};
+
+/** Data payload of an appleProvisioningProfile secret. */
+export type AppleProvisioningProfileSecretData = {
+  provisioningProfileBase64: string;
+  teamID?: string;
+  bundleID?: string;
+  profileName?: string;
+  uuid?: string;
+  expirationDate?: string;
+};
+
+function compactData(data: Record<string, string | undefined>) {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value) result[key] = value;
+  }
+  return result;
+}
+
+/** Stores an Apple development certificate (p12 + password) under the team ID. */
+export async function putAppleCertificateSecret(
+  store: SigningSecretStore,
+  name: string,
+  data: AppleCertificateSecretData,
+) {
+  return store.put(APPLE_CERTIFICATE_SECRET_TYPE, name, compactData(data));
+}
+
+/** Stores a provisioning profile, conventionally named `${teamID}/${bundleID}`. */
+export async function putAppleProvisioningProfileSecret(
+  store: SigningSecretStore,
+  name: string,
+  data: AppleProvisioningProfileSecretData,
+) {
+  return store.put(APPLE_PROVISIONING_PROFILE_SECRET_TYPE, name, compactData(data));
+}
+
+export type LimrunSecretStoreOptions = {
+  /** Base URL of the Limrun backend API, e.g. https://api.limrun.com */
+  apiUrl: string;
+  /** Bearer token: a user or organization token. */
+  token: string;
+  /** Organization TID owning the secrets. */
+  organizationId: string;
+  /** Custom fetch, mainly for tests. */
+  fetch?: typeof fetch;
+};
+
+type BackendSecretResult = {
+  id: string;
+  type: string;
+  name: string;
+  organizationId: string;
+  data: Record<string, string>;
+  createdAt: string;
+};
+
+/**
+ * A SigningSecretStore backed by Limrun's organization secret store
+ * (`/v1/organizations/{org}/secrets`). Secrets are stored server-side and
+ * shared across the organization.
+ */
+export function createLimrunSecretStore(options: LimrunSecretStoreOptions): SigningSecretStore {
+  const doFetch = options.fetch ?? fetch.bind(globalThis);
+  const base = options.apiUrl.replace(/\/+$/, '');
+  const secretUrl = (type: string, name: string) =>
+    `${base}/v1/organizations/${encodeURIComponent(options.organizationId)}/secrets/${encodeURIComponent(
+      type,
+    )}/${encodeURIComponent(name)}`;
+  const headers = {
+    Authorization: `Bearer ${options.token}`,
+    'Content-Type': 'application/json',
+  };
+
+  async function fail(response: Response, action: string): Promise<never> {
+    let message = `${response.status}`;
+    try {
+      const body = (await response.json()) as { message?: string };
+      if (body.message) message = body.message;
+    } catch {
+      // Non-JSON error body; the status code is the best we have.
+    }
+    throw new Error(`Failed to ${action} secret: ${message}`);
+  }
+
+  return {
+    async put(type, name, data) {
+      const response = await doFetch(secretUrl(type, name), {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ data, replace: true }),
+      });
+      if (!response.ok) await fail(response, 'store');
+      const result = (await response.json()) as BackendSecretResult;
+      return { type: result.type, name: result.name, createdAt: result.createdAt, data: result.data };
+    },
+    async get(type, name) {
+      const response = await doFetch(secretUrl(type, name), { method: 'GET', headers });
+      if (response.status === 404) return undefined;
+      if (!response.ok) await fail(response, 'fetch');
+      const result = (await response.json()) as BackendSecretResult;
+      return { type: result.type, name: result.name, createdAt: result.createdAt, data: result.data };
+    },
+    async list() {
+      const response = await doFetch(
+        `${base}/v1/organizations/${encodeURIComponent(options.organizationId)}/secrets`,
+        { method: 'GET', headers },
+      );
+      if (!response.ok) await fail(response, 'list');
+      const result = (await response.json()) as Omit<BackendSecretResult, 'data'>[];
+      return result
+        .filter(
+          (s) =>
+            s.type === APPLE_CERTIFICATE_SECRET_TYPE || s.type === APPLE_PROVISIONING_PROFILE_SECRET_TYPE,
+        )
+        .map((s) => ({ type: s.type, name: s.name, createdAt: s.createdAt }));
+    },
+    async delete(type, name) {
+      const response = await doFetch(secretUrl(type, name), { method: 'DELETE', headers });
+      if (response.status === 404) return;
+      if (!response.ok) await fail(response, 'delete');
+    },
+  };
+}
+
+const SECRETS_DB_NAME = 'limrun-signing-secrets';
+const SECRETS_DB_VERSION = 1;
+const SECRETS_STORE_NAME = 'secrets';
+
+type BrowserStoredSecret = {
+  id: string;
+  type: string;
+  name: string;
+  data: Record<string, string>;
+  createdAt: string;
+};
+
+/**
+ * A SigningSecretStore keeping everything in the browser's IndexedDB.
+ * Nothing leaves the machine; secrets are per-browser-profile.
+ */
+export function createBrowserSecretStore(): SigningSecretStore {
+  const idOf = (type: string, name: string) => `${type}:${name}`;
+
+  function open() {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(SECRETS_DB_NAME, SECRETS_DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(SECRETS_STORE_NAME)) {
+          db.createObjectStore(SECRETS_STORE_NAME, { keyPath: 'id' });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error ?? new Error('Open IndexedDB failed'));
+    });
+  }
+
+  function toPromise<T = unknown>(request: IDBRequest<T>) {
+    return new Promise<T>((resolve, reject) => {
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
+    });
+  }
+
+  return {
+    async put(type, name, data) {
+      const db = await open();
+      const existing = await toPromise<BrowserStoredSecret | undefined>(
+        db.transaction(SECRETS_STORE_NAME, 'readonly').objectStore(SECRETS_STORE_NAME).get(idOf(type, name)),
+      );
+      const stored: BrowserStoredSecret = {
+        id: idOf(type, name),
+        type,
+        name,
+        data,
+        createdAt: existing?.createdAt ?? new Date().toISOString(),
+      };
+      await toPromise(
+        db.transaction(SECRETS_STORE_NAME, 'readwrite').objectStore(SECRETS_STORE_NAME).put(stored),
+      );
+      return { type, name, createdAt: stored.createdAt, data };
+    },
+    async get(type, name) {
+      const db = await open();
+      const stored = await toPromise<BrowserStoredSecret | undefined>(
+        db.transaction(SECRETS_STORE_NAME, 'readonly').objectStore(SECRETS_STORE_NAME).get(idOf(type, name)),
+      );
+      if (!stored) return undefined;
+      return { type: stored.type, name: stored.name, createdAt: stored.createdAt, data: stored.data };
+    },
+    async list() {
+      const db = await open();
+      const all = await toPromise<BrowserStoredSecret[]>(
+        db.transaction(SECRETS_STORE_NAME, 'readonly').objectStore(SECRETS_STORE_NAME).getAll(),
+      );
+      return all.map((s) => ({ type: s.type, name: s.name, createdAt: s.createdAt }));
+    },
+    async delete(type, name) {
+      const db = await open();
+      await toPromise(
+        db
+          .transaction(SECRETS_STORE_NAME, 'readwrite')
+          .objectStore(SECRETS_STORE_NAME)
+          .delete(idOf(type, name)),
+      );
+    },
+  };
+}

--- a/packages/ui/src/core/device-install/storage/secret-store.ts
+++ b/packages/ui/src/core/device-install/storage/secret-store.ts
@@ -21,8 +21,11 @@ export type SigningSecretMetadata = {
   createdAt?: string;
 };
 
+/** Type-specific flat key-value payload of a signing secret. */
+export type SigningSecretData = Record<string, string>;
+
 export type SigningSecret = SigningSecretMetadata & {
-  data: Record<string, string>;
+  data: SigningSecretData;
 };
 
 export interface SigningSecretStore {
@@ -31,7 +34,7 @@ export interface SigningSecretStore {
    * exists its data is overwritten. Returns the stored secret; callers
    * should use the returned data.
    */
-  put(type: SigningSecretType, name: string, data: Record<string, string>): Promise<SigningSecret>;
+  put(type: SigningSecretType, name: string, data: SigningSecretData): Promise<SigningSecret>;
   /** Returns the secret including its data, or undefined when absent. */
   get(type: SigningSecretType, name: string): Promise<SigningSecret | undefined>;
   /** Lists metadata of all stored signing secrets, never their data. */
@@ -40,35 +43,66 @@ export interface SigningSecretStore {
   delete(type: SigningSecretType, name: string): Promise<void>;
 }
 
+/**
+ * Apple's certificate types as defined by the App Store Connect API
+ * (https://developer.apple.com/documentation/appstoreconnectapi/certificatetype).
+ */
+export type AppleCertificateType =
+  | 'DEVELOPMENT'
+  | 'DISTRIBUTION'
+  | 'IOS_DEVELOPMENT'
+  | 'IOS_DISTRIBUTION'
+  | 'MAC_APP_DEVELOPMENT'
+  | 'MAC_APP_DISTRIBUTION'
+  | 'MAC_INSTALLER_DISTRIBUTION'
+  | 'DEVELOPER_ID_APPLICATION'
+  | 'DEVELOPER_ID_INSTALLER'
+  | 'DEVELOPER_ID_KEXT'
+  | 'PASS_TYPE_ID'
+  | 'PASS_TYPE_ID_WITH_NFC';
+
 /** Data payload of an appleCertificate secret. */
 export type AppleCertificateSecretData = {
   certificateP12Base64: string;
+  /** Which of Apple's certificate types the p12 holds. */
+  certificateType: AppleCertificateType;
   certificatePassword?: string;
   teamID?: string;
+  /** Apple's portal certificate id, never a Limrun DB id. */
   certificateID?: string;
+  /** The certificate's serial number: uppercase hex, no leading zeros. */
   serialNumber?: string;
   expirationDate?: string;
 };
 
-/** Data payload of an appleProvisioningProfile secret. */
+/**
+ * Data payload of an appleProvisioningProfile secret. The
+ * certificateSerialNumbers, bundleIDs and deviceIDs fields duplicate what
+ * the signed profile binds (as comma-separated lists) so profiles can be
+ * filtered by certificate, bundle ID or device without parsing every
+ * entry. Certificates are referenced by serial number, the identifier
+ * Apple embeds in the profile itself.
+ */
 export type AppleProvisioningProfileSecretData = {
   provisioningProfileBase64: string;
+  certificateSerialNumbers?: string;
+  bundleIDs?: string;
+  deviceIDs?: string;
   teamID?: string;
-  bundleID?: string;
   profileName?: string;
   uuid?: string;
   expirationDate?: string;
 };
 
-function compactData(data: Record<string, string | undefined>) {
-  const result: Record<string, string> = {};
+function compactData(data: Record<string, string | undefined>): SigningSecretData {
+  const result: SigningSecretData = {};
   for (const [key, value] of Object.entries(data)) {
     if (value) result[key] = value;
   }
   return result;
 }
 
-/** Stores an Apple development certificate (p12 + password) under the team ID. */
+/** Stores an Apple certificate bundle, conventionally named `${teamID}/${certificateType}`. */
 export async function putAppleCertificateSecret(
   store: SigningSecretStore,
   name: string,
@@ -77,7 +111,11 @@ export async function putAppleCertificateSecret(
   return store.put(APPLE_CERTIFICATE_SECRET_TYPE, name, compactData(data));
 }
 
-/** Stores a provisioning profile, conventionally named `${teamID}/${bundleID}`. */
+/**
+ * Stores a provisioning profile, conventionally named `${teamID}/${uuid}`
+ * so a team can hold many profiles for the same bundle ID and certificate
+ * set; consumers select by the reference fields, not by name.
+ */
 export async function putAppleProvisioningProfileSecret(
   store: SigningSecretStore,
   name: string,
@@ -102,7 +140,7 @@ type BackendSecretResult = {
   type: string;
   name: string;
   organizationId: string;
-  data: Record<string, string>;
+  data: SigningSecretData;
   createdAt: string;
 };
 
@@ -182,7 +220,7 @@ type BrowserStoredSecret = {
   id: string;
   type: string;
   name: string;
-  data: Record<string, string>;
+  data: SigningSecretData;
   createdAt: string;
 };
 

--- a/packages/ui/src/core/device-install/types.ts
+++ b/packages/ui/src/core/device-install/types.ts
@@ -40,6 +40,12 @@ export type ProvisioningProfileInfo = {
   applicationIdentifier?: string;
   bundleID?: string;
   provisionedDevices: string[];
+  /**
+   * Serial numbers (uppercase hex, no leading zeros) of the developer
+   * certificates embedded in the profile; the profile is only usable for
+   * signing with one of these certificates.
+   */
+  certificateSerialNumbers: string[];
   getTaskAllow?: boolean;
   expirationDate?: string;
 };

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         index: resolve(__dirname, 'src/index.ts'),
         'app-store-relay/index': resolve(__dirname, 'src/app-store-relay/index.ts'),
         'app-store-relay/react': resolve(__dirname, 'src/app-store-relay/react.ts'),
+        'apple-credentials/index': resolve(__dirname, 'src/apple-credentials/index.ts'),
         'device-build/index': resolve(__dirname, 'src/device-build/index.ts'),
         'device-build/react': resolve(__dirname, 'src/device-build/react.ts'),
         'device-install/index': resolve(__dirname, 'src/device-install/index.ts'),


### PR DESCRIPTION
Credential material from the Apple relay always lands in the browser first; the browser then writes it into a SigningSecretStore. Limrun's org secret store is the default implementation, IndexedDB keeps it local, and customers can implement the interface for their own store.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Very large surface-area change across auth, remote build/signing/TestFlight credential handling, and instance lifecycle auto-create/delete; regressions could affect billing, builds, or credential flows.
> 
> **Overview**
> **Release 0.43.0** updates the OpenAPI-backed SDK and CLI together: package versions, changelog, and `.stats.yml` now reflect **18 endpoints** (Gradle instances, analytics, Xcode build-log helpers, and related types).
> 
> **Cloud Android builds:** New **`gradleInstances`** client surface and **`lim gradle`** commands (create/list/get/delete/**build**) sync a project remotely, run Gradle with streaming output, and can upload APKs as installable assets. **`lim android sync`** adds delta APK sync/install like iOS app sync.
> 
> **API & platform workflows:** **Analytics** (`client.analytics`) is added. **iOS** gains encrypted **keychain** save/restore, **push/pull/delete-file** (including app containers), **`--force-bundle-id`**, **`launch-app`** log streaming with **`--detach`**, and scroll **momentum**. **Xcode** **`build`** adds optional **XcodeGen** generation, **`git-init`**, sync **include** overrides, **TestFlight** upload flags, and tighter signing/upload validation; **`lim xcode run`** runs arbitrary sandbox commands after sync. **Assets** support **Keychain** kind filtering and streaming upload/download progress.
> 
> **Infrastructure & deps:** CI/publish move to **Node 24** and use Depot runners for all `stainless-sdks/*` repos. **`xdelta3-wasm`** is vendored as **`@limrun/xdelta3-wasm`** (git submodule + ignore rules); **`yauzl`** replaces the old npm `xdelta3-wasm` dependency. CLI **login** targets the API endpoint with richer messaging; **`lim set-api-key`** is new; **404 self-heal** and cleanup now cover **gradle** instances. The device-install example renames Apple login config to **`registryApiUrl`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69efce6644deb8f540fa3ad4865c2881cbbc7848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->