### PR TITLE
api,cli: add build-finish webhook for xcode builds

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -436,6 +436,9 @@ lim xcode build ./MyProject --scheme MyApp --build-setting 'SWIFT_ACTIVE_COMPILA
 # Signed device build
 lim xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa
 
+# Get an HTTP callback with the result and a build-log URL when the build finishes
+lim xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"
+
 # Attach an existing simulator so builds auto-install there
 lim xcode attach-simulator ios_abc123 --id sandbox_def456
 

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@limrun/api": "0.43.1",
+        "@limrun/api": "file:../../dist",
         "@oclif/core": "^4",
         "cli-progress": "^3.12.0",
         "cli-table3": "^0.6.5",
@@ -36,6 +36,21 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "../../dist": {
+      "name": "@limrun/api",
+      "version": "0.43.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@limrun/xdelta3-wasm": "0.2.0",
+        "eventsource-client": "^1.2.0",
+        "https-proxy-agent": "7.0.6",
+        "ignore": "^7.0.5",
+        "proxy-from-env": "^2.1.0",
+        "undici": "7.24.7",
+        "ws": "^8.18.3",
+        "yauzl": "^3.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1144,26 +1159,8 @@
       }
     },
     "node_modules/@limrun/api": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@limrun/api/-/api-0.43.1.tgz",
-      "integrity": "sha512-3LMx0AqIfvy6Up7wggqTMSM12diV9QaXUw/wT8hyMh/AxwEjNCsgZtvSgtgKsgBYUqeFxWH7YTOiU6TIl/qwKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@limrun/xdelta3-wasm": "0.2.0",
-        "eventsource-client": "^1.2.0",
-        "https-proxy-agent": "7.0.6",
-        "ignore": "^7.0.5",
-        "proxy-from-env": "^2.1.0",
-        "undici": "7.24.7",
-        "ws": "^8.18.3",
-        "yauzl": "^3.4.0"
-      }
-    },
-    "node_modules/@limrun/xdelta3-wasm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz",
-      "integrity": "sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==",
-      "license": "Apache-2.0"
+      "resolved": "../../dist",
+      "link": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1796,15 +1793,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2541,27 +2529,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/eventsource-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventsource-client/-/eventsource-client-1.2.0.tgz",
-      "integrity": "sha512-kDI75RSzO3TwyG/K9w1ap8XwqSPcwi6jaMkNulfVeZmSeUM49U8kUzk1s+vKNt0tGrXgK47i+620Yasn1ccFiw==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2886,19 +2853,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -2907,15 +2861,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/import-local": {
@@ -4242,12 +4187,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4329,15 +4268,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pure-rand": {
@@ -4882,15 +4812,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -5083,27 +5004,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -5176,18 +5076,6 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
       "engines": {
         "node": ">=12"
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.43.1",
+    "@limrun/api": "file:../../dist",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -30,6 +30,7 @@ export default class GradleBuild extends BaseCommand {
     '<%= config.bin %> gradle build ./my-monorepo --expo-app-dir apps/mobile',
     '<%= config.bin %> gradle build --sign --upload myapp.aab',
     '<%= config.bin %> gradle build --keystore upload.jks --keystore-password *** --key-alias upload --key-password *** --save-key',
+    '<%= config.bin %> gradle build ./my-app --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
   ];
 
   static args = {
@@ -92,6 +93,15 @@ export default class GradleBuild extends BaseCommand {
       description:
         "Escrow the provided --keystore as the organization's upload key for this app, so later builds can use --sign. Fails if a different key is already escrowed.",
       default: false,
+    }),
+    'webhook-url': Flags.string({
+      description:
+        'HTTPS URL that the build daemon POSTs a JSON payload to once the build reaches a terminal state, carrying the result and a console debug link. Must be a public DNS host; IP-literal and private targets are rejected. Delivery is best-effort and never fails the build.',
+    }),
+    'webhook-header': Flags.string({
+      description:
+        'Header to set verbatim on the webhook request as NAME=VALUE, for example Authorization="Bearer $SECRET". Requires --webhook-url. Repeat for multiple headers (at most 16).',
+      multiple: true,
     }),
     'basis-cache-dir': Flags.string({
       description: 'Directory for the client-side folder-sync cache.',

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -9,6 +9,7 @@ import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance }
 import {
   parseBuildSettingEntries,
   type TestflightUploadConfig,
+  type WebhookConfig,
   type XcodeBuildOptions,
   type XcodeClient,
 } from '@limrun/api';
@@ -51,6 +52,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
+    '<%= config.bin %> xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
     '<%= config.bin %> xcode build ./MyProject --basis-cache-dir ./.limsync-cache',
     '<%= config.bin %> xcode build ./MyProject --ignore "\\\\.xcuserdata/"',
     '<%= config.bin %> xcode build ./MyProject --additional-file ~/.netrc=~/.netrc',
@@ -156,6 +158,15 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Set the build number to one more than the highest already in App Store Connect (1 for a new app), so repeat uploads never collide on CFBundleVersion. Resolved server-side with the ASC key. Requires --upload-to-testflight and a project using Xcode-standard versioning (CFBundleVersion = $(CURRENT_PROJECT_VERSION)).',
       default: false,
+    }),
+    'webhook-url': Flags.string({
+      description:
+        'HTTPS URL that limbuild POSTs a JSON payload to once the build reaches a terminal state, carrying the result, a console debug link, and a presigned build-log URL. Must be a public DNS host; IP-literal and private targets are rejected. Delivery is best-effort and never fails the build.',
+    }),
+    'webhook-header': Flags.string({
+      description:
+        'Header to set verbatim on the webhook request as NAME=VALUE, for example Authorization="Bearer $SECRET". Requires --webhook-url. Repeat for multiple headers (at most 16).',
+      multiple: true,
     }),
     'basis-cache-dir': Flags.string({
       description: 'Directory to use for the client-side delta sync cache during the pre-build sync step.',
@@ -279,6 +290,10 @@ export default class XcodeBuild extends BaseCommand {
           signedUploadUrl: flags['signed-upload-url'],
         };
       }
+      const webhook = this.buildWebhookOptions(flags);
+      if (webhook) {
+        options.webhook = webhook;
+      }
 
       this.info(`Syncing ${syncPath} to instance ${id}...`);
       const syncStart = Date.now();
@@ -356,6 +371,31 @@ export default class XcodeBuild extends BaseCommand {
         this.output(`Artifact download URL: ${result.signedDownloadUrl}`);
       }
     });
+  }
+
+  private buildWebhookOptions(flags: {
+    'webhook-url'?: string;
+    'webhook-header'?: string[];
+  }): WebhookConfig | undefined {
+    const headerEntries = flags['webhook-header'] ?? [];
+    if (!flags['webhook-url']) {
+      if (headerEntries.length > 0) {
+        this.error('--webhook-header requires --webhook-url.');
+      }
+      return undefined;
+    }
+    const headers: Record<string, string> = {};
+    for (const entry of headerEntries) {
+      const separator = entry.indexOf('=');
+      if (separator <= 0) {
+        this.error(`Invalid --webhook-header ${JSON.stringify(entry)}: expected NAME=VALUE.`);
+      }
+      headers[entry.slice(0, separator)] = entry.slice(separator + 1);
+    }
+    return {
+      url: flags['webhook-url'],
+      ...(Object.keys(headers).length > 0 && { headers }),
+    };
   }
 
   private async buildSigningOptions(flags: SigningFlags): Promise<

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -6,10 +6,10 @@ import { formatDurationMs } from '../../lib/duration';
 import { formatBytes } from '../../lib/bytes';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
+import { webhookConfigFromFlags } from '../../lib/webhook-options';
 import {
   parseBuildSettingEntries,
   type TestflightUploadConfig,
-  type WebhookConfig,
   type XcodeBuildOptions,
   type XcodeClient,
 } from '@limrun/api';
@@ -290,9 +290,13 @@ export default class XcodeBuild extends BaseCommand {
           signedUploadUrl: flags['signed-upload-url'],
         };
       }
-      const webhook = this.buildWebhookOptions(flags);
-      if (webhook) {
-        options.webhook = webhook;
+      try {
+        const webhook = webhookConfigFromFlags(flags);
+        if (webhook) {
+          options.webhook = webhook;
+        }
+      } catch (err) {
+        this.error(err instanceof Error ? err.message : String(err));
       }
 
       this.info(`Syncing ${syncPath} to instance ${id}...`);
@@ -371,31 +375,6 @@ export default class XcodeBuild extends BaseCommand {
         this.output(`Artifact download URL: ${result.signedDownloadUrl}`);
       }
     });
-  }
-
-  private buildWebhookOptions(flags: {
-    'webhook-url'?: string;
-    'webhook-header'?: string[];
-  }): WebhookConfig | undefined {
-    const headerEntries = flags['webhook-header'] ?? [];
-    if (!flags['webhook-url']) {
-      if (headerEntries.length > 0) {
-        this.error('--webhook-header requires --webhook-url.');
-      }
-      return undefined;
-    }
-    const headers: Record<string, string> = {};
-    for (const entry of headerEntries) {
-      const separator = entry.indexOf('=');
-      if (separator <= 0) {
-        this.error(`Invalid --webhook-header ${JSON.stringify(entry)}: expected NAME=VALUE.`);
-      }
-      headers[entry.slice(0, separator)] = entry.slice(separator + 1);
-    }
-    return {
-      url: flags['webhook-url'],
-      ...(Object.keys(headers).length > 0 && { headers }),
-    };
   }
 
   private async buildSigningOptions(flags: SigningFlags): Promise<

--- a/packages/cli/src/lib/gradle-build-options.ts
+++ b/packages/cli/src/lib/gradle-build-options.ts
@@ -1,4 +1,5 @@
 import type { GradleAndroidABI, GradleBuildOptions } from '@limrun/api';
+import { webhookConfigFromFlags, type WebhookFlagValues } from './webhook-options';
 
 /**
  * Single source for the --abi enum: `satisfies` pins every entry to the SDK
@@ -13,7 +14,7 @@ export const gradleAndroidABIs = [
   'all',
 ] as const satisfies readonly GradleAndroidABI[];
 
-export interface GradleBuildFlagValues {
+export interface GradleBuildFlagValues extends WebhookFlagValues {
   task?: string[];
   'project-path'?: string;
   'expo-app-dir'?: string;
@@ -111,6 +112,10 @@ export function gradleBuildOptionsFromFlags(flags: GradleBuildFlagValues): Gradl
     options.upload = { assetName: flags.upload };
   } else if (flags['signed-upload-url']) {
     options.upload = { signedUploadUrl: flags['signed-upload-url'] };
+  }
+  const webhook = webhookConfigFromFlags(flags);
+  if (webhook) {
+    options.webhook = webhook;
   }
   return options;
 }

--- a/packages/cli/src/lib/webhook-options.test.ts
+++ b/packages/cli/src/lib/webhook-options.test.ts
@@ -1,0 +1,68 @@
+import { webhookConfigFromFlags } from './webhook-options';
+
+describe('webhookConfigFromFlags', () => {
+  test('returns undefined without flags', () => {
+    expect(webhookConfigFromFlags({})).toBeUndefined();
+  });
+
+  test('maps url and headers', () => {
+    expect(
+      webhookConfigFromFlags({
+        'webhook-url': 'https://ci.example.com/hooks/limrun',
+        'webhook-header': ['Authorization=Bearer secret', 'X-Build=release'],
+      }),
+    ).toEqual({
+      url: 'https://ci.example.com/hooks/limrun',
+      headers: { Authorization: 'Bearer secret', 'X-Build': 'release' },
+    });
+  });
+
+  test('omits headers key when none are given', () => {
+    expect(webhookConfigFromFlags({ 'webhook-url': 'https://ci.example.com/h' })).toEqual({
+      url: 'https://ci.example.com/h',
+    });
+  });
+
+  test('preserves = in header values', () => {
+    expect(
+      webhookConfigFromFlags({
+        'webhook-url': 'https://ci.example.com/h',
+        'webhook-header': ['X-Sig=a=b=c'],
+      }),
+    ).toEqual({ url: 'https://ci.example.com/h', headers: { 'X-Sig': 'a=b=c' } });
+  });
+
+  test('rejects headers without a url', () => {
+    expect(() => webhookConfigFromFlags({ 'webhook-header': ['A=b'] })).toThrow(
+      '--webhook-header requires --webhook-url.',
+    );
+  });
+
+  test('rejects entries without NAME=VALUE shape', () => {
+    for (const entry of ['NoSeparator', '=value-only']) {
+      expect(() =>
+        webhookConfigFromFlags({ 'webhook-url': 'https://ci.example.com/h', 'webhook-header': [entry] }),
+      ).toThrow('expected NAME=VALUE');
+    }
+  });
+
+  test('rejects duplicate header names', () => {
+    expect(() =>
+      webhookConfigFromFlags({
+        'webhook-url': 'https://ci.example.com/h',
+        'webhook-header': ['Authorization=Bearer one', 'Authorization=Bearer two'],
+      }),
+    ).toThrow('Duplicate --webhook-header name "Authorization".');
+  });
+
+  test('rejects duplicate header names case-insensitively', () => {
+    // Header names are case-insensitive on the wire and the daemon
+    // canonicalizes them, so a different casing would still overwrite.
+    expect(() =>
+      webhookConfigFromFlags({
+        'webhook-url': 'https://ci.example.com/h',
+        'webhook-header': ['Authorization=Bearer one', 'authorization=Bearer two'],
+      }),
+    ).toThrow('Duplicate --webhook-header name "authorization".');
+  });
+});

--- a/packages/cli/src/lib/webhook-options.ts
+++ b/packages/cli/src/lib/webhook-options.ts
@@ -1,0 +1,46 @@
+import type { WebhookConfig } from '@limrun/api';
+
+export interface WebhookFlagValues {
+  'webhook-url'?: string;
+  'webhook-header'?: string[];
+}
+
+/**
+ * Maps the shared --webhook-url / --webhook-header flags onto the exec
+ * request's webhook config, throwing on invalid combinations. Pure and
+ * oclif-free so both `xcode build` and `gradle build` share it and it is
+ * unit-testable.
+ *
+ * Duplicate header names are rejected (case-insensitively: header names are
+ * case-insensitive on the wire, and the daemon canonicalizes them) instead
+ * of last-one-wins, so a misconfigured CI auth header fails at the command
+ * line rather than silently at callback time.
+ */
+export function webhookConfigFromFlags(flags: WebhookFlagValues): WebhookConfig | undefined {
+  const headerEntries = flags['webhook-header'] ?? [];
+  if (!flags['webhook-url']) {
+    if (headerEntries.length > 0) {
+      throw new Error('--webhook-header requires --webhook-url.');
+    }
+    return undefined;
+  }
+  const headers: Record<string, string> = {};
+  const seen = new Set<string>();
+  for (const entry of headerEntries) {
+    const separator = entry.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(`Invalid --webhook-header ${JSON.stringify(entry)}: expected NAME=VALUE.`);
+    }
+    const name = entry.slice(0, separator);
+    const key = name.toLowerCase();
+    if (seen.has(key)) {
+      throw new Error(`Duplicate --webhook-header name ${JSON.stringify(name)}.`);
+    }
+    seen.add(key);
+    headers[name] = entry.slice(separator + 1);
+  }
+  return {
+    url: flags['webhook-url'],
+    ...(Object.keys(headers).length > 0 && { headers }),
+  };
+}

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -41,9 +41,34 @@ export type XcodeBuildExecRequest = {
   buildSettings?: Record<string, string>;
   gitInit?: boolean;
   signedUploadUrl?: string;
+  webhook?: WebhookConfig;
   additionalMetadata?: {
     signedDownloadUrl?: string;
   };
+};
+
+/**
+ * Build-finish webhook: limbuild POSTs a JSON payload to `url` once the build
+ * reaches a terminal state (SUCCEEDED, FAILED, or CANCELLED), carrying the
+ * result (execId, status, exitCode, timing), the instance's identity with a
+ * Limrun Console debug link, and a presigned URL for the persisted build log
+ * when log persistence is configured. Delivery is best-effort with bounded
+ * retries; a webhook failure never fails the build.
+ */
+export type WebhookConfig = {
+  /**
+   * HTTPS URL the payload is POSTed to. Must be a public DNS host;
+   * IP-literal, private, and cluster-internal targets are rejected by the
+   * server with HTTP 400 at build request time.
+   */
+  url: string;
+  /**
+   * Headers set verbatim on the callback request (e.g. an Authorization
+   * bearer token so your endpoint can authenticate the call). At most 16
+   * headers; hop-by-hop and message-framing headers (Host, Content-Length,
+   * Transfer-Encoding, Connection) are rejected.
+   */
+  headers?: Record<string, string>;
 };
 
 /** Android ABIs the gradle daemon accepts; 'all' keeps the project's own configuration. */

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -117,6 +117,7 @@ export type GradleBuildExecRequest = {
   reactNative?: GradleReactNativeConfig;
   signing?: GradleSigningConfig;
   signedUploadUrl?: string;
+  webhook?: WebhookConfig;
   additionalMetadata?: {
     signedDownloadUrl?: string;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export {
   type ExecChildProcess,
   type TestflightEvent,
   type TestflightUploadConfig,
+  type WebhookConfig,
 } from './exec-client';
 export {
   type XcodeCreateClientParams,

--- a/src/resources/gradle-instances-helpers.ts
+++ b/src/resources/gradle-instances-helpers.ts
@@ -5,6 +5,7 @@ import {
   type GradleBuildExecRequest,
   type GradleReactNativeConfig,
   type GradleSigningConfig,
+  type WebhookConfig,
 } from '../exec-client';
 import { syncFolder as syncFolderImpl, type FolderSyncOptions } from '../folder-sync';
 import { createIgnoreFn } from '../folder-sync-ignore';
@@ -52,6 +53,11 @@ export type GradleBuildOptions = {
   reactNative?: GradleReactNativeConfig;
   /** Release signing config; presence makes bundleRelease the default task. */
   signing?: GradleSigningConfig;
+  /**
+   * HTTP callback fired once the build reaches a terminal state, POSTed the
+   * build result. Delivery is best-effort and never fails the build.
+   */
+  webhook?: WebhookConfig;
 };
 
 export type GradleClient = {
@@ -135,6 +141,7 @@ export class GradleInstances extends GeneratedGradleInstances {
           ...(options?.projectPath && { projectPath: options.projectPath }),
           ...(options?.reactNative && { reactNative: options.reactNative }),
           ...(options?.signing && { signing: options.signing }),
+          ...(options?.webhook && { webhook: options.webhook }),
         };
 
         if (options?.upload && 'assetName' in options.upload) {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -65,6 +65,7 @@ export {
   type RbeInstallResult,
   type XcodeBuildLog,
   type BazelBuildLog,
+  type WebhookConfig,
 } from './xcode-instances-helpers';
 export {
   GradleInstances,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -3,9 +3,15 @@ import { type IosInstance } from './ios-instances';
 import { APIPromise } from '../core/api-promise';
 import { RequestOptions } from '../internal/request-options';
 import { path } from '../internal/utils/path';
-import { exec, type ExecChildProcess, type ExecRequest, type TestflightUploadConfig } from '../exec-client';
+import {
+  exec,
+  type ExecChildProcess,
+  type ExecRequest,
+  type TestflightUploadConfig,
+  type WebhookConfig,
+} from '../exec-client';
 
-export type { TestflightUploadConfig } from '../exec-client';
+export type { TestflightUploadConfig, WebhookConfig } from '../exec-client';
 import {
   syncFolder as syncFolderImpl,
   type AdditionalFileSyncEntry,
@@ -159,6 +165,15 @@ export type XcodeBuildOptions = {
    * dependency resolution, and xcodebuild.
    */
   gitInit?: boolean;
+  /**
+   * HTTP callback fired once the build reaches a terminal state (SUCCEEDED,
+   * FAILED, or CANCELLED). The payload carries the result (execId, status,
+   * exitCode, timing), the instance's identity with a Limrun Console debug
+   * link, and a presigned URL for the persisted build log. Delivery is
+   * best-effort with bounded retries; a webhook failure never fails the
+   * build. Older limbuild servers silently ignore this option.
+   */
+  webhook?: WebhookConfig;
 };
 
 export type SimulatorInstallState =
@@ -721,6 +736,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ...(options?.testflight && { testflight: options.testflight }),
           ...(options?.buildSettings && { buildSettings: options.buildSettings }),
           ...(options?.gitInit !== undefined && { gitInit: options.gitInit }),
+          ...(options?.webhook && { webhook: options.webhook }),
         };
 
         if (options?.upload && 'assetName' in options.upload) {

--- a/tests/gradle-client-webhook.test.ts
+++ b/tests/gradle-client-webhook.test.ts
@@ -1,0 +1,86 @@
+jest.mock('eventsource-client', () => ({
+  createEventSource: jest.fn((options: { onMessage: (message: { event: string; data: string }) => void }) => {
+    setTimeout(() => options.onMessage({ event: 'exitCode', data: '0' }), 0);
+    return { close: jest.fn() };
+  }),
+}));
+
+import Limrun from '@limrun/api';
+import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
+import type { RequestInfo } from '../src/internal/builtin-types';
+
+const originalFetch = nodeProxyTransport.fetch;
+
+describe('gradle client build-finish webhook', () => {
+  afterEach(() => {
+    nodeProxyTransport.fetch = originalFetch;
+  });
+
+  test('serializes webhook in gradlebuild exec request', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://gradle.example.test/exec') {
+        return jsonResponse({ execId: 'build-1' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const gradle = await client.gradleInstances.createClient({
+      apiUrl: 'https://gradle.example.test',
+      token: 'gradle-token',
+    });
+
+    const result = await gradle.gradlebuild({
+      tasks: ['assembleDebug'],
+      webhook: {
+        url: 'https://ci.example.com/hooks/limrun',
+        headers: { Authorization: 'Bearer hook-secret' },
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(calls[0]?.init?.method).toBe('POST');
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'gradlebuild',
+      tasks: ['assembleDebug'],
+      webhook: {
+        url: 'https://ci.example.com/hooks/limrun',
+        headers: { Authorization: 'Bearer hook-secret' },
+      },
+    });
+  });
+
+  test('omits webhook when not configured', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://gradle.example.test/exec') {
+        return jsonResponse({ execId: 'build-2' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const gradle = await client.gradleInstances.createClient({
+      apiUrl: 'https://gradle.example.test',
+      token: 'gradle-token',
+    });
+
+    const result = await gradle.gradlebuild({ tasks: ['assembleDebug'] });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'gradlebuild',
+      tasks: ['assembleDebug'],
+    });
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/tests/xcode-client-webhook.test.ts
+++ b/tests/xcode-client-webhook.test.ts
@@ -1,0 +1,88 @@
+jest.mock('eventsource-client', () => ({
+  createEventSource: jest.fn((options: { onMessage: (message: { event: string; data: string }) => void }) => {
+    setTimeout(() => options.onMessage({ event: 'exitCode', data: '0' }), 0);
+    return { close: jest.fn() };
+  }),
+}));
+
+import Limrun from '@limrun/api';
+import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
+import type { RequestInfo } from '../src/internal/builtin-types';
+
+const originalFetch = nodeProxyTransport.fetch;
+
+describe('xcode client build-finish webhook', () => {
+  afterEach(() => {
+    nodeProxyTransport.fetch = originalFetch;
+  });
+
+  test('serializes webhook in limbuild exec request', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://xcode.example.test/exec') {
+        return jsonResponse({ execId: 'build-1' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const xcode = await client.xcodeInstances.createClient({
+      apiUrl: 'https://xcode.example.test',
+      token: 'xcode-token',
+    });
+
+    const result = await xcode.xcodebuild(
+      { scheme: 'Scripty' },
+      {
+        webhook: {
+          url: 'https://ci.example.com/hooks/limrun',
+          headers: { Authorization: 'Bearer hook-secret' },
+        },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls[0]?.init?.method).toBe('POST');
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'xcodebuild',
+      xcodebuild: { scheme: 'Scripty' },
+      webhook: {
+        url: 'https://ci.example.com/hooks/limrun',
+        headers: { Authorization: 'Bearer hook-secret' },
+      },
+    });
+  });
+
+  test('omits webhook when not configured', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://xcode.example.test/exec') {
+        return jsonResponse({ execId: 'build-2' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const xcode = await client.xcodeInstances.createClient({
+      apiUrl: 'https://xcode.example.test',
+      token: 'xcode-token',
+    });
+
+    const result = await xcode.xcodebuild({ scheme: 'Scripty' });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'xcodebuild',
+      xcodebuild: { scheme: 'Scripty' },
+    });
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
## What

Adds support for the new limbuild build-finish webhook (server side: limrun-inc/limrun#450) to the API package and the CLI.

The xcodebuild exec request can now carry a `webhook` config (URL plus a set of headers). Once the build reaches a terminal state (SUCCEEDED, FAILED, or CANCELLED), limbuild POSTs a JSON payload to that URL with the build result, the instance's identity with a Limrun Console debug link, and a presigned URL for the persisted `.jsonl` build log:

```json
{
  "execId": "build-1700000000000000000",
  "command": "xcodebuild",
  "status": "SUCCEEDED",
  "exitCode": 0,
  "startedAt": "2026-07-20T19:00:00Z",
  "finishedAt": "2026-07-20T19:03:25Z",
  "buildDurationMs": 205000,
  "instanceId": "sandbox_someid",
  "consoleUrl": "https://console.limrun.com/builds/sandbox_someid",
  "logsUrl": "https://..."
}
```

## API

- New `WebhookConfig` type (`url` + optional `headers`), exported from the package root.
- `webhook` field on `XcodeBuildExecRequest` and `XcodeBuildOptions`, serialized into the `/exec` body by `xcodeClient.xcodebuild`. Older limbuild servers silently ignore it.
- Same `webhook` field on `GradleBuildExecRequest` and `GradleBuildOptions`, serialized by `gradleClient.gradlebuild` (server side: the gradlebuild webhook on the same limrun PR). Gradle payloads carry `command: "gradlebuild"` and no `logsUrl` (gradlebuild has no build-log persistence).

## CLI

```bash
lim xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"
```

```bash
lim gradle build ./my-app --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"
```

- `--webhook-url`: HTTPS public-DNS URL (the server rejects IP-literal/private targets with 400).
- `--webhook-header NAME=VALUE`: repeatable, split on the first `=`; requires `--webhook-url`. Duplicate header names (case-insensitive) are rejected instead of silently keeping the last value.
- Both `lim xcode build` and `lim gradle build` share the flag parsing (`packages/cli/src/lib/webhook-options.ts`).

## Testing

- `tests/xcode-client-webhook.test.ts` and `tests/gradle-client-webhook.test.ts` assert the webhook is serialized into the exec body (and omitted when unset).
- `packages/cli/src/lib/webhook-options.test.ts` covers the flag parsing, including duplicate-header rejection.
- `./scripts/lint`, `./scripts/test`, CLI `npm run lint`, `npm test`, and `npm run build` all pass; `lim xcode build --help` renders the new flags.

## Notes

- `@limrun/api` is flipped to `file:../../dist` per the usual development flow; the release commit pins the published version once the API package ships.

Made with [Cursor](https://cursor.com)
