### PR TITLE
Support for registry API

### DIFF
--- a/examples/device-install/frontend/src/hooks/useSigning.ts
+++ b/examples/device-install/frontend/src/hooks/useSigning.ts
@@ -69,7 +69,7 @@ export function useSigning({ apiUrl, token, deviceUDID, deviceName, log, onError
   const [certificatePassword, setCertificatePassword] = useState('');
 
   // Apple ID flow.
-  const appleLogin = useAppleIDLogin({ limbuildApiUrl: apiUrl ?? '', token });
+  const appleLogin = useAppleIDLogin({ registryApiUrl: apiUrl ?? '', token });
   const [appleAccount, setAppleAccount] = useState('');
   const [applePassword, setApplePassword] = useState('');
   const [twoFactorCode, setTwoFactorCode] = useState('');

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/ui",
-  "version": "0.14.0-rc.1",
+  "version": "0.14.0-rc.3",
   "publishConfig": {
     "access": "public"
   },
@@ -42,6 +42,16 @@
       "types": "./dist/device-install/react.d.ts",
       "import": "./dist/device-install/react.js",
       "require": "./dist/device-install/react.cjs"
+    },
+    "./play-publish": {
+      "types": "./dist/play-publish/index.d.ts",
+      "import": "./dist/play-publish/index.js",
+      "require": "./dist/play-publish/index.cjs"
+    },
+    "./play-publish/react": {
+      "types": "./dist/play-publish/react.d.ts",
+      "import": "./dist/play-publish/react.js",
+      "require": "./dist/play-publish/react.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limrun/ui",
-  "version": "0.13.9",
+  "version": "0.14.0-rc.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,8 @@
   "name": "@limrun/ui",
   "version": "0.14.0-rc.3",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "next"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/ui/src/app-store-relay/index.test.ts
+++ b/packages/ui/src/app-store-relay/index.test.ts
@@ -3,58 +3,48 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { assertAppleDeveloperPortalResponseOK, deleteAppleProfile, listAppleTeams } from './index';
 
-describe('App Store relay primitives', () => {
+describe('Registry relay primitives', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   test('sends explicit CRUD requests through the provisioning proxy', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ status: 200, body: { resultCode: 0 } }), {
-        status: 200,
-      }),
-    );
+    const relay = { request: vi.fn().mockResolvedValue({ status: 200, body: { resultCode: 0 } }) };
 
     await deleteAppleProfile({
-      apiUrl: 'https://limbuild.example',
-      token: 'token',
-      appleSessionId: 'apple-session',
+      relay,
       teamId: 'TEAM',
       profileId: 'PROFILE',
     });
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(String(url)).toBe('https://limbuild.example/apple/provisioning?token=token');
-    expect(JSON.parse(String(init?.body))).toMatchObject({
-      appleSessionId: 'apple-session',
+    expect(relay.request).toHaveBeenCalledOnce();
+    expect(relay.request.mock.calls[0]).toMatchObject([
+      'provisioning',
+      {
       method: 'POST',
       path: '/account/ios/profile/deleteProvisioningProfile.action',
       payload: {
         teamId: 'TEAM',
         provisioningProfileId: 'PROFILE',
       },
-    });
+      },
+    ]);
   });
 
   test('maps team list responses to teams', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          status: 200,
-          body: {
-            resultCode: 0,
-            teams: [{ name: 'Team One', teamId: 'TEAM1' }],
-          },
-        }),
-        { status: 200 },
-      ),
-    );
+    const relay = {
+      request: vi.fn().mockResolvedValue({
+        status: 200,
+        body: {
+          resultCode: 0,
+          teams: [{ name: 'Team One', teamId: 'TEAM1' }],
+        },
+      }),
+    };
 
     await expect(
       listAppleTeams({
-        apiUrl: 'https://limbuild.example',
-        appleSessionId: 'apple-session',
+        relay,
       }),
     ).resolves.toEqual([{ name: 'Team One', teamId: 'TEAM1' }]);
   });

--- a/packages/ui/src/app-store-relay/index.test.ts
+++ b/packages/ui/src/app-store-relay/index.test.ts
@@ -21,12 +21,12 @@ describe('Registry relay primitives', () => {
     expect(relay.request.mock.calls[0]).toMatchObject([
       'provisioning',
       {
-      method: 'POST',
-      path: '/account/ios/profile/deleteProvisioningProfile.action',
-      payload: {
-        teamId: 'TEAM',
-        provisioningProfileId: 'PROFILE',
-      },
+        method: 'POST',
+        path: '/account/ios/profile/deleteProvisioningProfile.action',
+        payload: {
+          teamId: 'TEAM',
+          provisioningProfileId: 'PROFILE',
+        },
       },
     ]);
   });

--- a/packages/ui/src/app-store-relay/index.ts
+++ b/packages/ui/src/app-store-relay/index.ts
@@ -22,6 +22,7 @@ import {
   type AppleDeveloperPortalTeam,
   type AppleProvisioningRequest,
   type AppleRelayResponse,
+  type AppleRelayWebSocketClient,
 } from '../core/device-install/apple';
 
 export * from '../core/device-install/apple/client';
@@ -36,9 +37,9 @@ export type {
   AppleRelayResponse,
 } from '../core/device-install/apple';
 export {
-  createAppleRelaySession,
-  deleteAppleRelaySession,
+  AppleRelayWebSocketClient,
   fetchAppleAccountSession,
+  openAppleRelayWebSocket,
   proxyPhoneTwoFactorCode,
   proxySrpComplete,
   proxySrpInit,
@@ -48,9 +49,7 @@ export {
 } from '../core/device-install/apple';
 
 export type AppleRelayClientOptions = {
-  apiUrl: string;
-  token?: string;
-  appleSessionId: string;
+  relay: AppleRelayWebSocketClient;
 };
 
 export type AppleTeamScopedOptions = AppleRelayClientOptions & {
@@ -150,15 +149,13 @@ export function requestAppleProvisioning<T = AppleDeveloperPortalResponse>(
   options: RequestAppleProvisioningOptions<T>,
 ): Promise<AppleRelayResponse<T>>;
 export async function requestAppleProvisioning<T = AppleDeveloperPortalResponse>({
-  apiUrl,
-  token,
-  appleSessionId,
+  relay,
   request,
   label = 'Apple Developer Portal request',
   validatePortalResponse = true,
   mapBody,
 }: RequestAppleProvisioningOptions<T>) {
-  const response = await proxyProvisioningRequest<T>(apiUrl, appleSessionId, request, token);
+  const response = await proxyProvisioningRequest<T>(relay, request);
   if (validatePortalResponse) {
     assertAppleDeveloperPortalResponseOK(response.body as AppleDeveloperPortalResponse | undefined, label);
   }

--- a/packages/ui/src/app-store-relay/react.ts
+++ b/packages/ui/src/app-store-relay/react.ts
@@ -29,7 +29,11 @@ export type UseAppleIDLoginResult = {
   close: () => Promise<void>;
 };
 
-export function useAppleIDLogin({ registryApiUrl, token, organizationId }: UseAppleIDLoginOptions): UseAppleIDLoginResult {
+export function useAppleIDLogin({
+  registryApiUrl,
+  token,
+  organizationId,
+}: UseAppleIDLoginOptions): UseAppleIDLoginResult {
   const [status, setStatus] = useState<AppleIDLoginStatus>('idle');
   const [session, setSession] = useState<AppleIDLoginResult | undefined>();
   const [completeResponse, setCompleteResponse] = useState<AppleRelayResponse | undefined>();

--- a/packages/ui/src/app-store-relay/react.ts
+++ b/packages/ui/src/app-store-relay/react.ts
@@ -6,7 +6,7 @@ import {
   type AppleRelayResponse,
 } from './index';
 
-export type UseAppleIDLoginOptions = Pick<AppleIDLoginInput, 'limbuildApiUrl' | 'token'>;
+export type UseAppleIDLoginOptions = Pick<AppleIDLoginInput, 'registryApiUrl' | 'token' | 'organizationId'>;
 
 export type AppleIDLoginStatus =
   | 'idle'
@@ -29,7 +29,7 @@ export type UseAppleIDLoginResult = {
   close: () => Promise<void>;
 };
 
-export function useAppleIDLogin({ limbuildApiUrl, token }: UseAppleIDLoginOptions): UseAppleIDLoginResult {
+export function useAppleIDLogin({ registryApiUrl, token, organizationId }: UseAppleIDLoginOptions): UseAppleIDLoginResult {
   const [status, setStatus] = useState<AppleIDLoginStatus>('idle');
   const [session, setSession] = useState<AppleIDLoginResult | undefined>();
   const [completeResponse, setCompleteResponse] = useState<AppleRelayResponse | undefined>();
@@ -63,8 +63,9 @@ export function useAppleIDLogin({ limbuildApiUrl, token }: UseAppleIDLoginOption
       await sessionRef.current?.close().catch(() => undefined);
       try {
         const next = await startBrowserOwnedAppleIDLogin({
-          limbuildApiUrl,
+          registryApiUrl,
           token,
+          organizationId,
           accountName,
           password,
         });
@@ -82,7 +83,7 @@ export function useAppleIDLogin({ limbuildApiUrl, token }: UseAppleIDLoginOption
         return undefined;
       }
     },
-    [limbuildApiUrl, token],
+    [registryApiUrl, organizationId, token],
   );
 
   const submitTwoFactorCode = useCallback(async (code: string) => {

--- a/packages/ui/src/app-store-relay/react.ts
+++ b/packages/ui/src/app-store-relay/react.ts
@@ -5,6 +5,7 @@ import {
   type AppleIDLoginResult,
   type AppleRelayResponse,
 } from './index';
+import { errorMessage } from '../core/errors';
 
 export type UseAppleIDLoginOptions = Pick<AppleIDLoginInput, 'registryApiUrl' | 'token' | 'organizationId'>;
 
@@ -127,8 +128,4 @@ export function useAppleIDLogin({
     finalize,
     close,
   };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/ui/src/core/device-install/apple/client.ts
+++ b/packages/ui/src/core/device-install/apple/client.ts
@@ -1,7 +1,6 @@
 import { AppleGsaSrpClient } from './gsa-srp';
 import {
-  createAppleRelaySession,
-  deleteAppleRelaySession,
+  openAppleRelayWebSocket,
   fetchAppleAccountSession,
   proxyPhoneTwoFactorCode,
   proxySrpComplete,
@@ -9,18 +8,20 @@ import {
   proxyTwoFactorCode,
   triggerPhoneTwoFactor,
   triggerTrustedDeviceTwoFactor,
+  type AppleRelayWebSocketClient,
   type AppleRelayResponse,
 } from './relay';
 
 export type AppleIDLoginInput = {
-  limbuildApiUrl: string;
+  registryApiUrl: string;
   accountName: string;
   password: string;
   token?: string;
+  organizationId?: string;
 };
 
 export type AppleIDLoginResult = {
-  appleSessionId: string;
+  relay: AppleRelayWebSocketClient;
   completeResponse: AppleRelayResponse;
   twoFactorChallengeResponse?: AppleRelayResponse;
   requiresTwoFactor: boolean;
@@ -32,15 +33,16 @@ export type AppleIDLoginResult = {
 type TwoFactorMethod = { type: 'trustedDevice' } | { type: 'phone'; phoneNumberId: number; mode: string };
 
 export async function startBrowserOwnedAppleIDLogin({
-  limbuildApiUrl,
+  registryApiUrl,
   accountName,
   password,
   token,
+  organizationId,
 }: AppleIDLoginInput): Promise<AppleIDLoginResult> {
-  const { appleSessionId } = await createAppleRelaySession(limbuildApiUrl, token);
+  const relay = await openAppleRelayWebSocket(registryApiUrl, token, organizationId);
   try {
     const srp = new AppleGsaSrpClient(accountName);
-    const initResponse = await proxySrpInit(limbuildApiUrl, appleSessionId, await srp.init(), token);
+    const initResponse = await proxySrpInit(relay, await srp.init());
     if (initResponse.status < 200 || initResponse.status >= 300) {
       throw new Error(
         `Apple SRP init failed: HTTP ${initResponse.status} ${initResponse.rawBody ?? ''}`.trim(),
@@ -50,21 +52,16 @@ export async function startBrowserOwnedAppleIDLogin({
       throw new Error('Apple SRP init response did not include a body.');
     }
     const proof = await srp.complete(password, initResponse.body);
-    const completeResponse = await proxySrpComplete(
-      limbuildApiUrl,
-      appleSessionId,
-      {
-        ...proof,
-        rememberMe: false,
-        trustTokens: [],
-      },
-      token,
-    );
+    const completeResponse = await proxySrpComplete(relay, {
+      ...proof,
+      rememberMe: false,
+      trustTokens: [],
+    });
     const requiresTwoFactor = completeResponse.status === 409;
     let twoFactorChallengeResponse: AppleRelayResponse | undefined;
     let twoFactorMethod: TwoFactorMethod = { type: 'trustedDevice' };
     if (requiresTwoFactor) {
-      twoFactorChallengeResponse = await triggerTrustedDeviceTwoFactor(limbuildApiUrl, appleSessionId, token);
+      twoFactorChallengeResponse = await triggerTrustedDeviceTwoFactor(relay);
       const phone = trustedPhoneNumberFromChallenge(twoFactorChallengeResponse.body);
       // Only route codes through the phone/SMS endpoint when Apple actually
       // falls back to phone verification (HTTP 412). The trusted-device
@@ -80,13 +77,7 @@ export async function startBrowserOwnedAppleIDLogin({
           phoneNumberId: phone.id,
           mode: phone.pushMode ?? 'sms',
         };
-        twoFactorChallengeResponse = await triggerPhoneTwoFactor(
-          limbuildApiUrl,
-          appleSessionId,
-          phone.id,
-          phone.pushMode ?? 'sms',
-          token,
-        );
+        twoFactorChallengeResponse = await triggerPhoneTwoFactor(relay, phone.id, phone.pushMode ?? 'sms');
       }
       if (twoFactorChallengeResponse.status < 200 || twoFactorChallengeResponse.status >= 300) {
         throw new Error(
@@ -101,7 +92,7 @@ export async function startBrowserOwnedAppleIDLogin({
       );
     }
     return {
-      appleSessionId,
+      relay,
       completeResponse,
       twoFactorChallengeResponse,
       requiresTwoFactor,
@@ -109,14 +100,12 @@ export async function startBrowserOwnedAppleIDLogin({
         const response =
           twoFactorMethod.type === 'phone' ?
             await proxyPhoneTwoFactorCode(
-              limbuildApiUrl,
-              appleSessionId,
+              relay,
               twoFactorMethod.phoneNumberId,
               code,
               twoFactorMethod.mode,
-              token,
             )
-          : await proxyTwoFactorCode(limbuildApiUrl, appleSessionId, code, token);
+          : await proxyTwoFactorCode(relay, code);
         if (response.status < 200 || response.status >= 300) {
           throw new Error(
             `Apple two-factor code failed: HTTP ${response.status} ${response.rawBody ?? ''}`.trim(),
@@ -124,11 +113,11 @@ export async function startBrowserOwnedAppleIDLogin({
         }
         return response;
       },
-      finalize: async () => fetchAppleAccountSession(limbuildApiUrl, appleSessionId, token),
-      close: () => deleteAppleRelaySession(limbuildApiUrl, appleSessionId, token),
+      finalize: async () => fetchAppleAccountSession(relay),
+      close: async () => relay.close(),
     };
   } catch (error) {
-    await deleteAppleRelaySession(limbuildApiUrl, appleSessionId, token).catch(() => undefined);
+    relay.close();
     throw error;
   }
 }

--- a/packages/ui/src/core/device-install/apple/client.ts
+++ b/packages/ui/src/core/device-install/apple/client.ts
@@ -99,12 +99,7 @@ export async function startBrowserOwnedAppleIDLogin({
       finishTwoFactor: async (code) => {
         const response =
           twoFactorMethod.type === 'phone' ?
-            await proxyPhoneTwoFactorCode(
-              relay,
-              twoFactorMethod.phoneNumberId,
-              code,
-              twoFactorMethod.mode,
-            )
+            await proxyPhoneTwoFactorCode(relay, twoFactorMethod.phoneNumberId, code, twoFactorMethod.mode)
           : await proxyTwoFactorCode(relay, code);
         if (response.status < 200 || response.status >= 300) {
           throw new Error(

--- a/packages/ui/src/core/device-install/apple/relay.ts
+++ b/packages/ui/src/core/device-install/apple/relay.ts
@@ -104,10 +104,7 @@ export async function openAppleRelayWebSocket(apiUrl: string, token?: string, or
   return client;
 }
 
-export async function proxySrpInit(
-  relay: AppleRelayWebSocketClient,
-  payload: AppleSRPInitRequest,
-) {
+export async function proxySrpInit(relay: AppleRelayWebSocketClient, payload: AppleSRPInitRequest) {
   return relay.request<AppleSRPInitResponse>('srpInit', payload);
 }
 

--- a/packages/ui/src/core/device-install/apple/relay.ts
+++ b/packages/ui/src/core/device-install/apple/relay.ts
@@ -15,178 +15,146 @@ export type AppleProvisioningRequest = {
   payload?: unknown;
 };
 
-export async function createAppleRelaySession(limbuildApiUrl: string, token?: string) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/auth/session', token), {
-    method: 'POST',
-    headers: authHeaders(token),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple relay session failed: HTTP ${response.status} ${await response.text()}`);
+type AppleRelayWebSocketMessage<T = unknown> = {
+  id: string;
+  ok: boolean;
+  response?: AppleRelayResponse<T>;
+  error?: string;
+};
+
+export class AppleRelayWebSocketClient {
+  private socket?: WebSocket;
+  private nextId = 1;
+  private readonly pending = new Map<
+    string,
+    {
+      resolve: (response: AppleRelayResponse) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+
+  constructor(
+    private readonly apiUrl: string,
+    private readonly token?: string,
+    private readonly organizationId?: string,
+  ) {}
+
+  async connect() {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) return;
+    const socket = new WebSocket(appleRelayWebSocketURL(this.apiUrl, this.token, this.organizationId));
+    this.socket = socket;
+    socket.onmessage = (event) => this.handleMessage(event);
+    socket.onclose = () => this.rejectPending(new Error('Apple relay WebSocket closed'));
+    socket.onerror = () => this.rejectPending(new Error('Apple relay WebSocket failed'));
+    await new Promise<void>((resolve, reject) => {
+      socket.onopen = () => resolve();
+      socket.onerror = () => reject(new Error('Apple relay WebSocket connection failed'));
+    });
   }
-  return (await response.json()) as { appleSessionId: string };
+
+  request<T = unknown>(type: string, payload?: unknown) {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      throw new Error('Apple relay WebSocket is not connected.');
+    }
+    const id = String(this.nextId++);
+    const response = new Promise<AppleRelayResponse<T>>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: (value) => resolve(normalizeAppleProxyResponse<T>(value as AppleRelayResponse<T>)),
+        reject,
+      });
+    });
+    socket.send(JSON.stringify({ id, type, ...(payload === undefined ? {} : { payload }) }));
+    return response;
+  }
+
+  close() {
+    this.rejectPending(new Error('Apple relay WebSocket closed'));
+    this.socket?.close();
+    this.socket = undefined;
+  }
+
+  private handleMessage(event: MessageEvent) {
+    const message = JSON.parse(String(event.data)) as AppleRelayWebSocketMessage;
+    const waiter = this.pending.get(message.id);
+    if (!waiter) return;
+    this.pending.delete(message.id);
+    if (!message.ok) {
+      waiter.reject(new Error(message.error || 'Apple relay request failed'));
+      return;
+    }
+    if (!message.response) {
+      waiter.reject(new Error('Apple relay response was empty.'));
+      return;
+    }
+    waiter.resolve(message.response);
+  }
+
+  private rejectPending(error: Error) {
+    for (const waiter of this.pending.values()) {
+      waiter.reject(error);
+    }
+    this.pending.clear();
+  }
 }
 
-export async function deleteAppleRelaySession(
-  limbuildApiUrl: string,
-  appleSessionId: string,
-  token?: string,
-) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/auth/session/delete', token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple relay session delete failed: HTTP ${response.status} ${await response.text()}`);
-  }
+export async function openAppleRelayWebSocket(apiUrl: string, token?: string, organizationId?: string) {
+  const client = new AppleRelayWebSocketClient(apiUrl, token, organizationId);
+  await client.connect();
+  return client;
 }
 
 export async function proxySrpInit(
-  limbuildApiUrl: string,
-  appleSessionId: string,
+  relay: AppleRelayWebSocketClient,
   payload: AppleSRPInitRequest,
-  token?: string,
 ) {
-  return postAppleProxy<AppleSRPInitResponse>(
-    limbuildApiUrl,
-    '/apple/auth/srp/init',
-    appleSessionId,
-    payload,
-    token,
-  );
+  return relay.request<AppleSRPInitResponse>('srpInit', payload);
 }
 
 export async function proxySrpComplete(
-  limbuildApiUrl: string,
-  appleSessionId: string,
+  relay: AppleRelayWebSocketClient,
   payload: AppleSRPCompleteProof & {
     rememberMe: boolean;
     trustTokens: string[];
   },
-  token?: string,
 ) {
-  return postAppleProxy(limbuildApiUrl, '/apple/auth/srp/complete', appleSessionId, payload, token);
+  return relay.request('srpComplete', payload);
 }
 
-export async function triggerTrustedDeviceTwoFactor(
-  limbuildApiUrl: string,
-  appleSessionId: string,
-  token?: string,
-) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/auth/2fa/trigger', token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple 2FA trigger failed: HTTP ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as AppleRelayResponse;
+export async function triggerTrustedDeviceTwoFactor(relay: AppleRelayWebSocketClient) {
+  return relay.request('triggerTrustedDevice2FA');
 }
 
 export async function triggerPhoneTwoFactor(
-  limbuildApiUrl: string,
-  appleSessionId: string,
+  relay: AppleRelayWebSocketClient,
   phoneNumberId: number,
   mode = 'sms',
-  token?: string,
 ) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/auth/2fa/phone/trigger', token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId, phoneNumberId, mode }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple phone 2FA trigger failed: HTTP ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as AppleRelayResponse;
+  return relay.request('triggerPhone2FA', { phoneNumberId, mode });
 }
 
-export async function proxyTwoFactorCode(
-  limbuildApiUrl: string,
-  appleSessionId: string,
-  code: string,
-  token?: string,
-) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/auth/2fa', token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId, code }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple 2FA proxy failed: HTTP ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as AppleRelayResponse;
+export async function proxyTwoFactorCode(relay: AppleRelayWebSocketClient, code: string) {
+  return relay.request('submitTrustedDevice2FA', { code });
 }
 
 export async function proxyPhoneTwoFactorCode(
-  limbuildApiUrl: string,
-  appleSessionId: string,
+  relay: AppleRelayWebSocketClient,
   phoneNumberId: number,
   code: string,
   mode = 'sms',
-  token?: string,
 ) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/auth/2fa/phone', token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId, phoneNumberId, mode, code }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple phone 2FA proxy failed: HTTP ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as AppleRelayResponse;
+  return relay.request('submitPhone2FA', { phoneNumberId, mode, code });
 }
 
-export async function fetchAppleAccountSession(
-  limbuildApiUrl: string,
-  appleSessionId: string,
-  token?: string,
-) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/auth/finalize', token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple session finalization failed: HTTP ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as AppleRelayResponse;
+export async function fetchAppleAccountSession(relay: AppleRelayWebSocketClient) {
+  return relay.request('finalize');
 }
 
 export async function proxyProvisioningRequest<T = unknown>(
-  limbuildApiUrl: string,
-  appleSessionId: string,
+  relay: AppleRelayWebSocketClient,
   request: AppleProvisioningRequest,
-  token?: string,
 ) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, '/apple/provisioning', token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId, ...request }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple provisioning proxy failed: HTTP ${response.status} ${await response.text()}`);
-  }
-  return normalizeAppleProxyResponse<T>((await response.json()) as AppleRelayResponse<T>);
-}
-
-async function postAppleProxy<T>(
-  limbuildApiUrl: string,
-  path: string,
-  appleSessionId: string,
-  payload: unknown,
-  token?: string,
-) {
-  const response = await fetch(limbuildURL(limbuildApiUrl, path, token), {
-    method: 'POST',
-    headers: jsonHeaders(token),
-    body: JSON.stringify({ appleSessionId, payload }),
-  });
-  if (!response.ok) {
-    throw new Error(`Apple proxy ${path} failed: HTTP ${response.status} ${await response.text()}`);
-  }
-  return normalizeAppleProxyResponse<T>((await response.json()) as AppleRelayResponse<T>);
+  return relay.request<T>('provisioning', request);
 }
 
 function normalizeAppleProxyResponse<T>(response: AppleRelayResponse<T>) {
@@ -203,23 +171,15 @@ function normalizeAppleProxyResponse<T>(response: AppleRelayResponse<T>) {
   }
 }
 
-function limbuildURL(limbuildApiUrl: string, path: string, token?: string) {
-  const base = limbuildApiUrl.replace(/\/$/, '');
-  const suffix = path.startsWith('/') ? path : `/${path}`;
-  const url = new URL(`${base}${suffix}`);
+function appleRelayWebSocketURL(apiUrl: string, token?: string, organizationId?: string) {
+  const url = new URL(apiUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/ios/appstoreconnect/ws`;
   if (token) {
     url.searchParams.set('token', token);
   }
-  return url;
-}
-
-function jsonHeaders(token?: string): Record<string, string> {
-  return {
-    'Content-Type': 'application/json',
-    ...authHeaders(token),
-  };
-}
-
-function authHeaders(token?: string): Record<string, string> {
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  if (organizationId) {
+    url.searchParams.set('organization', organizationId);
+  }
+  return url.toString();
 }

--- a/packages/ui/src/core/device-install/operations/limbuild-client.ts
+++ b/packages/ui/src/core/device-install/operations/limbuild-client.ts
@@ -14,6 +14,7 @@ export type StartSignedDeviceBuildOptions = {
   certificateP12Base64: string;
   certificatePassword?: string;
   provisioningProfileBase64: string;
+  signedUploadUrl?: string;
 };
 
 export type BuildLogEventsOptions = {
@@ -61,6 +62,7 @@ export async function startSignedDeviceBuild({
   certificateP12Base64,
   certificatePassword,
   provisioningProfileBase64,
+  signedUploadUrl,
 }: StartSignedDeviceBuildOptions) {
   const url = new URL(`${limbuildApiUrl}/exec`);
   if (token) {
@@ -75,6 +77,7 @@ export async function startSignedDeviceBuild({
     body: JSON.stringify({
       command: 'xcodebuild',
       xcodebuild: { sdk: 'iphoneos' },
+      ...(signedUploadUrl ? { signedUploadUrl } : {}),
       signing: {
         certificateP12Base64,
         ...(certificatePassword ? { certificatePassword } : {}),

--- a/packages/ui/src/core/device-install/operations/operations.ts
+++ b/packages/ui/src/core/device-install/operations/operations.ts
@@ -18,14 +18,21 @@ export type RequestUSBAccessOptions = {
 };
 
 export type StartPairingRelayOptions = {
-  limbuildApiUrl: string;
+  registryApiUrl: string;
   token?: string;
+  organizationId?: string;
   log: DeviceInstallLog;
   target: DeviceRelayTarget;
 };
 
+export type InstallSource =
+  | { assetId: string; assetName?: never; downloadUrl?: never }
+  | { assetId?: never; assetName: string; downloadUrl?: never }
+  | { assetId?: never; assetName?: never; downloadUrl: string };
+
 export type StartInstallRelayOptions = StartPairingRelayOptions & {
   pairRecord: PairRecordPayload;
+  installSource: InstallSource;
 };
 
 export async function requestUSBAccess({ log }: RequestUSBAccessOptions) {
@@ -39,8 +46,8 @@ export async function requestUSBAccess({ log }: RequestUSBAccessOptions) {
   return target;
 }
 
-export async function startPairingRelay({ limbuildApiUrl, token, log, target }: StartPairingRelayOptions) {
-  const deviceRelayUrl = deviceRelayWebSocketUrl(limbuildApiUrl, token);
+export async function startPairingRelay({ registryApiUrl, token, organizationId, log, target }: StartPairingRelayOptions) {
+  const deviceRelayUrl = deviceRelayWebSocketUrl(registryApiUrl, token, organizationId);
   let relay: RelayClient | undefined;
   try {
     relay = await connectRelay(deviceRelayUrl, target, log);
@@ -53,17 +60,19 @@ export async function startPairingRelay({ limbuildApiUrl, token, log, target }: 
 }
 
 export async function startInstallRelay({
-  limbuildApiUrl,
+  registryApiUrl,
   token,
+  organizationId,
   log,
   target,
   pairRecord,
+  installSource,
 }: StartInstallRelayOptions) {
-  const deviceRelayUrl = deviceRelayWebSocketUrl(limbuildApiUrl, token);
+  const deviceRelayUrl = deviceRelayWebSocketUrl(registryApiUrl, token, organizationId);
   let relay: RelayClient | undefined;
   try {
     relay = await connectRelay(deviceRelayUrl, target, log);
-    await relay.startInstall(pairRecord);
+    await relay.startInstall(pairRecord, installSource);
     return relay;
   } catch (error) {
     relay?.close();
@@ -182,12 +191,15 @@ function orderedUsbmuxCandidates(device: USBDevice) {
   ];
 }
 
-export function deviceRelayWebSocketUrl(limbuildApiUrl: string, token?: string) {
-  const url = new URL(limbuildApiUrl);
+export function deviceRelayWebSocketUrl(registryApiUrl: string, token?: string, organizationId?: string) {
+  const url = new URL(registryApiUrl);
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-  url.pathname = `${url.pathname.replace(/\/$/, '')}/device/ws`;
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/ios/device/ws`;
   if (token) {
     url.searchParams.set('token', token);
+  }
+  if (organizationId) {
+    url.searchParams.set('organization', organizationId);
   }
   return url.toString();
 }

--- a/packages/ui/src/core/device-install/operations/operations.ts
+++ b/packages/ui/src/core/device-install/operations/operations.ts
@@ -4,6 +4,7 @@ import type { DeviceHello, DeviceInstallLog, PairRecordPayload } from '../types'
 import { RelayClient } from './relay-client';
 import { closeUsbmuxSession, createUsbmuxSession, type UsbmuxSession } from './usbmux';
 import { claimUsbmux, findUsbmuxCandidates, requestAppleDevice, type UsbmuxCandidate } from './webusb';
+import { errorMessage } from '../../errors';
 
 export type DeviceRelayTarget = {
   device: USBDevice;
@@ -208,10 +209,6 @@ export function deviceRelayWebSocketUrl(registryApiUrl: string, token?: string, 
     url.searchParams.set('organization', organizationId);
   }
   return url.toString();
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }
 
 async function resetUSBDevice(target: DeviceRelayTarget) {

--- a/packages/ui/src/core/device-install/operations/operations.ts
+++ b/packages/ui/src/core/device-install/operations/operations.ts
@@ -46,7 +46,13 @@ export async function requestUSBAccess({ log }: RequestUSBAccessOptions) {
   return target;
 }
 
-export async function startPairingRelay({ registryApiUrl, token, organizationId, log, target }: StartPairingRelayOptions) {
+export async function startPairingRelay({
+  registryApiUrl,
+  token,
+  organizationId,
+  log,
+  target,
+}: StartPairingRelayOptions) {
   const deviceRelayUrl = deviceRelayWebSocketUrl(registryApiUrl, token, organizationId);
   let relay: RelayClient | undefined;
   try {

--- a/packages/ui/src/core/device-install/operations/relay-client.ts
+++ b/packages/ui/src/core/device-install/operations/relay-client.ts
@@ -1,5 +1,6 @@
 import type { DeviceHello, DeviceInstallLog, PairRecordPayload } from '../types';
 import { decodeFrame, decodeJson, encodeFrame, encodeJson, RelayMessageType } from './relay-protocol';
+import type { InstallSource } from './operations';
 import {
   openStream,
   receiveStreamData,
@@ -83,12 +84,12 @@ export class RelayClient {
     return recordPromise;
   }
 
-  async startInstall(pairRecord: PairRecordPayload) {
+  async startInstall(pairRecord: PairRecordPayload, installSource: InstallSource) {
     await this.send({
       type: RelayMessageType.StartInstall,
       requestId: 0,
       streamId: 0,
-      payload: encodeJson(pairRecord),
+      payload: encodeJson({ ...pairRecord, ...installSource }),
     });
     this.log('Installation requested');
   }

--- a/packages/ui/src/core/errors.ts
+++ b/packages/ui/src/core/errors.ts
@@ -1,0 +1,3 @@
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ui/src/core/play-publish/google.ts
+++ b/packages/ui/src/core/play-publish/google.ts
@@ -93,9 +93,9 @@ export async function requestGoogleAccessToken({
       },
       error_callback: (error) => {
         const fallback =
-          error?.type === 'popup_failed_to_open'
-            ? 'Google sign-in popup was blocked by the browser.'
-            : 'Google sign-in was cancelled.';
+          error?.type === 'popup_failed_to_open' ?
+            'Google sign-in popup was blocked by the browser.'
+          : 'Google sign-in was cancelled.';
         reject(new Error(error?.message || fallback));
       },
     });

--- a/packages/ui/src/core/play-publish/google.ts
+++ b/packages/ui/src/core/play-publish/google.ts
@@ -71,11 +71,20 @@ export type RequestGoogleAccessTokenInput = {
  * call loadGoogleIdentityServices beforehand (e.g. when the surrounding
  * dialog opens) to keep this call synchronous with the click.
  */
-export async function requestGoogleAccessToken({
+export function requestGoogleAccessToken(input: RequestGoogleAccessTokenInput): Promise<string> {
+  // When GSI is already loaded the popup must open inside the caller's
+  // click turn: even an await of a resolved promise yields a microtask,
+  // which the strictest popup blockers treat as leaving the gesture.
+  if (googleOAuth2()) {
+    return openTokenPopup(input);
+  }
+  return loadGoogleIdentityServices().then(() => openTokenPopup(input));
+}
+
+function openTokenPopup({
   clientId,
   scope = ANDROID_PUBLISHER_SCOPE,
 }: RequestGoogleAccessTokenInput): Promise<string> {
-  await loadGoogleIdentityServices();
   return new Promise<string>((resolve, reject) => {
     const client = googleOAuth2()!.initTokenClient({
       client_id: clientId,

--- a/packages/ui/src/core/play-publish/google.ts
+++ b/packages/ui/src/core/play-publish/google.ts
@@ -1,0 +1,104 @@
+const GSI_SRC = 'https://accounts.google.com/gsi/client';
+
+export const ANDROID_PUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';
+
+type TokenResponse = { access_token?: string; error?: string; error_description?: string };
+type TokenClient = { requestAccessToken: () => void };
+type GoogleOAuth2 = {
+  initTokenClient: (config: {
+    client_id: string;
+    scope: string;
+    callback: (response: TokenResponse) => void;
+    error_callback?: (error: { type?: string; message?: string }) => void;
+  }) => TokenClient;
+};
+
+function googleOAuth2(): GoogleOAuth2 | undefined {
+  return (globalThis as { google?: { accounts?: { oauth2?: GoogleOAuth2 } } }).google?.accounts?.oauth2;
+}
+
+let gsiLoad: Promise<void> | undefined;
+
+export function loadGoogleIdentityServices(): Promise<void> {
+  if (googleOAuth2()) {
+    return Promise.resolve();
+  }
+  if (typeof document === 'undefined') {
+    return Promise.reject(new Error('Google sign-in requires a browser environment.'));
+  }
+  if (!gsiLoad) {
+    gsiLoad = new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = GSI_SRC;
+      script.async = true;
+      script.addEventListener(
+        'load',
+        () => {
+          if (googleOAuth2()) {
+            resolve();
+          } else {
+            reject(new Error('Google sign-in script loaded without the OAuth client.'));
+          }
+        },
+        { once: true },
+      );
+      script.addEventListener(
+        'error',
+        () => {
+          script.remove();
+          reject(new Error('Failed to load the Google sign-in script.'));
+        },
+        { once: true },
+      );
+      document.head.appendChild(script);
+    });
+    // A failed load (offline, blocked CDN) must not poison retries.
+    gsiLoad.catch(() => {
+      gsiLoad = undefined;
+    });
+  }
+  return gsiLoad;
+}
+
+export type RequestGoogleAccessTokenInput = {
+  clientId: string;
+  scope?: string;
+};
+
+/**
+ * Opens the Google consent popup and resolves with a short-lived OAuth
+ * access token. Call from a user gesture so popup blockers allow it, and
+ * call loadGoogleIdentityServices beforehand (e.g. when the surrounding
+ * dialog opens) to keep this call synchronous with the click.
+ */
+export async function requestGoogleAccessToken({
+  clientId,
+  scope = ANDROID_PUBLISHER_SCOPE,
+}: RequestGoogleAccessTokenInput): Promise<string> {
+  await loadGoogleIdentityServices();
+  return new Promise<string>((resolve, reject) => {
+    const client = googleOAuth2()!.initTokenClient({
+      client_id: clientId,
+      scope,
+      callback: (response) => {
+        if (response.error) {
+          reject(new Error(response.error_description || response.error));
+          return;
+        }
+        if (!response.access_token) {
+          reject(new Error('Google returned no access token.'));
+          return;
+        }
+        resolve(response.access_token);
+      },
+      error_callback: (error) => {
+        const fallback =
+          error?.type === 'popup_failed_to_open'
+            ? 'Google sign-in popup was blocked by the browser.'
+            : 'Google sign-in was cancelled.';
+        reject(new Error(error?.message || fallback));
+      },
+    });
+    client.requestAccessToken();
+  });
+}

--- a/packages/ui/src/core/play-publish/publish.test.ts
+++ b/packages/ui/src/core/play-publish/publish.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlaystorePublishError, publishToPlaystore } from './publish';
+
+function mockFetch(status: number, body: string) {
+  const fetchMock = vi.fn(async () => new Response(body, { status }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('publishToPlaystore', () => {
+  it('posts to the publish path with auth and org headers and returns the versionCode', async () => {
+    const fetchMock = mockFetch(200, JSON.stringify({ versionCode: 42 }));
+    const result = await publishToPlaystore({
+      registryApiUrl: 'https://registry-staging.limrun.dev',
+      token: 'limrun-token',
+      organizationId: 'org_x',
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetName: 'app-release.aab',
+    });
+    expect(result.versionCode).toBe(42);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://registry-staging.limrun.dev/android/playstore/publish');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer limrun-token');
+    expect(headers['X-Limrun-Organization']).toBe('org_x');
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetName: 'app-release.aab',
+    });
+  });
+
+  it('surfaces the registry error message and code', async () => {
+    mockFetch(409, JSON.stringify({ message: 'Version code 2 has already been used', code: 'versionCodeExists' }));
+    const error = await publishToPlaystore({
+      registryApiUrl: 'https://registry-staging.limrun.dev',
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetName: 'app-release.aab',
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(PlaystorePublishError);
+    const publishError = error as PlaystorePublishError;
+    expect(publishError.code).toBe('versionCodeExists');
+    expect(publishError.status).toBe(409);
+    expect(publishError.message).toContain('already been used');
+  });
+
+  it('handles non-JSON error bodies', async () => {
+    mockFetch(502, '<html>bad gateway</html>');
+    const error = await publishToPlaystore({
+      registryApiUrl: 'https://registry-staging.limrun.dev',
+      accessToken: 'google-token',
+      packageName: 'com.example.app',
+      assetId: 'asset_1',
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(PlaystorePublishError);
+    expect((error as PlaystorePublishError).message).toContain('HTTP 502');
+  });
+});

--- a/packages/ui/src/core/play-publish/publish.test.ts
+++ b/packages/ui/src/core/play-publish/publish.test.ts
@@ -37,7 +37,10 @@ describe('publishToPlaystore', () => {
   });
 
   it('surfaces the registry error message and code', async () => {
-    mockFetch(409, JSON.stringify({ message: 'Version code 2 has already been used', code: 'versionCodeExists' }));
+    mockFetch(
+      409,
+      JSON.stringify({ message: 'Version code 2 has already been used', code: 'versionCodeExists' }),
+    );
     const error = await publishToPlaystore({
       registryApiUrl: 'https://registry-staging.limrun.dev',
       accessToken: 'google-token',

--- a/packages/ui/src/core/play-publish/publish.ts
+++ b/packages/ui/src/core/play-publish/publish.ts
@@ -1,0 +1,89 @@
+export type PlaystorePublishInput = {
+  registryApiUrl: string;
+  /** Limrun API token authenticating the registry call. */
+  token?: string;
+  /** Organization tid; required when it differs from the token's default organization. */
+  organizationId?: string;
+  /** Google OAuth access token with the androidpublisher scope. Sent per request, never stored. */
+  accessToken: string;
+  packageName: string;
+  assetId?: string;
+  assetName?: string;
+  /** Play track ID, defaults to internal on the server. */
+  track?: string;
+  /** Required by the server when track is production. */
+  releaseStatus?: 'draft' | 'completed';
+};
+
+export type PlaystorePublishResult = {
+  versionCode: number;
+};
+
+/**
+ * Registry publish failure. `code` carries the registry's machine-readable
+ * error code when available: invalidRequest, assetNotFound, internal, busy,
+ * listingNotFound, permissionDenied, versionCodeExists, uploadKeyMismatch
+ * or unknown; the set grows additively.
+ */
+export class PlaystorePublishError extends Error {
+  readonly code?: string;
+  readonly status?: number;
+
+  constructor(message: string, options: { code?: string; status?: number } = {}) {
+    super(message);
+    this.name = 'PlaystorePublishError';
+    this.code = options.code;
+    this.status = options.status;
+  }
+}
+
+export async function publishToPlaystore(input: PlaystorePublishInput): Promise<PlaystorePublishResult> {
+  const { registryApiUrl, token, organizationId, ...body } = input;
+  let url: URL;
+  try {
+    url = new URL(registryApiUrl);
+  } catch {
+    throw new PlaystorePublishError(`Invalid registry URL: ${registryApiUrl}`);
+  }
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/android/playstore/publish`;
+  url.search = '';
+  url.hash = '';
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  if (organizationId) {
+    headers['X-Limrun-Organization'] = organizationId;
+  }
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+  } catch (caught) {
+    throw new PlaystorePublishError(
+      `Cannot reach the registry: ${caught instanceof Error ? caught.message : String(caught)}`,
+    );
+  }
+  const raw = await response.text();
+  let parsed: { versionCode?: number; message?: string; code?: string } | undefined;
+  try {
+    parsed = raw ? (JSON.parse(raw) as typeof parsed) : undefined;
+  } catch {
+    parsed = undefined;
+  }
+  if (!response.ok) {
+    throw new PlaystorePublishError(parsed?.message || `Play publish failed with HTTP ${response.status}`, {
+      code: parsed?.code,
+      status: response.status,
+    });
+  }
+  if (typeof parsed?.versionCode !== 'number') {
+    throw new PlaystorePublishError('Play publish response is missing versionCode.', {
+      status: response.status,
+    });
+  }
+  return { versionCode: parsed.versionCode };
+}

--- a/packages/ui/src/device-build/react.ts
+++ b/packages/ui/src/device-build/react.ts
@@ -18,6 +18,7 @@ export type UseDeviceBuildOptions = {
 
 export type StartDeviceBuildInput = {
   signingAssets?: StoredSigningAssets;
+  signedUploadUrl?: string;
 };
 
 export type UseDeviceBuildResult = {
@@ -82,6 +83,7 @@ export function useDeviceBuild({
           certificateP12Base64: activeSigningAssets.certificateP12Base64,
           certificatePassword: activeSigningAssets.certificatePassword,
           provisioningProfileBase64: activeSigningAssets.provisioningProfileBase64,
+          signedUploadUrl: input.signedUploadUrl,
         });
         if (!result.execId) {
           throw new Error('Build request did not return an exec ID.');

--- a/packages/ui/src/device-build/react.ts
+++ b/packages/ui/src/device-build/react.ts
@@ -8,6 +8,7 @@ import {
   type IOSOTAInstall,
   type StoredSigningAssets,
 } from './index';
+import { errorMessage } from '../core/errors';
 
 export type UseDeviceBuildOptions = {
   apiUrl?: string;
@@ -126,8 +127,4 @@ export function useDeviceBuild({
     startBuild,
     reset,
   };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/ui/src/device-install/README.md
+++ b/packages/ui/src/device-install/README.md
@@ -83,7 +83,7 @@ user only taps **Trust** once per device.
 ```tsx
 import { useDeviceInstallRelay } from '@limrun/ui/device-install/react';
 
-const install = useDeviceInstallRelay({ apiUrl, token, log: (m, d) => console.log(m, d) });
+const install = useDeviceInstallRelay({ apiUrl, token, organizationId, log: (m, d) => console.log(m, d) });
 
 // 1. Pick the iPhone (shows Chrome's WebUSB chooser).
 await install.requestUSBAccess();
@@ -156,13 +156,13 @@ import {
   putAppleGeneratedSigningAssets,
 } from '@limrun/ui/device-build';
 
-const appleLogin = useAppleIDLogin({ limbuildApiUrl: apiUrl, token });
+const appleLogin = useAppleIDLogin({ registryApiUrl: apiUrl, token, organizationId });
 const session = await appleLogin.startLogin({ accountName, password });
 if (session?.requiresTwoFactor) await appleLogin.submitTwoFactorCode(code);
 
 // Resolve the team id across all three fields Apple may use.
 const teamId = team.teamId ?? String(team.providerId ?? team.publicProviderId ?? '');
-const base = { apiUrl, token, appleSessionId: appleLogin.session!.appleSessionId, teamId };
+const base = { relay: appleLogin.session!.relay, teamId };
 
 // Register the paired iPhone (no-op if already registered).
 await registerAppleDevice({ ...base, deviceUDID, name: 'My iPhone' });
@@ -298,7 +298,7 @@ export function InstallToIPhone({
   const [log, setLog] = useState<string[]>([]);
   const append = (m: string, d?: string) => setLog((l) => [d ? `${m}: ${d}` : m, ...l]);
 
-  const install = useDeviceInstallRelay({ apiUrl, token, log: append });
+  const install = useDeviceInstallRelay({ apiUrl, token, organizationId, log: append });
   const build = useDeviceBuild({ apiUrl, token, signingAssets });
 
   async function prepare() {

--- a/packages/ui/src/device-install/demo/demo.tsx
+++ b/packages/ui/src/device-install/demo/demo.tsx
@@ -29,6 +29,7 @@ import {
 import { useDeviceBuild } from '../../device-build/react';
 import { useDeviceInstallRelay } from '../react';
 import './demo.css';
+import { errorMessage } from '../../core/errors';
 
 type ActivityLine = {
   id: number;
@@ -1051,10 +1052,6 @@ function useLocalStorage(key: string, initialValue: string) {
     localStorage.setItem(key, value);
   }, [key, value]);
   return [value, setValue] as const;
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/packages/ui/src/device-install/demo/demo.tsx
+++ b/packages/ui/src/device-install/demo/demo.tsx
@@ -64,6 +64,7 @@ const emptyAppleResources: AppleResourceState = {
 const storageKeys = {
   apiUrl: 'limrun-device-demo-api-url',
   token: 'limrun-device-demo-token',
+  ipaDownloadUrl: 'limrun-device-demo-ipa-download-url',
   bundleId: 'limrun-device-demo-bundle-id',
   certificatePassword: 'limrun-device-demo-certificate-password',
   appleAccount: 'limrun-device-demo-apple-account',
@@ -72,6 +73,7 @@ const storageKeys = {
 function App() {
   const [apiUrl, setApiUrl] = useLocalStorage(storageKeys.apiUrl, 'http://127.0.0.1:8080');
   const [token, setToken] = useLocalStorage(storageKeys.token, '');
+  const [ipaDownloadUrl, setIPADownloadUrl] = useLocalStorage(storageKeys.ipaDownloadUrl, '');
   const [bundleId, setBundleId] = useLocalStorage(storageKeys.bundleId, '');
   const [appleAccount, setAppleAccount] = useLocalStorage(storageKeys.appleAccount, '');
   const [certificatePassword, setCertificatePassword] = useLocalStorage(storageKeys.certificatePassword, '');
@@ -131,7 +133,7 @@ function App() {
   });
 
   const appleLogin = useAppleIDLogin({
-    limbuildApiUrl: apiUrl.trim(),
+    registryApiUrl: apiUrl.trim(),
     token: token.trim() || undefined,
   });
 
@@ -148,10 +150,10 @@ function App() {
   const selectedProfile = resources.profiles.find(
     (profile) => stringField(profile, 'provisioningProfileId') === selectedProfileId,
   );
-  const canUseApple = !!apiUrl.trim() && !!appleLogin.session?.appleSessionId && !!developerTeamId;
+  const canUseApple = !!apiUrl.trim() && !!appleLogin.session?.relay && !!developerTeamId;
   const canPrepareSigning = !!certificateFile && !!profileFile;
   const canStartBuild = !!signingAssets && build.status !== 'queued' && build.status !== 'running';
-  const canInstall = install.canInstall && build.status === 'succeeded';
+  const canInstall = install.canInstall && build.status === 'succeeded' && !!ipaDownloadUrl.trim();
 
   // Live per-step status used by the overview stepper and the section pills.
   const pairStep: StepView =
@@ -182,7 +184,7 @@ function App() {
 
   async function runInstall() {
     setInstallPhase('installing');
-    const relay = await install.startInstallation();
+    const relay = await install.startInstallation({ downloadUrl: ipaDownloadUrl.trim() });
     if (!relay) setInstallPhase('error');
   }
 
@@ -246,7 +248,7 @@ function App() {
       });
       setApplePassword('');
       if (session && !session.requiresTwoFactor) {
-        await loadAppleTeams(session.appleSessionId);
+        await loadAppleTeams(session.relay);
       }
     } catch (error) {
       setPrepareError(errorMessage(error));
@@ -262,7 +264,7 @@ function App() {
     try {
       await appleLogin.submitTwoFactorCode(twoFactorCode);
       setTwoFactorCode('');
-      await loadAppleTeams(appleLogin.session.appleSessionId);
+      await loadAppleTeams(appleLogin.session.relay);
     } catch (error) {
       setPrepareError(errorMessage(error));
     } finally {
@@ -270,17 +272,13 @@ function App() {
     }
   }
 
-  async function loadAppleTeams(appleSessionId = appleLogin.session?.appleSessionId) {
-    if (!apiUrl.trim() || !appleSessionId) return;
+  async function loadAppleTeams(relay = appleLogin.session?.relay) {
+    if (!apiUrl.trim() || !relay) return;
     setAppleBusy('teams');
     setPrepareError(undefined);
     try {
       await appleLogin.finalize().catch(() => undefined);
-      const teams = await listAppleTeams({
-        apiUrl: apiUrl.trim(),
-        token: token.trim() || undefined,
-        appleSessionId,
-      });
+      const teams = await listAppleTeams({ relay });
       setResources((current) => ({ ...current, teams }));
       const firstTeamId = teams.map(appleTeamSelectionId).find(Boolean) ?? '';
       setSelectedTeamId(firstTeamId);
@@ -288,7 +286,7 @@ function App() {
         teams.find((team) => appleTeamSelectionId(team) === firstTeamId),
       );
       if (firstDeveloperTeamId) {
-        await loadAppleResources(firstDeveloperTeamId, appleSessionId);
+        await loadAppleResources(firstDeveloperTeamId, relay);
       }
     } catch (error) {
       setPrepareError(errorMessage(error));
@@ -299,13 +297,11 @@ function App() {
 
   async function loadAppleResources(
     teamId = developerTeamId,
-    appleSessionId = appleLogin.session?.appleSessionId,
+    relay = appleLogin.session?.relay,
   ) {
-    if (!apiUrl.trim() || !appleSessionId || !teamId) return;
+    if (!apiUrl.trim() || !relay || !teamId) return;
     const base = {
-      apiUrl: apiUrl.trim(),
-      token: token.trim() || undefined,
-      appleSessionId,
+      relay,
       teamId,
     };
     const [appIds, devices, certificates, profiles] = await Promise.all([
@@ -336,9 +332,7 @@ function App() {
     setPrepareError(undefined);
     try {
       const app = await createAppleBundleID({
-        apiUrl: apiUrl.trim(),
-        token: token.trim() || undefined,
-        appleSessionId: appleLogin.session.appleSessionId,
+        relay: appleLogin.session.relay,
         teamId: developerTeamId,
         bundleId: bundleId.trim(),
       });
@@ -359,9 +353,7 @@ function App() {
     setPrepareError(undefined);
     try {
       await registerAppleDevice({
-        apiUrl: apiUrl.trim(),
-        token: token.trim() || undefined,
-        appleSessionId: appleLogin.session.appleSessionId,
+        relay: appleLogin.session.relay,
         teamId: developerTeamId,
         deviceUDID: selectedUDID,
         name: install.device?.hello.productName ?? 'Limrun iPhone',
@@ -393,9 +385,7 @@ function App() {
     setPrepareError(undefined);
     try {
       const base = {
-        apiUrl: apiUrl.trim(),
-        token: token.trim() || undefined,
-        appleSessionId: appleLogin.session.appleSessionId,
+        relay: appleLogin.session.relay,
         teamId: developerTeamId,
       };
       let certificateId = storedCertificate?.certificateID;
@@ -599,6 +589,14 @@ function App() {
         <p className="hint">
           Run this page on <code>localhost</code> or HTTPS. WebUSB is available in Chromium browsers only.
         </p>
+        <label>
+          IPA download URL
+          <input
+            value={ipaDownloadUrl}
+            onChange={(event) => setIPADownloadUrl(event.currentTarget.value)}
+            placeholder="https://asset-storage.example/app.ipa"
+          />
+        </label>
       </section>
 
       <section className="card">

--- a/packages/ui/src/device-install/demo/demo.tsx
+++ b/packages/ui/src/device-install/demo/demo.tsx
@@ -295,10 +295,7 @@ function App() {
     }
   }
 
-  async function loadAppleResources(
-    teamId = developerTeamId,
-    relay = appleLogin.session?.relay,
-  ) {
+  async function loadAppleResources(teamId = developerTeamId, relay = appleLogin.session?.relay) {
     if (!apiUrl.trim() || !relay || !teamId) return;
     const base = {
       relay,

--- a/packages/ui/src/device-install/index.ts
+++ b/packages/ui/src/device-install/index.ts
@@ -14,6 +14,7 @@ export {
   startInstallRelay as startDeviceInstallRelay,
   startPairingRelay as startDevicePairingRelay,
   type DeviceRelayTarget,
+  type InstallSource,
   type StartInstallRelayOptions,
   type StartPairingRelayOptions,
 } from '../core/device-install/operations';

--- a/packages/ui/src/device-install/react.ts
+++ b/packages/ui/src/device-install/react.ts
@@ -136,33 +136,36 @@ export function useDeviceInstallRelay({
     }
   }, [apiUrl, cleanupDeviceAccess, device, organizationId, token]);
 
-  const startInstallation = useCallback(async (installSource: InstallSource) => {
-    if (!apiUrl || !device || !pairRecord) {
-      throw new Error('Select and pair a USB device before starting installation.');
-    }
-    setBusyAction('install');
-    setError(undefined);
-    try {
-      await cleanupDeviceAccess();
-      relayRef.current = await startDeviceInstall({
-        registryApiUrl: apiUrl,
-        token,
-        organizationId,
-        log: logRef.current,
-        target: device,
-        pairRecord,
-        installSource,
-      });
-      logRef.current('Device install started', 'Installation will continue through the connected iPhone.');
-      return relayRef.current;
-    } catch (caught) {
-      await closeDeviceRelayTarget(device, logRef.current);
-      setError(errorMessage(caught));
-      return undefined;
-    } finally {
-      setBusyAction(undefined);
-    }
-  }, [apiUrl, cleanupDeviceAccess, device, organizationId, pairRecord, token]);
+  const startInstallation = useCallback(
+    async (installSource: InstallSource) => {
+      if (!apiUrl || !device || !pairRecord) {
+        throw new Error('Select and pair a USB device before starting installation.');
+      }
+      setBusyAction('install');
+      setError(undefined);
+      try {
+        await cleanupDeviceAccess();
+        relayRef.current = await startDeviceInstall({
+          registryApiUrl: apiUrl,
+          token,
+          organizationId,
+          log: logRef.current,
+          target: device,
+          pairRecord,
+          installSource,
+        });
+        logRef.current('Device install started', 'Installation will continue through the connected iPhone.');
+        return relayRef.current;
+      } catch (caught) {
+        await closeDeviceRelayTarget(device, logRef.current);
+        setError(errorMessage(caught));
+        return undefined;
+      } finally {
+        setBusyAction(undefined);
+      }
+    },
+    [apiUrl, cleanupDeviceAccess, device, organizationId, pairRecord, token],
+  );
 
   const stopRelay = useCallback(() => {
     void cleanupDeviceAccess();

--- a/packages/ui/src/device-install/react.ts
+++ b/packages/ui/src/device-install/react.ts
@@ -8,6 +8,7 @@ import {
   startDeviceInstall,
   type DeviceInstallLog,
   type DeviceRelayTarget,
+  type InstallSource,
   type RelayClient,
   type StoredPairRecord,
 } from './index';
@@ -17,6 +18,7 @@ export type DeviceInstallRelayBusyAction = 'usb' | 'pair' | 'install';
 export type UseDeviceInstallRelayOptions = {
   apiUrl?: string;
   token?: string;
+  organizationId?: string;
   log?: DeviceInstallLog;
 };
 
@@ -31,7 +33,7 @@ export type UseDeviceInstallRelayResult = {
   canInstall: boolean;
   requestUSBAccess: () => Promise<DeviceRelayTarget | undefined>;
   pairBrowser: () => Promise<StoredPairRecord | undefined>;
-  startInstallation: () => Promise<RelayClient | undefined>;
+  startInstallation: (installSource: InstallSource) => Promise<RelayClient | undefined>;
   stopRelay: () => void;
   clearError: () => void;
 };
@@ -39,6 +41,7 @@ export type UseDeviceInstallRelayResult = {
 export function useDeviceInstallRelay({
   apiUrl,
   token,
+  organizationId,
   log = noopLog,
 }: UseDeviceInstallRelayOptions): UseDeviceInstallRelayResult {
   const [device, setDevice] = useState<DeviceRelayTarget | undefined>();
@@ -108,8 +111,9 @@ export function useDeviceInstallRelay({
     try {
       await cleanupDeviceAccess();
       const result = await pairDevice({
-        limbuildApiUrl: apiUrl,
+        registryApiUrl: apiUrl,
         token,
+        organizationId,
         log: logRef.current,
         target: device,
       });
@@ -130,9 +134,9 @@ export function useDeviceInstallRelay({
     } finally {
       setBusyAction(undefined);
     }
-  }, [apiUrl, cleanupDeviceAccess, device, token]);
+  }, [apiUrl, cleanupDeviceAccess, device, organizationId, token]);
 
-  const startInstallation = useCallback(async () => {
+  const startInstallation = useCallback(async (installSource: InstallSource) => {
     if (!apiUrl || !device || !pairRecord) {
       throw new Error('Select and pair a USB device before starting installation.');
     }
@@ -141,11 +145,13 @@ export function useDeviceInstallRelay({
     try {
       await cleanupDeviceAccess();
       relayRef.current = await startDeviceInstall({
-        limbuildApiUrl: apiUrl,
+        registryApiUrl: apiUrl,
         token,
+        organizationId,
         log: logRef.current,
         target: device,
         pairRecord,
+        installSource,
       });
       logRef.current('Device install started', 'Installation will continue through the connected iPhone.');
       return relayRef.current;
@@ -156,7 +162,7 @@ export function useDeviceInstallRelay({
     } finally {
       setBusyAction(undefined);
     }
-  }, [apiUrl, cleanupDeviceAccess, device, pairRecord, token]);
+  }, [apiUrl, cleanupDeviceAccess, device, organizationId, pairRecord, token]);
 
   const stopRelay = useCallback(() => {
     void cleanupDeviceAccess();

--- a/packages/ui/src/device-install/react.ts
+++ b/packages/ui/src/device-install/react.ts
@@ -12,6 +12,7 @@ import {
   type RelayClient,
   type StoredPairRecord,
 } from './index';
+import { errorMessage } from '../core/errors';
 
 export type DeviceInstallRelayBusyAction = 'usb' | 'pair' | 'install';
 
@@ -191,8 +192,4 @@ export function useDeviceInstallRelay({
 
 function noopLog() {
   // Intentionally empty. Consumers can pass a logger for progress messages.
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/ui/src/play-publish/README.md
+++ b/packages/ui/src/play-publish/README.md
@@ -39,9 +39,9 @@ await play.publish({ assetName: 'app-release.aab', packageName: 'com.example.app
 // Render from state: play.status, play.versionCode, play.error, play.errorCode
 ```
 
-`errorCode` values: `invalidRequest`, `assetNotFound`, `internal`, `busy`,
-`listingNotFound`, `permissionDenied`, `versionCodeExists`,
-`uploadKeyMismatch`, `unknown`. The set grows additively.
+`errorCode` carries the registry's machine-readable error code; the
+canonical value list lives on `PlaystorePublishError`'s doc comment and
+grows additively.
 
 Google access tokens expire after about an hour. A `permissionDenied`
 error long after sign-in usually means the token expired; offer "Sign in

--- a/packages/ui/src/play-publish/README.md
+++ b/packages/ui/src/play-publish/README.md
@@ -1,0 +1,65 @@
+# @limrun/ui/play-publish
+
+Headless building blocks for publishing an AAB asset from the Limrun
+registry to Google Play, with a browser-owned Google sign-in. No UI ships
+here; embedders render their own buttons and dialogs around the hook,
+same as `device-install`.
+
+The Google access token is minted in the browser via Google Identity
+Services (token model, no client secret) and sent to the registry once
+per publish. Limrun never stores it.
+
+## Requirements
+
+- A Google OAuth **Web application** client ID whose authorized
+  JavaScript origins include your app's origin.
+- The signed-in Google account needs release permission for the target
+  app in Play Console, and the app listing must already exist.
+- The asset must be an AAB signed with the app's Play upload key.
+
+## React
+
+```tsx
+import { usePlaystorePublish } from '@limrun/ui/play-publish/react';
+
+const play = usePlaystorePublish({
+  registryApiUrl: 'https://registry.limrun.com',
+  token: limrunToken,
+  organizationId: organizationTid,
+  googleClientId: GOOGLE_OAUTH_CLIENT_ID,
+});
+
+// On dialog open, warm the sign-in script so the click stays popup-safe:
+play.preloadGoogle();
+
+// Button handlers:
+await play.signInWithGoogle();
+await play.publish({ assetName: 'app-release.aab', packageName: 'com.example.app' });
+
+// Render from state: play.status, play.versionCode, play.error, play.errorCode
+```
+
+`errorCode` values: `invalidRequest`, `assetNotFound`, `internal`, `busy`,
+`listingNotFound`, `permissionDenied`, `versionCodeExists`,
+`uploadKeyMismatch`, `unknown`. The set grows additively.
+
+Google access tokens expire after about an hour. A `permissionDenied`
+error long after sign-in usually means the token expired; offer "Sign in
+with Google" again rather than pointing users at Play Console
+permissions.
+
+## Without React
+
+```ts
+import { requestGoogleAccessToken, publishToPlaystore } from '@limrun/ui/play-publish';
+
+const accessToken = await requestGoogleAccessToken({ clientId: GOOGLE_OAUTH_CLIENT_ID });
+const { versionCode } = await publishToPlaystore({
+  registryApiUrl,
+  token,
+  organizationId,
+  accessToken,
+  assetName: 'app-release.aab',
+  packageName: 'com.example.app',
+});
+```

--- a/packages/ui/src/play-publish/README.md
+++ b/packages/ui/src/play-publish/README.md
@@ -29,7 +29,8 @@ const play = usePlaystorePublish({
   googleClientId: GOOGLE_OAUTH_CLIENT_ID,
 });
 
-// On dialog open, warm the sign-in script so the click stays popup-safe:
+// On dialog open, warm the sign-in script so the click stays popup-safe.
+// Optionally await the returned promise (true = ready) to gate the button:
 play.preloadGoogle();
 
 // Button handlers:

--- a/packages/ui/src/play-publish/index.ts
+++ b/packages/ui/src/play-publish/index.ts
@@ -1,0 +1,12 @@
+export {
+  ANDROID_PUBLISHER_SCOPE,
+  loadGoogleIdentityServices,
+  requestGoogleAccessToken,
+  type RequestGoogleAccessTokenInput,
+} from '../core/play-publish/google';
+export {
+  publishToPlaystore,
+  PlaystorePublishError,
+  type PlaystorePublishInput,
+  type PlaystorePublishResult,
+} from '../core/play-publish/publish';

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -1,0 +1,168 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  loadGoogleIdentityServices,
+  PlaystorePublishError,
+  publishToPlaystore,
+  requestGoogleAccessToken,
+  type PlaystorePublishInput,
+  type PlaystorePublishResult,
+} from './index';
+
+export type UsePlaystorePublishOptions = Partial<
+  Pick<PlaystorePublishInput, 'registryApiUrl' | 'token' | 'organizationId'>
+> & {
+  /** Google OAuth Web application client ID used for sign-in. */
+  googleClientId?: string;
+};
+
+export type PlaystorePublishStatus = 'idle' | 'signing-in' | 'ready' | 'publishing' | 'published' | 'error';
+
+export type PlaystorePublishRequest = Omit<
+  PlaystorePublishInput,
+  'registryApiUrl' | 'token' | 'organizationId' | 'accessToken'
+>;
+
+export type UsePlaystorePublishResult = {
+  status: PlaystorePublishStatus;
+  isSignedIn: boolean;
+  versionCode?: number;
+  error?: string;
+  /** Registry error code driving per-cause UX, e.g. versionCodeExists. */
+  errorCode?: string;
+  /** Warm up the Google sign-in script (e.g. on dialog open) so signInWithGoogle stays synchronous with the click. */
+  preloadGoogle: () => void;
+  signInWithGoogle: () => Promise<boolean>;
+  publish: (request: PlaystorePublishRequest) => Promise<PlaystorePublishResult | undefined>;
+  reset: () => void;
+};
+
+export function usePlaystorePublish({
+  registryApiUrl,
+  token,
+  organizationId,
+  googleClientId,
+}: UsePlaystorePublishOptions): UsePlaystorePublishResult {
+  const [status, setStatus] = useState<PlaystorePublishStatus>('idle');
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  const [versionCode, setVersionCode] = useState<number | undefined>();
+  const [error, setError] = useState<string | undefined>();
+  const [errorCode, setErrorCode] = useState<string | undefined>();
+  // The token lives in a ref so publish() right after signInWithGoogle()
+  // in one handler sees it before React re-renders.
+  const accessTokenRef = useRef<string | undefined>(undefined);
+  // reset() bumps the generation so an abandoned in-flight call cannot
+  // overwrite the state it settles into.
+  const generationRef = useRef(0);
+  const busyRef = useRef(false);
+
+  const preloadGoogle = useCallback(() => {
+    void loadGoogleIdentityServices().catch(() => undefined);
+  }, []);
+
+  const signInWithGoogle = useCallback(async () => {
+    if (busyRef.current) {
+      return false;
+    }
+    if (!googleClientId) {
+      setError('Google OAuth client ID is not configured.');
+      setStatus('error');
+      return false;
+    }
+    busyRef.current = true;
+    const generation = generationRef.current;
+    setStatus('signing-in');
+    setError(undefined);
+    setErrorCode(undefined);
+    try {
+      const nextToken = await requestGoogleAccessToken({ clientId: googleClientId });
+      accessTokenRef.current = nextToken;
+      if (generation === generationRef.current) {
+        setIsSignedIn(true);
+        setStatus('ready');
+      }
+      return true;
+    } catch (caught) {
+      if (generation === generationRef.current) {
+        setError(errorMessage(caught));
+        setStatus('error');
+      }
+      return false;
+    } finally {
+      busyRef.current = false;
+    }
+  }, [googleClientId]);
+
+  const publish = useCallback(
+    async (request: PlaystorePublishRequest) => {
+      if (busyRef.current) {
+        return undefined;
+      }
+      if (!registryApiUrl) {
+        setError('Registry URL is not configured.');
+        setStatus('error');
+        return undefined;
+      }
+      const accessToken = accessTokenRef.current;
+      if (!accessToken) {
+        setError('Sign in with Google before publishing.');
+        setStatus('error');
+        return undefined;
+      }
+      busyRef.current = true;
+      const generation = generationRef.current;
+      setStatus('publishing');
+      setError(undefined);
+      setErrorCode(undefined);
+      try {
+        const result = await publishToPlaystore({
+          registryApiUrl,
+          token,
+          organizationId,
+          accessToken,
+          ...request,
+        });
+        if (generation === generationRef.current) {
+          setVersionCode(result.versionCode);
+          setStatus('published');
+        }
+        return result;
+      } catch (caught) {
+        if (generation === generationRef.current) {
+          setError(errorMessage(caught));
+          if (caught instanceof PlaystorePublishError) {
+            setErrorCode(caught.code);
+          }
+          setStatus('error');
+        }
+        return undefined;
+      } finally {
+        busyRef.current = false;
+      }
+    },
+    [registryApiUrl, token, organizationId],
+  );
+
+  const reset = useCallback(() => {
+    generationRef.current += 1;
+    setVersionCode(undefined);
+    setError(undefined);
+    setErrorCode(undefined);
+    setStatus(accessTokenRef.current ? 'ready' : 'idle');
+  }, []);
+
+  return {
+    status,
+    isSignedIn,
+    versionCode,
+    error,
+    errorCode,
+    preloadGoogle,
+    signInWithGoogle,
+    publish,
+    reset,
+  };
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -30,8 +30,13 @@ export type UsePlaystorePublishResult = {
   error?: string;
   /** Registry error code driving per-cause UX, e.g. versionCodeExists. */
   errorCode?: string;
-  /** Warm up the Google sign-in script (e.g. on dialog open) so signInWithGoogle stays synchronous with the click. */
-  preloadGoogle: () => void;
+  /**
+   * Warm up the Google sign-in script (e.g. on dialog open) so
+   * signInWithGoogle stays synchronous with the click. Resolves true once
+   * the script is ready; await it to gate the sign-in button, or ignore
+   * the result and rely on the blocked-popup error plus retry.
+   */
+  preloadGoogle: () => Promise<boolean>;
   signInWithGoogle: () => Promise<boolean>;
   publish: (request: PlaystorePublishRequest) => Promise<PlaystorePublishResult | undefined>;
   /**
@@ -63,9 +68,14 @@ export function usePlaystorePublish({
   const generationRef = useRef(0);
   const busyRef = useRef(false);
 
-  const preloadGoogle = useCallback(() => {
-    void loadGoogleIdentityServices().catch(() => undefined);
-  }, []);
+  const preloadGoogle = useCallback(
+    () =>
+      loadGoogleIdentityServices().then(
+        () => true,
+        () => false,
+      ),
+    [],
+  );
 
   // Guard failures replace the whole outcome, like the main paths do: a
   // stale errorCode or versionCode must not render beside the new error.

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -124,12 +124,15 @@ export function usePlaystorePublish({
       // attempt's success next to an error state.
       setVersionCode(undefined);
       try {
+        // Hook-owned fields spread last: excess-property checking does not
+        // protect wider-typed request objects from smuggling in same-named
+        // credential fields.
         const result = await publishToPlaystore({
+          ...request,
           registryApiUrl,
           token,
           organizationId,
           accessToken,
-          ...request,
         });
         if (generation === generationRef.current) {
           setVersionCode(result.versionCode);

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { errorMessage } from '../core/errors';
 import {
   loadGoogleIdentityServices,
   PlaystorePublishError,
@@ -48,7 +49,9 @@ export function usePlaystorePublish({
   googleClientId,
 }: UsePlaystorePublishOptions): UsePlaystorePublishResult {
   const [status, setStatus] = useState<PlaystorePublishStatus>('idle');
-  const [isSignedIn, setIsSignedIn] = useState(false);
+  // isSignedIn derives from token possession so the two can never diverge,
+  // even when a reset() during the popup makes the flow's status stale.
+  const [accessToken, setAccessToken] = useState<string | undefined>();
   const [versionCode, setVersionCode] = useState<number | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [errorCode, setErrorCode] = useState<string | undefined>();
@@ -81,9 +84,7 @@ export function usePlaystorePublish({
     try {
       const nextToken = await requestGoogleAccessToken({ clientId: googleClientId });
       accessTokenRef.current = nextToken;
-      // isSignedIn mirrors token possession, so it is set even when a
-      // reset() during the popup made the flow's status stale.
-      setIsSignedIn(true);
+      setAccessToken(nextToken);
       if (generation === generationRef.current) {
         setStatus('ready');
       }
@@ -109,8 +110,8 @@ export function usePlaystorePublish({
         setStatus('error');
         return undefined;
       }
-      const accessToken = accessTokenRef.current;
-      if (!accessToken) {
+      const googleToken = accessTokenRef.current;
+      if (!googleToken) {
         setError('Sign in with Google before publishing.');
         setStatus('error');
         return undefined;
@@ -124,15 +125,19 @@ export function usePlaystorePublish({
       // attempt's success next to an error state.
       setVersionCode(undefined);
       try {
-        // Hook-owned fields spread last: excess-property checking does not
-        // protect wider-typed request objects from smuggling in same-named
-        // credential fields.
+        // Fields picked explicitly: spreading a wider-typed request object
+        // could smuggle same-named credential fields or excess properties
+        // into the request body.
         const result = await publishToPlaystore({
-          ...request,
           registryApiUrl,
           token,
           organizationId,
-          accessToken,
+          accessToken: googleToken,
+          packageName: request.packageName,
+          assetId: request.assetId,
+          assetName: request.assetName,
+          track: request.track,
+          releaseStatus: request.releaseStatus,
         });
         if (generation === generationRef.current) {
           setVersionCode(result.versionCode);
@@ -163,19 +168,20 @@ export function usePlaystorePublish({
     setStatus(accessTokenRef.current ? 'ready' : 'idle');
   }, []);
 
-  return {
-    status,
-    isSignedIn,
-    versionCode,
-    error,
-    errorCode,
-    preloadGoogle,
-    signInWithGoogle,
-    publish,
-    reset,
-  };
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
+  // Memoized so the result works as a prop or dependency without
+  // re-rendering consumers on unrelated parent renders.
+  return useMemo(
+    () => ({
+      status,
+      isSignedIn: accessToken !== undefined,
+      versionCode,
+      error,
+      errorCode,
+      preloadGoogle,
+      signInWithGoogle,
+      publish,
+      reset,
+    }),
+    [status, accessToken, versionCode, error, errorCode, preloadGoogle, signInWithGoogle, publish, reset],
+  );
 }

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -67,13 +67,21 @@ export function usePlaystorePublish({
     void loadGoogleIdentityServices().catch(() => undefined);
   }, []);
 
+  // Guard failures replace the whole outcome, like the main paths do: a
+  // stale errorCode or versionCode must not render beside the new error.
+  const failGuard = useCallback((message: string) => {
+    setError(message);
+    setErrorCode(undefined);
+    setVersionCode(undefined);
+    setStatus('error');
+  }, []);
+
   const signInWithGoogle = useCallback(async () => {
     if (busyRef.current) {
       return false;
     }
     if (!googleClientId) {
-      setError('Google OAuth client ID is not configured.');
-      setStatus('error');
+      failGuard('Google OAuth client ID is not configured.');
       return false;
     }
     busyRef.current = true;
@@ -87,6 +95,11 @@ export function usePlaystorePublish({
       setAccessToken(nextToken);
       if (generation === generationRef.current) {
         setStatus('ready');
+      } else {
+        // A reset() during the popup ran before the token landed and left
+        // idle; upgrade it so status agrees with isSignedIn. Anything but
+        // idle belongs to a newer flow and must not be stomped.
+        setStatus((current) => (current === 'idle' ? 'ready' : current));
       }
       return true;
     } catch (caught) {
@@ -106,14 +119,12 @@ export function usePlaystorePublish({
         return undefined;
       }
       if (!registryApiUrl) {
-        setError('Registry URL is not configured.');
-        setStatus('error');
+        failGuard('Registry URL is not configured.');
         return undefined;
       }
       const googleToken = accessTokenRef.current;
       if (!googleToken) {
-        setError('Sign in with Google before publishing.');
-        setStatus('error');
+        failGuard('Sign in with Google before publishing.');
         return undefined;
       }
       busyRef.current = true;

--- a/packages/ui/src/play-publish/react.ts
+++ b/packages/ui/src/play-publish/react.ts
@@ -33,6 +33,11 @@ export type UsePlaystorePublishResult = {
   preloadGoogle: () => void;
   signInWithGoogle: () => Promise<boolean>;
   publish: (request: PlaystorePublishRequest) => Promise<PlaystorePublishResult | undefined>;
+  /**
+   * Clears the outcome state (keeps the Google session). Does not cancel an
+   * in-flight sign-in or publish: their completion is ignored status-wise
+   * and new calls stay refused until the in-flight one settles.
+   */
   reset: () => void;
 };
 
@@ -76,8 +81,10 @@ export function usePlaystorePublish({
     try {
       const nextToken = await requestGoogleAccessToken({ clientId: googleClientId });
       accessTokenRef.current = nextToken;
+      // isSignedIn mirrors token possession, so it is set even when a
+      // reset() during the popup made the flow's status stale.
+      setIsSignedIn(true);
       if (generation === generationRef.current) {
-        setIsSignedIn(true);
         setStatus('ready');
       }
       return true;
@@ -113,6 +120,9 @@ export function usePlaystorePublish({
       setStatus('publishing');
       setError(undefined);
       setErrorCode(undefined);
+      // A stale code from an earlier publish must not render as this
+      // attempt's success next to an error state.
+      setVersionCode(undefined);
       try {
         const result = await publishToPlaystore({
           registryApiUrl,

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
         'device-build/react': resolve(__dirname, 'src/device-build/react.ts'),
         'device-install/index': resolve(__dirname, 'src/device-install/index.ts'),
         'device-install/react': resolve(__dirname, 'src/device-install/react.ts'),
+        'play-publish/index': resolve(__dirname, 'src/play-publish/index.ts'),
+        'play-publish/react': resolve(__dirname, 'src/play-publish/react.ts'),
       },
       name: 'LimrunUI',
       formats: ['es', 'cjs'],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Breaking public API changes (relay session model, WebSocket URLs, install payload) affect auth, signing, and device install flows; consumers must update alongside the registry backend.
> 
> **Overview**
> **Migrates `@limrun/ui` from limbuild HTTP Apple/device endpoints to the registry API**, with a breaking shift in how Apple Developer and USB install traffic is carried.
> 
> **Apple App Store relay** no longer uses per-request HTTP (`/apple/auth/*`, `/apple/provisioning`) or an `appleSessionId`. Login and portal calls go through **`AppleRelayWebSocketClient`** at `/ios/appstoreconnect/ws`, with typed messages (`srpInit`, `provisioning`, etc.). Callers pass **`registryApiUrl`**, optional **`organizationId`**, and a live **`relay`** from `useAppleIDLogin` / `startBrowserOwnedAppleIDLogin` instead of `apiUrl` + `appleSessionId`.
> 
> **Device install relay** uses **`registryApiUrl`** and **`/ios/device/ws`** (replacing `/device/ws`). **`startInstallation`** now requires an **`InstallSource`** (`assetId`, `assetName`, or `downloadUrl`); the demo wires install to an IPA download URL.
> 
> **Device build** can pass optional **`signedUploadUrl`** on signed builds. Shared **`errorMessage`** lives in `core/errors`.
> 
> **New `@limrun/ui/play-publish`**: browser Google Identity Services OAuth plus **`publishToPlaystore`** against `/android/playstore/publish`, with **`usePlaystorePublish`** React hook and tests.
> 
> Package bumps to **`0.14.0-rc.3`** with **`publishConfig.tag: next`** and new Vite entry points for play-publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0bca754e928a78021e2c151e58d5b3aa5f8adbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->