### PR TITLE
cli: install all skills for all agents by default in `lim skills install`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+Make sure to run "./scripts/lint" before pushing a commit.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -723,7 +723,7 @@ lim skills install --json
 | Flag                        | Description                                                                                                                                                         |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`. Defaults to agents with an existing skills directory, or all agents when none exists. |
-| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills, with Expo/Bazel skills included only when the folder scan finds matching clues.         |
+| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills, with Expo/Bazel/Detox skills included only when the folder scan finds matching clues.   |
 | `--scope <project\|global>` | `project` (default) writes into the current directory; `global` writes into the user's home directory.                                                              |
 | `--keep-existing`           | Keep existing skill directories that differ from the fetched version instead of updating them.                                                                      |
 | `--json`                    | Emit structured JSON instead of the human summary.                                                                                                                  |
@@ -734,7 +734,7 @@ lim skills install --json
 - `limrun-xcode`: Build and launch iOS apps with remote Xcode.
 - `limrun-ios-simulator`: Control and test apps on Limrun iOS simulators.
 - `limrun-expo-development` (conditional): Iterate on Expo / React Native apps with remote iOS dev-client workflows.
-- `limrun-detox-testing`: Configure, run, and debug Detox against Limrun iOS simulators.
+- `limrun-detox-testing` (conditional): Configure, run, and debug Detox against Limrun iOS simulators.
 - `limrun-xcode-bazel` (conditional): Build Bazel-based iOS apps with remote Xcode.
 
 **Install paths:**
@@ -747,7 +747,7 @@ lim skills install --json
 
 **Behavior:**
 
-- Without flags, the command installs every skill for every agent. Two skills are conditional: `limrun-expo-development` is only included when the folder scan finds an `expo` dependency in a `package.json`, and `limrun-xcode-bazel` is only included when it finds Bazel workspace markers (`WORKSPACE`, `MODULE.bazel`, `.bazelrc`, ...). Pass `--skills` to override the scan.
+- Without flags, the command installs every skill for every agent. Three skills are conditional: `limrun-expo-development` is only included when the folder scan finds an `expo` dependency in a `package.json`, `limrun-xcode-bazel` when it finds Bazel workspace markers (`WORKSPACE`, `MODULE.bazel`, `.bazelrc`, ...), and `limrun-detox-testing` when it finds a `detox` dependency, a `detox` section in `package.json`, or a Detox config file (`.detoxrc*`, `detox.config.*`). Pass `--skills` to override the scan.
 - If an existing skills structure is found for the chosen scope (e.g. `.claude/skills/` or `.cursor/skills/` already exists), the install adopts it: skills are only installed for the agents that already have a skills directory, instead of creating directories for every agent. Pass `--agents` to override.
 - The command fetches `limrun-inc/skills@main` at runtime, so skill updates do not require a new `lim` release.
 - The command compares fetched vs existing skill directories byte-for-byte. Identical content is reported as `Unchanged` (no writes).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,7 +52,7 @@ The CLI stores configuration in `~/.lim/config.yaml`. This file is compatible wi
 lim run
 ```
 
-`lim run` is the fastest way to get started with Limrun. Run it inside a clear iOS or Expo project root to install the Limrun agent skills for that project and get the next prompt for your coding agent. Run it anywhere else to clone the native sample app, build it on Limrun, and print a cloud simulator URL.
+`lim run` is the fastest way to get started with Limrun. Run it inside a clear iOS or Expo project root to install the Limrun agent skills for that project and get the next prompt for your coding agent. Run it anywhere else to clone a sample app (Swift, Expo 56, or Bazel — picked interactively, Swift by default), build it on Limrun, and print a cloud simulator URL.
 
 ## Global Flags
 
@@ -124,7 +124,7 @@ lim run
 
 - In a clear native iOS project, it installs the Limrun iOS/Xcode skill into `.agents/skills/` and `.claude/skills/`.
 - In a clear Expo project, it installs the Limrun iOS/Xcode and Expo skills into `.agents/skills/` and `.claude/skills/`.
-- In any other directory, it clones `limrun-inc/sample-native-app`, builds it with a Limrun iOS simulator + Xcode sandbox, and prints a simulator URL.
+- In any other directory, it asks which sample project you want to run — Swift (`limrun-inc/sample-native-app`), Expo 56 (`limrun-inc/sample-expo56-app`), or Bazel (`limrun-inc/sample-bazel-native-app`) — clones it, builds it with a Limrun iOS simulator + Xcode sandbox, and prints a simulator URL. Non-interactive sessions default to the Swift sample.
 
 After setup, open your coding agent in the project and ask it to build and run the app with Limrun. For manual agent setup, use `lim skills install`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -703,39 +703,39 @@ Provide `--certificate-p12`, `--certificate-password`, and `--provisioning-profi
 Fetch the latest Limrun skills from `limrun-inc/skills@main` and install them into the native skills directory of AI coding agents (Claude Code, Cursor, Codex). After installation, the agent auto-discovers the skill and triggers it when you ask things like "build the iOS app" or "show me a screenshot."
 
 ```bash
-# Interactive: prompts for agents (with detected ones pre-checked) and scope
+# Install all skills for all agents (Expo/Bazel skills only when the folder scan finds matching clues)
 lim skills install
 
-# Non-interactive
-lim skills install --agents claude --scope project
-lim skills install --agents claude --agents cursor --scope project
+# Narrow the install with flags
+lim skills install --agents claude --agents cursor
 lim skills install --agents codex --scope global
-lim skills install --agents cursor --scope project --skills limrun-expo-development
+lim skills install --agents cursor --skills limrun-expo-development
 
 # Overwrite existing skill directories (otherwise the command refuses on non-interactive runs)
-lim skills install --agents claude --scope project --force
+lim skills install --agents claude --force
 
 # Machine-readable output for scripts
-lim skills install --agents claude --scope project --json
+lim skills install --json
 ```
 
 **Flags:**
 
-| Flag                        | Description                                                                                  |
-| --------------------------- | -------------------------------------------------------------------------------------------- |
-| `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`.                |
-| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to the remote catalog default.  |
-| `--scope <project\|global>` | `project` writes into the current directory; `global` writes into the user's home directory. |
-| `--force`                   | Overwrite existing skill directories without confirmation.                                   |
-| `--json`                    | Emit structured JSON instead of the human summary.                                           |
-| `--quiet`                   | Suppress non-result output.                                                                  |
+| Flag                        | Description                                                                                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`. Defaults to agents with an existing skills directory, or all agents when none exists. |
+| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills, with Expo/Bazel skills included only when the folder scan finds matching clues. |
+| `--scope <project\|global>` | `project` (default) writes into the current directory; `global` writes into the user's home directory.                                      |
+| `--force`                   | Overwrite existing skill directories without confirmation.                                                                                  |
+| `--json`                    | Emit structured JSON instead of the human summary.                                                                                          |
+| `--quiet`                   | Suppress non-result output.                                                                                                                 |
 
 **Available skills:**
 
-- `limrun-xcode` (default): Build and launch iOS apps with remote Xcode.
-- `limrun-ios-simulator` (default): Control and test apps on Limrun iOS simulators.
-- `limrun-expo-development`: Iterate on Expo / React Native apps with remote iOS dev-client workflows.
+- `limrun-xcode`: Build and launch iOS apps with remote Xcode.
+- `limrun-ios-simulator`: Control and test apps on Limrun iOS simulators.
+- `limrun-expo-development` (conditional): Iterate on Expo / React Native apps with remote iOS dev-client workflows.
 - `limrun-detox-testing`: Configure, run, and debug Detox against Limrun iOS simulators.
+- `limrun-xcode-bazel` (conditional): Build Bazel-based iOS apps with remote Xcode.
 
 **Install paths:**
 
@@ -747,13 +747,15 @@ lim skills install --agents claude --scope project --json
 
 **Behavior:**
 
+- Without flags, the command installs every skill for every agent. Two skills are conditional: `limrun-expo-development` is only included when the folder scan finds an `expo` dependency in a `package.json`, and `limrun-xcode-bazel` is only included when it finds Bazel workspace markers (`WORKSPACE`, `MODULE.bazel`, `.bazelrc`, ...). Pass `--skills` to override the scan.
+- If an existing skills structure is found for the chosen scope (e.g. `.claude/skills/` or `.cursor/skills/` already exists), the install adopts it: skills are only installed for the agents that already have a skills directory, instead of creating directories for every agent. Pass `--agents` to override.
 - The command fetches `limrun-inc/skills@main` at runtime, so skill updates do not require a new `lim` release.
 - The command compares fetched vs existing skill directories byte-for-byte. Identical content is reported as `Unchanged` (no writes).
 - Different content: in interactive mode you are asked to confirm each overwrite; in non-interactive mode the command refuses unless `--force` is passed.
 - Non-interactive runs are all-or-nothing: if any selected target conflicts and `--force` is not set, no files are written for any target, and the command exits with status 1.
 - Ctrl-C cancellation at any prompt exits cleanly without writing.
 
-Cursor reads `.agents/skills/` natively, so we install there rather than `.cursor/skills/`. As a bonus, the same install reaches OpenCode and any other tool that follows the AGENTS.md convention - no extra menu options needed.
+Cursor reads `.agents/skills/` natively, so we prefer installing there rather than `.cursor/skills/` (an existing `.cursor/skills/` directory is adopted instead of creating a second structure). As a bonus, the `.agents/skills/` install reaches OpenCode and any other tool that follows the AGENTS.md convention - no extra menu options needed.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -124,7 +124,7 @@ lim run
 
 - In a clear native iOS project, it installs the Limrun iOS/Xcode skill into `.agents/skills/` and `.claude/skills/`.
 - In a clear Expo project, it installs the Limrun iOS/Xcode and Expo skills into `.agents/skills/` and `.claude/skills/`.
-- In any other directory, it asks which sample project you want to run — Swift (`limrun-inc/sample-native-app`), Expo 56 (`limrun-inc/sample-expo56-app`), or Bazel (`limrun-inc/sample-bazel-native-app`) — clones it, builds it with a Limrun iOS simulator + Xcode sandbox, and prints a simulator URL. Non-interactive sessions default to the Swift sample.
+- In any other directory, it asks which sample project you want to run — Swift (`limrun-inc/sample-native-app`), Expo 56 (`limrun-inc/sample-expo56-app`), or Bazel (`limrun-inc/sample-native-bazel-app`) — clones it, builds it with a Limrun iOS simulator + Xcode sandbox, and prints a simulator URL. Non-interactive sessions default to the Swift sample.
 
 After setup, open your coding agent in the project and ask it to build and run the app with Limrun. For manual agent setup, use `lim skills install`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -720,14 +720,14 @@ lim skills install --json
 
 **Flags:**
 
-| Flag                        | Description                                                                                                                                 |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Flag                        | Description                                                                                                                                                         |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`. Defaults to agents with an existing skills directory, or all agents when none exists. |
-| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills, with Expo/Bazel skills included only when the folder scan finds matching clues. |
-| `--scope <project\|global>` | `project` (default) writes into the current directory; `global` writes into the user's home directory.                                      |
-| `--keep-existing`           | Keep existing skill directories that differ from the fetched version instead of updating them.                                              |
-| `--json`                    | Emit structured JSON instead of the human summary.                                                                                          |
-| `--quiet`                   | Suppress non-result output.                                                                                                                 |
+| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills, with Expo/Bazel skills included only when the folder scan finds matching clues.         |
+| `--scope <project\|global>` | `project` (default) writes into the current directory; `global` writes into the user's home directory.                                                              |
+| `--keep-existing`           | Keep existing skill directories that differ from the fetched version instead of updating them.                                                                      |
+| `--json`                    | Emit structured JSON instead of the human summary.                                                                                                                  |
+| `--quiet`                   | Suppress non-result output.                                                                                                                                         |
 
 **Available skills:**
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -711,8 +711,8 @@ lim skills install --agents claude --agents cursor
 lim skills install --agents codex --scope global
 lim skills install --agents cursor --skills limrun-expo-development
 
-# Overwrite existing skill directories (otherwise the command refuses on non-interactive runs)
-lim skills install --agents claude --force
+# Keep existing skill directories that differ instead of updating them
+lim skills install --keep-existing
 
 # Machine-readable output for scripts
 lim skills install --json
@@ -725,7 +725,7 @@ lim skills install --json
 | `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`. Defaults to agents with an existing skills directory, or all agents when none exists. |
 | `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills, with Expo/Bazel skills included only when the folder scan finds matching clues. |
 | `--scope <project\|global>` | `project` (default) writes into the current directory; `global` writes into the user's home directory.                                      |
-| `--force`                   | Overwrite existing skill directories without confirmation.                                                                                  |
+| `--keep-existing`           | Keep existing skill directories that differ from the fetched version instead of updating them.                                              |
 | `--json`                    | Emit structured JSON instead of the human summary.                                                                                          |
 | `--quiet`                   | Suppress non-result output.                                                                                                                 |
 
@@ -751,9 +751,7 @@ lim skills install --json
 - If an existing skills structure is found for the chosen scope (e.g. `.claude/skills/` or `.cursor/skills/` already exists), the install adopts it: skills are only installed for the agents that already have a skills directory, instead of creating directories for every agent. Pass `--agents` to override.
 - The command fetches `limrun-inc/skills@main` at runtime, so skill updates do not require a new `lim` release.
 - The command compares fetched vs existing skill directories byte-for-byte. Identical content is reported as `Unchanged` (no writes).
-- Different content: in interactive mode you are asked to confirm each overwrite; in non-interactive mode the command refuses unless `--force` is passed.
-- Non-interactive runs are all-or-nothing: if any selected target conflicts and `--force` is not set, no files are written for any target, and the command exits with status 1.
-- Ctrl-C cancellation at any prompt exits cleanly without writing.
+- Different content is updated in place by default and reported as `Updated`. The previous content stays reviewable in your VCS diff, so you can inspect the change or ask your agent to reconcile local edits. Pass `--keep-existing` to leave differing skill directories untouched (reported as `Skipped`).
 
 Cursor reads `.agents/skills/` natively, so we prefer installing there rather than `.cursor/skills/` (an existing `.cursor/skills/` directory is adopted instead of creating a second structure). As a bonus, the `.agents/skills/` install reaches OpenCode and any other tool that follows the AGENTS.md convention - no extra menu options needed.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -720,20 +720,20 @@ lim skills install --json
 
 **Flags:**
 
-| Flag                        | Description                                                                                                                                                         |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`. Defaults to agents with an existing skills directory, or all agents when none exists. |
-| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills, with Expo/Bazel/Detox skills included only when the folder scan finds matching clues.   |
-| `--scope <project\|global>` | `project` (default) writes into the current directory; `global` writes into the user's home directory.                                                              |
-| `--keep-existing`           | Keep existing skill directories that differ from the fetched version instead of updating them.                                                                      |
-| `--json`                    | Emit structured JSON instead of the human summary.                                                                                                                  |
-| `--quiet`                   | Suppress non-result output.                                                                                                                                         |
+| Flag                        | Description                                                                                                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--agents <id>`             | Target agent. Repeat to select multiple. One of: `claude`, `cursor`, `codex`. Defaults to agents with an existing skills directory, or all agents when none exists.  |
+| `--skills <name>`           | Limrun skill to install. Repeat to select multiple. Defaults to all skills; in project scope, Bazel/Detox skills are included only when the folder scan finds clues. |
+| `--scope <project\|global>` | `project` (default) writes into the current directory; `global` writes into the user's home directory.                                                               |
+| `--keep-existing`           | Keep existing skill directories that differ from the fetched version instead of updating them.                                                                       |
+| `--json`                    | Emit structured JSON instead of the human summary.                                                                                                                   |
+| `--quiet`                   | Suppress non-result output.                                                                                                                                          |
 
 **Available skills:**
 
 - `limrun-xcode`: Build and launch iOS apps with remote Xcode.
 - `limrun-ios-simulator`: Control and test apps on Limrun iOS simulators.
-- `limrun-expo-development` (conditional): Iterate on Expo / React Native apps with remote iOS dev-client workflows.
+- `limrun-expo-development`: Iterate on Expo / React Native apps with remote iOS dev-client workflows.
 - `limrun-detox-testing` (conditional): Configure, run, and debug Detox against Limrun iOS simulators.
 - `limrun-xcode-bazel` (conditional): Build Bazel-based iOS apps with remote Xcode.
 
@@ -747,7 +747,7 @@ lim skills install --json
 
 **Behavior:**
 
-- Without flags, the command installs every skill for every agent. Three skills are conditional: `limrun-expo-development` is only included when the folder scan finds an `expo` dependency in a `package.json`, `limrun-xcode-bazel` when it finds Bazel workspace markers (`WORKSPACE`, `MODULE.bazel`, `.bazelrc`, ...), and `limrun-detox-testing` when it finds a `detox` dependency, a `detox` section in `package.json`, or a Detox config file (`.detoxrc*`, `detox.config.*`). Pass `--skills` to override the scan.
+- Without flags, the command installs every skill for every agent. In project scope, two skills are conditional: `limrun-xcode-bazel` is only included when the folder scan finds Bazel workspace markers (`WORKSPACE`, `MODULE.bazel`, `.bazelrc`, ...), and `limrun-detox-testing` when it finds a `detox` dependency, a `detox` section in `package.json`, or a Detox config file (`.detoxrc*`, `detox.config.*`). Global installs are not tied to a project folder, so they skip the scan and install every skill. Pass `--skills` to override.
 - If an existing skills structure is found for the chosen scope (e.g. `.claude/skills/` or `.cursor/skills/` already exists), the install adopts it: skills are only installed for the agents that already have a skills directory, instead of creating directories for every agent. Pass `--agents` to override.
 - The command fetches `limrun-inc/skills@main` at runtime, so skill updates do not require a new `lim` release.
 - The command compares fetched vs existing skill directories byte-for-byte. Identical content is reported as `Unchanged` (no writes).

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -7,10 +7,13 @@ import { readConfig, registerCreatedInstance } from '../lib/config';
 import { detectProject, type ProjectDetection } from '../lib/project-detection';
 import {
   applyProjectEnvApiKey,
+  DEFAULT_SAMPLE_KIND,
   ensureLoggedIn,
   ensureProjectEnvApiKey,
   ensureSampleRepo,
   installProjectSkills,
+  SAMPLE_APPS,
+  type SampleKind,
   type SkillInstallResult,
 } from '../lib/onboarding';
 
@@ -174,10 +177,37 @@ export default class Run extends BaseCommand {
     await check();
   }
 
+  private async promptSampleKind(): Promise<SampleKind> {
+    if (this.shouldSuppressInfo() || !process.stdin.isTTY || !process.stderr.isTTY) {
+      return DEFAULT_SAMPLE_KIND;
+    }
+    const response = await prompts(
+      {
+        type: 'select',
+        name: 'kind',
+        message: 'Which sample project do you want to run?',
+        choices: Object.values(SAMPLE_APPS).map((sample) => ({
+          title: sample.displayName,
+          value: sample.kind,
+        })),
+        initial: 0,
+      },
+      {
+        onCancel: () => {
+          this.error('Cancelled.');
+        },
+      },
+    );
+    return response.kind as SampleKind;
+  }
+
   private async runSampleFlow(apiKey: string, allowAuthRetry: boolean): Promise<void> {
     const cwd = process.cwd();
+    const sampleApp = SAMPLE_APPS[await this.promptSampleKind()];
     await this.reporter.withProgress('Checking Limrun access', () => this.validateAuth(allowAuthRetry));
-    const sample = await this.reporter.withProgress('Setting up sample app', () => ensureSampleRepo({ cwd }));
+    const sample = await this.reporter.withProgress('Setting up sample app', () =>
+      ensureSampleRepo({ cwd, sample: sampleApp }),
+    );
     const samplePathFromStart = humanPath(sample.path, cwd);
     this.reporter.success(`${sample.reused ? 'Using existing' : 'Cloned'} ${samplePathFromStart}`);
     process.chdir(sample.path);
@@ -189,9 +219,9 @@ export default class Run extends BaseCommand {
       displayName: 'lim-run-sample',
       labels: {
         name: 'lim-go-sample',
-        repo: 'sample-native-app',
+        repo: sampleApp.dir,
       },
-      progressLabel: buildProgressLabel('native-ios'),
+      progressLabel: buildProgressLabel(sampleApp.kind === 'expo56' ? 'expo' : 'native-ios'),
       failureLabel: 'Sample build failed',
       recoveryPath: sample.path,
       recoveryFromDir: cwd,

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -140,20 +140,20 @@ export default class Run extends BaseCommand {
   private printSkillSummary(results: SkillInstallResult[]): void {
     const installed = results.filter((result) => result.status === 'installed').length;
     const unchanged = results.filter((result) => result.status === 'unchanged').length;
-    const skipped = results.filter((result) => result.status === 'skipped');
-    if (installed > 0) {
+    const updated = results.filter((result) => result.status === 'updated');
+    if (installed > 0 || updated.length > 0) {
       this.reporter.success('Limrun skills installed for Claude Code and Cursor/OpenCode-compatible agents');
-    } else if (unchanged > 0 && skipped.length === 0) {
+    } else if (unchanged > 0) {
       this.reporter.success(
         'Limrun skills are already installed for Claude Code and Cursor/OpenCode-compatible agents',
       );
     }
-    if (skipped.length > 0) {
-      this.info('Skipped skill directories with local changes:');
-      for (const result of skipped) {
+    if (updated.length > 0) {
+      this.info('Updated skill directories that had local changes:');
+      for (const result of updated) {
         this.info(`  ${humanPath(result.path)}`);
       }
-      this.info('Run `lim skills install` interactively, or rerun it with `--force`, to update them.');
+      this.info('Review the diff in version control and ask your agent to reconcile if needed.');
     }
   }
 

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -80,7 +80,7 @@ function statusLabel(status: Status): string {
 export default class SkillsInstall extends Command {
   static summary = 'Install Limrun skills for AI coding agents';
   static description =
-    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each agent (Claude Code, Cursor, Codex). By default all skills are installed for all agents; Expo and Bazel skills are only included when the folder scan finds matching clues, and an existing skills structure (e.g. .claude/skills/) is adopted instead of creating directories for every agent. Existing skill directories with different content are updated in place; review the change in your VCS diff, or pass --keep-existing to leave them untouched.';
+    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each agent (Claude Code, Cursor, Codex). By default all skills are installed for all agents; Expo, Bazel, and Detox skills are only included when the folder scan finds matching clues, and an existing skills structure (e.g. .claude/skills/) is adopted instead of creating directories for every agent. Existing skill directories with different content are updated in place; review the change in your VCS diff, or pass --keep-existing to leave them untouched.';
   static examples = [
     '<%= config.bin %> skills install',
     '<%= config.bin %> skills install --agents claude --agents cursor',
@@ -97,7 +97,7 @@ export default class SkillsInstall extends Command {
     }),
     skills: Flags.string({
       description:
-        'Limrun skill to install. Repeat to pick multiple. Defaults to all skills, with Expo/Bazel skills included only when the folder scan finds matching clues.',
+        'Limrun skill to install. Repeat to pick multiple. Defaults to all skills, with Expo/Bazel/Detox skills included only when the folder scan finds matching clues.',
       multiple: true,
     }),
     scope: Flags.string({
@@ -273,20 +273,32 @@ export default class SkillsInstall extends Command {
       return;
     }
 
-    // Human summary.
+    // Human summary: one line per skill, with all target folders combined.
     this.log('');
     this.log('  Limrun skills');
-    const skillColWidth = Math.max(...results.map((r) => r.skill.length), 'Skill'.length);
-    const agentColWidth = Math.max(
-      ...results.map((r) => AGENTS[r.agent].displayName.length),
-      'Claude Code'.length,
-    );
+    const bySkill = new Map<SkillName, ResultRow[]>();
     for (const r of results) {
-      const skillLabel = r.skill.padEnd(skillColWidth);
-      const agentLabel = AGENTS[r.agent].displayName.padEnd(agentColWidth);
-      const displayPath = humanPath(r.path, r.scope);
-      const reason = r.reason ? `  (${r.reason})` : '';
-      this.log(`    ${skillLabel}  ${agentLabel}  ->  ${displayPath}    ${statusLabel(r.status)}${reason}`);
+      const rows = bySkill.get(r.skill);
+      if (rows) {
+        rows.push(r);
+      } else {
+        bySkill.set(r.skill, [r]);
+      }
+    }
+    const skillColWidth = Math.max(...results.map((r) => r.skill.length), 'Skill'.length);
+    for (const [skill, rows] of bySkill) {
+      const skillLabel = skill.padEnd(skillColWidth);
+      // The skill name already leads the line, so list the parent skills
+      // directories instead of repeating <dir>/<skill> for every folder.
+      const folders = rows.map((r) => humanPath(path.dirname(r.path), r.scope));
+      const uniformStatus = rows.every((r) => r.status === rows[0]!.status) ? rows[0]!.status : undefined;
+      if (uniformStatus) {
+        const reason = rows[0]!.reason ? `  (${rows[0]!.reason})` : '';
+        this.log(`    ${skillLabel}  ->  ${folders.join(', ')}    ${statusLabel(uniformStatus)}${reason}`);
+      } else {
+        const annotated = rows.map((r, i) => `${folders[i]} (${statusLabel(r.status).toLowerCase()})`);
+        this.log(`    ${skillLabel}  ->  ${annotated.join(', ')}`);
+      }
     }
     this.log('');
   }

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -109,13 +109,6 @@ export default class SkillsInstall extends Command {
       description: 'Keep existing skill directories that differ from the fetched version instead of updating them.',
       default: false,
     }),
-    // Accepted for backwards compatibility; the flag key is only present when
-    // the user passes it, so the deprecation warning fires only then.
-    force: Flags.boolean({
-      description: 'Deprecated: updating existing skill directories is now the default.',
-      hidden: true,
-      deprecated: { message: 'Updating existing skill directories is now the default; --force has no effect.' },
-    }),
     json: Flags.boolean({
       description: 'Emit structured JSON output.',
       default: false,

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -80,7 +80,7 @@ function statusLabel(status: Status): string {
 export default class SkillsInstall extends Command {
   static summary = 'Install Limrun skills for AI coding agents';
   static description =
-    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each agent (Claude Code, Cursor, Codex). By default all skills are installed for all agents; Expo, Bazel, and Detox skills are only included when the folder scan finds matching clues, and an existing skills structure (e.g. .claude/skills/) is adopted instead of creating directories for every agent. Existing skill directories with different content are updated in place; review the change in your VCS diff, or pass --keep-existing to leave them untouched.';
+    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each agent (Claude Code, Cursor, Codex). By default all skills are installed for all agents; in project scope, Bazel and Detox skills are only included when the folder scan finds matching clues, while global installs include every skill. An existing skills structure (e.g. .claude/skills/) is adopted instead of creating directories for every agent. Existing skill directories with different content are updated in place; review the change in your VCS diff, or pass --keep-existing to leave them untouched.';
   static examples = [
     '<%= config.bin %> skills install',
     '<%= config.bin %> skills install --agents claude --agents cursor',
@@ -97,7 +97,7 @@ export default class SkillsInstall extends Command {
     }),
     skills: Flags.string({
       description:
-        'Limrun skill to install. Repeat to pick multiple. Defaults to all skills, with Expo/Bazel/Detox skills included only when the folder scan finds matching clues.',
+        'Limrun skill to install. Repeat to pick multiple. Defaults to all skills; in project scope, Bazel/Detox skills are included only when the folder scan finds matching clues.',
       multiple: true,
     }),
     scope: Flags.string({
@@ -143,6 +143,10 @@ export default class SkillsInstall extends Command {
 
       if (flags.skills && flags.skills.length > 0) {
         skills = uniqueSkillNames(flags.skills, availableSkills);
+      } else if (scope === 'global') {
+        // Global installs are not tied to a project folder, so the folder
+        // scan does not apply: install every skill.
+        skills = availableSkills.map((skill) => skill.name);
       } else {
         const hints = scanSkillHints(process.cwd());
         const selection = selectDefaultSkills(

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -106,7 +106,8 @@ export default class SkillsInstall extends Command {
       default: 'project',
     }),
     'keep-existing': Flags.boolean({
-      description: 'Keep existing skill directories that differ from the fetched version instead of updating them.',
+      description:
+        'Keep existing skill directories that differ from the fetched version instead of updating them.',
       default: false,
     }),
     json: Flags.boolean({

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import prompts from 'prompts';
 import { Command, Flags } from '@oclif/core';
 import {
   AGENTS,
@@ -18,9 +17,7 @@ import { scanSkillHints } from '../../lib/project-detection';
 import { loadRemoteSkills, type LoadedRemoteSkills, type RemoteSkill } from '../../lib/remote-skills';
 
 type SkillName = string;
-const SKIPPED_REASON_CONFLICT = 'existing skill directory differs; re-run with --force to overwrite';
-const SKIPPED_REASON_BLOCKED = 'blocked: another target requires --force to proceed';
-const SKIPPED_REASON_DECLINED = 'user declined overwrite confirmation';
+const SKIPPED_REASON_KEPT = 'existing skill directory differs; kept because --keep-existing was passed';
 
 type Status = 'installed' | 'updated' | 'unchanged' | 'skipped';
 
@@ -56,30 +53,6 @@ function uniqueSkillNames(values: string[], availableSkills: RemoteSkill[]): Ski
   return skills;
 }
 
-class PromptCancelled extends Error {
-  constructor() {
-    super('cancelled');
-    this.name = 'PromptCancelled';
-  }
-}
-
-async function promptOverwrite(targetPath: string): Promise<boolean> {
-  const response = await prompts(
-    {
-      type: 'confirm',
-      name: 'ok',
-      message: `Overwrite existing ${targetPath}?`,
-      initial: false,
-    },
-    {
-      onCancel: () => {
-        throw new PromptCancelled();
-      },
-    },
-  );
-  return Boolean(response.ok);
-}
-
 function humanPath(absolutePath: string, scope: Scope): string {
   if (scope !== 'project') {
     return absolutePath;
@@ -107,12 +80,13 @@ function statusLabel(status: Status): string {
 export default class SkillsInstall extends Command {
   static summary = 'Install Limrun skills for AI coding agents';
   static description =
-    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each agent (Claude Code, Cursor, Codex). By default all skills are installed for all agents; Expo and Bazel skills are only included when the folder scan finds matching clues, and an existing skills structure (e.g. .claude/skills/) is adopted instead of creating directories for every agent.';
+    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each agent (Claude Code, Cursor, Codex). By default all skills are installed for all agents; Expo and Bazel skills are only included when the folder scan finds matching clues, and an existing skills structure (e.g. .claude/skills/) is adopted instead of creating directories for every agent. Existing skill directories with different content are updated in place; review the change in your VCS diff, or pass --keep-existing to leave them untouched.';
   static examples = [
     '<%= config.bin %> skills install',
     '<%= config.bin %> skills install --agents claude --agents cursor',
     '<%= config.bin %> skills install --agents cursor --skills limrun-xcode --skills limrun-ios-simulator',
-    '<%= config.bin %> skills install --agents codex --scope global --force',
+    '<%= config.bin %> skills install --keep-existing',
+    '<%= config.bin %> skills install --agents codex --scope global',
   ];
   static flags = {
     agents: Flags.string({
@@ -131,9 +105,16 @@ export default class SkillsInstall extends Command {
       options: ['project', 'global'],
       default: 'project',
     }),
-    force: Flags.boolean({
-      description: 'Overwrite existing skill directories without confirmation.',
+    'keep-existing': Flags.boolean({
+      description: 'Keep existing skill directories that differ from the fetched version instead of updating them.',
       default: false,
+    }),
+    // Accepted for backwards compatibility; the flag key is only present when
+    // the user passes it, so the deprecation warning fires only then.
+    force: Flags.boolean({
+      description: 'Deprecated: updating existing skill directories is now the default.',
+      hidden: true,
+      deprecated: { message: 'Updating existing skill directories is now the default; --force has no effect.' },
     }),
     json: Flags.boolean({
       description: 'Emit structured JSON output.',
@@ -146,20 +127,8 @@ export default class SkillsInstall extends Command {
   };
 
   async run(): Promise<void> {
-    try {
-      await this.runInner();
-    } catch (err) {
-      if (err instanceof PromptCancelled) {
-        this.exit(130);
-      }
-      throw err;
-    }
-  }
-
-  private async runInner(): Promise<void> {
     const { flags } = await this.parse(SkillsInstall);
 
-    const interactive = process.stdin.isTTY === true && !flags.json && !flags.quiet;
     const verbose = !flags.json && !flags.quiet;
     const scope = flags.scope as Scope;
 
@@ -240,70 +209,39 @@ export default class SkillsInstall extends Command {
         }
       }
 
-      // Phase 2: Confirm.
+      // Phase 2: Apply. Differing targets are updated in place by default so
+      // installs always converge on the latest fetched skills; the previous
+      // content stays reviewable in the user's VCS diff. --keep-existing opts
+      // out and leaves differing directories untouched.
       const results: ResultRow[] = [];
-      const anyConflict = planned.some((t) => t.kind === 'conflict');
-
-      if (anyConflict && !flags.force && !interactive) {
-        // Non-interactive + conflict + no force: all-or-nothing. Skip all targets.
-        for (const t of planned) {
-          results.push({
-            skill: t.skill,
-            agent: t.agent.id,
-            scope: t.scope,
-            path: t.target,
-            status: 'skipped',
-            reason: t.kind === 'conflict' ? SKIPPED_REASON_CONFLICT : SKIPPED_REASON_BLOCKED,
-          });
-        }
-        if (!flags.json) {
-          // --quiet still suppresses the human summary, but a hard refusal needs to be visible.
-          process.stderr.write(
-            'Existing skill directories would be overwritten. Re-run with --force, or run interactively to confirm per target.\n',
-          );
-        }
-        this.emitOutput(results, flags, skills, source);
-        this.exit(1);
-      }
-
-      // Decide final status per target (no writes yet).
-      const finalDecisions: Array<{ target: PlannedTarget; status: Status; reason?: string }> = [];
+      let anyUpdated = false;
       for (const t of planned) {
-        if (t.kind === 'install') {
-          finalDecisions.push({ target: t, status: 'installed' });
-        } else if (t.kind === 'unchanged') {
-          finalDecisions.push({ target: t, status: 'unchanged' });
-        } else if (flags.force) {
-          finalDecisions.push({ target: t, status: 'updated' });
+        let status: Status;
+        let reason: string | undefined;
+        if (t.kind === 'unchanged') {
+          status = 'unchanged';
+        } else if (t.kind === 'conflict' && flags['keep-existing']) {
+          status = 'skipped';
+          reason = SKIPPED_REASON_KEPT;
         } else {
-          // Interactive conflict without --force: prompt per target.
-          const displayPath = humanPath(t.target, t.scope);
-          const ok = await promptOverwrite(displayPath);
-          if (ok) {
-            finalDecisions.push({ target: t, status: 'updated' });
-          } else {
-            finalDecisions.push({
-              target: t,
-              status: 'skipped',
-              reason: SKIPPED_REASON_DECLINED,
-            });
-          }
-        }
-      }
-
-      // Phase 3: Apply.
-      for (const decision of finalDecisions) {
-        if (decision.status === 'installed' || decision.status === 'updated') {
-          applySkillDirectoryCopy(decision.target.source, decision.target.target);
+          applySkillDirectoryCopy(t.source, t.target);
+          status = t.kind === 'conflict' ? 'updated' : 'installed';
+          anyUpdated = anyUpdated || status === 'updated';
         }
         results.push({
-          skill: decision.target.skill,
-          agent: decision.target.agent.id,
-          scope: decision.target.scope,
-          path: decision.target.target,
-          status: decision.status,
-          ...(decision.reason ? { reason: decision.reason } : {}),
+          skill: t.skill,
+          agent: t.agent.id,
+          scope: t.scope,
+          path: t.target,
+          status,
+          ...(reason ? { reason } : {}),
         });
+      }
+
+      if (verbose && anyUpdated) {
+        process.stderr.write(
+          'Updated skill directories that had local changes. Review the diff in version control and ask your agent to reconcile if needed, or re-run with --keep-existing to leave them untouched.\n',
+        );
       }
 
       this.emitOutput(results, flags, skills, source);

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -5,6 +5,8 @@ import { Command, Flags } from '@oclif/core';
 import {
   AGENTS,
   AGENT_IDS,
+  detectAdoptedAgents,
+  selectDefaultSkills,
   type AgentId,
   type AgentSpec,
   type Scope,
@@ -12,6 +14,7 @@ import {
   planSkillDirectoryCopy,
   applySkillDirectoryCopy,
 } from '../../lib/skills';
+import { scanSkillHints } from '../../lib/project-detection';
 import { loadRemoteSkills, type LoadedRemoteSkills, type RemoteSkill } from '../../lib/remote-skills';
 
 type SkillName = string;
@@ -53,208 +56,11 @@ function uniqueSkillNames(values: string[], availableSkills: RemoteSkill[]): Ski
   return skills;
 }
 
-function createPromptCursorTracker(itemCount: number): {
-  current(): number;
-  onKeypress(_str: string, key: { name?: string; ctrl?: boolean; meta?: boolean }): void;
-} {
-  let cursor = 0;
-  return {
-    current: () => cursor,
-    onKeypress: (_str, key) => {
-      if (!key || !key.name || itemCount === 0) return;
-      if (key.meta && key.name !== 'escape') return;
-      const last = itemCount - 1;
-      if (key.ctrl) {
-        if (key.name === 'a') cursor = 0;
-        else if (key.name === 'e') cursor = last;
-        return;
-      }
-      if (key.name === 'up' || key.name === 'k') {
-        cursor = cursor === 0 ? last : cursor - 1;
-      } else if (key.name === 'down' || key.name === 'j' || key.name === 'tab') {
-        cursor = cursor === last ? 0 : cursor + 1;
-      }
-    },
-  };
-}
-
-function wrapDescription(value: string, width: number, indentSize = 2): string {
-  const indent = ' '.repeat(indentSize);
-  const words = value.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
-  const lines: string[] = [];
-  let line = indent;
-  for (const word of words) {
-    if (line === indent) {
-      line += word;
-    } else if (line.length + 1 + word.length <= width) {
-      line += ` ${word}`;
-    } else {
-      lines.push(line);
-      line = `${indent}${word}`;
-    }
-  }
-  if (line !== indent) {
-    lines.push(line);
-  }
-  return lines.join('\n');
-}
-
-function installCompactMultiselectDescriptionRenderer(): () => void {
-  // prompts only exposes description text through its default renderer, whose
-  // wrap indent is too deep for long skill descriptions. Patch just this prompt
-  // and restore immediately after it completes.
-  const MultiselectPrompt = require('prompts/lib/elements/multiselect');
-  const color = require('kleur');
-  const { figures } = require('prompts/lib/util');
-  const originalRenderOption = MultiselectPrompt.prototype.renderOption;
-
-  MultiselectPrompt.prototype.renderOption = function renderOption(
-    this: { out: { columns?: number } },
-    cursor: number,
-    choice: { disabled?: boolean; selected?: boolean; title: string; description?: string },
-    index: number,
-    arrowIndicator: string,
-  ): string {
-    const prefix =
-      (choice.selected ? color.green(figures.radioOn) : figures.radioOff) + ' ' + arrowIndicator + ' ';
-    let title: string;
-
-    if (choice.disabled) {
-      title =
-        cursor === index ? color.gray().underline(choice.title) : color.strikethrough().gray(choice.title);
-    } else {
-      title = cursor === index ? color.cyan().underline(choice.title) : choice.title;
-    }
-
-    const description =
-      !choice.disabled && cursor === index && choice.description ?
-        `\n${wrapDescription(choice.description, this.out.columns ?? 100, 4)}`
-      : '';
-    return prefix + title + color.gray(description);
-  };
-
-  return () => {
-    MultiselectPrompt.prototype.renderOption = originalRenderOption;
-  };
-}
-
 class PromptCancelled extends Error {
   constructor() {
     super('cancelled');
     this.name = 'PromptCancelled';
   }
-}
-
-function detectAgentsForScope(scope: Scope): Set<AgentId> {
-  const detected = new Set<AgentId>();
-  for (const id of AGENT_IDS) {
-    const agent = AGENTS[id];
-    for (const p of agent.detectionPaths(scope)) {
-      if (fs.existsSync(p)) {
-        detected.add(id);
-        break;
-      }
-    }
-  }
-  return detected;
-}
-
-async function promptAgents(preselected: Set<AgentId>): Promise<AgentId[]> {
-  const cursor = createPromptCursorTracker(AGENT_IDS.length);
-  process.stdin.on('keypress', cursor.onKeypress);
-  let response;
-  try {
-    response = await prompts(
-      {
-        type: 'multiselect',
-        name: 'agents',
-        message: 'Which agents do you want to set up?',
-        instructions: false,
-        choices: AGENT_IDS.map((id) => ({
-          title: AGENTS[id].displayName,
-          value: id,
-          selected: preselected.has(id),
-        })),
-        hint: 'Space to toggle, Enter to confirm (Enter alone picks the highlighted agent)',
-      },
-      {
-        onCancel: () => {
-          throw new PromptCancelled();
-        },
-      },
-    );
-  } finally {
-    process.stdin.off('keypress', cursor.onKeypress);
-  }
-
-  let picked = (response.agents ?? []) as AgentId[];
-  const highlightedAgent = AGENT_IDS[cursor.current()];
-  if (picked.length === 0 && highlightedAgent) {
-    picked = [highlightedAgent];
-  }
-  process.stderr.write(`  Selected: ${picked.map((id) => AGENTS[id].displayName).join(', ')}\n`);
-  return picked;
-}
-
-async function promptSkills(availableSkills: RemoteSkill[]): Promise<SkillName[]> {
-  const cursor = createPromptCursorTracker(availableSkills.length);
-  let response;
-  const restoreMultiselectRenderer = installCompactMultiselectDescriptionRenderer();
-  process.stdin.on('keypress', cursor.onKeypress);
-  try {
-    response = await prompts(
-      {
-        type: 'multiselect',
-        name: 'skills',
-        message: 'Which Limrun skills do you want to install?',
-        instructions: false,
-        choices: availableSkills.map((skill) => ({
-          title: skill.name,
-          description: skill.description.replace(/\s+/g, ' ').trim(),
-          value: skill.name,
-          selected: skill.defaultSelected,
-        })),
-        hint: 'Catalog defaults selected. Space toggles, Enter confirms.',
-      },
-      {
-        onCancel: () => {
-          throw new PromptCancelled();
-        },
-      },
-    );
-  } finally {
-    restoreMultiselectRenderer();
-    process.stdin.off('keypress', cursor.onKeypress);
-  }
-
-  let picked = uniqueSkillNames((response.skills ?? []) as string[], availableSkills);
-  const highlightedSkill = availableSkills[cursor.current()];
-  if (picked.length === 0 && highlightedSkill) {
-    picked = [highlightedSkill.name];
-  }
-  process.stderr.write(`  Selected skills: ${picked.join(', ')}\n`);
-  return picked;
-}
-
-async function promptScope(): Promise<Scope> {
-  const response = await prompts(
-    {
-      type: 'select',
-      name: 'scope',
-      message: 'Install location?',
-      choices: [
-        { title: 'Project', value: 'project', description: 'Install into the current directory' },
-        { title: 'Global', value: 'global', description: 'Install into your home directory' },
-      ],
-      initial: 0,
-    },
-    {
-      onCancel: () => {
-        throw new PromptCancelled();
-      },
-    },
-  );
-  return response.scope as Scope;
 }
 
 async function promptOverwrite(targetPath: string): Promise<boolean> {
@@ -301,27 +107,29 @@ function statusLabel(status: Status): string {
 export default class SkillsInstall extends Command {
   static summary = 'Install Limrun skills for AI coding agents';
   static description =
-    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each selected agent (Claude Code, Cursor, Codex). Pre-checks detected agents and lets you pick project or global scope.';
+    'Fetch the latest Limrun skills from limrun-inc/skills and install them into the native skills directory for each agent (Claude Code, Cursor, Codex). By default all skills are installed for all agents; Expo and Bazel skills are only included when the folder scan finds matching clues, and an existing skills structure (e.g. .claude/skills/) is adopted instead of creating directories for every agent.';
   static examples = [
     '<%= config.bin %> skills install',
-    '<%= config.bin %> skills install --agents claude --agents cursor --scope project',
-    '<%= config.bin %> skills install --agents cursor --scope project --skills limrun-xcode --skills limrun-ios-simulator',
+    '<%= config.bin %> skills install --agents claude --agents cursor',
+    '<%= config.bin %> skills install --agents cursor --skills limrun-xcode --skills limrun-ios-simulator',
     '<%= config.bin %> skills install --agents codex --scope global --force',
   ];
   static flags = {
     agents: Flags.string({
-      description: 'Target agent. Repeat to pick multiple.',
+      description:
+        'Target agent. Repeat to pick multiple. Defaults to agents with an existing skills directory, or all agents when none exists.',
       multiple: true,
       options: AGENT_IDS,
     }),
     skills: Flags.string({
       description:
-        'Limrun skill to install. Repeat to pick multiple. Defaults to the remote catalog default.',
+        'Limrun skill to install. Repeat to pick multiple. Defaults to all skills, with Expo/Bazel skills included only when the folder scan finds matching clues.',
       multiple: true,
     }),
     scope: Flags.string({
       description: 'Install scope.',
       options: ['project', 'global'],
+      default: 'project',
     }),
     force: Flags.boolean({
       description: 'Overwrite existing skill directories without confirmation.',
@@ -352,23 +160,14 @@ export default class SkillsInstall extends Command {
     const { flags } = await this.parse(SkillsInstall);
 
     const interactive = process.stdin.isTTY === true && !flags.json && !flags.quiet;
+    const verbose = !flags.json && !flags.quiet;
+    const scope = flags.scope as Scope;
 
-    let agents: AgentId[];
     let skills: SkillName[] = [];
-    let scope: Scope;
     let source: LoadedRemoteSkills | undefined;
 
     try {
-      if (!interactive) {
-        if (!flags.agents || flags.agents.length === 0) {
-          this.error(`--agents requires at least one of: ${AGENT_IDS.join(', ')}.`, { exit: 2 });
-        }
-        if (!flags.scope) {
-          this.error('Specify --agents and --scope in non-interactive mode.', { exit: 2 });
-        }
-      }
-
-      if (interactive) {
+      if (verbose) {
         process.stderr.write('Fetching latest Limrun skills...\n');
       }
       source = await loadRemoteSkills();
@@ -381,35 +180,43 @@ export default class SkillsInstall extends Command {
 
       if (flags.skills && flags.skills.length > 0) {
         skills = uniqueSkillNames(flags.skills, availableSkills);
-      } else if (interactive) {
-        skills = await promptSkills(availableSkills);
       } else {
-        skills = availableSkills.filter((skill) => skill.defaultSelected).map((skill) => skill.name);
+        const hints = scanSkillHints(process.cwd());
+        const selection = selectDefaultSkills(
+          availableSkills.map((skill) => skill.name),
+          hints,
+        );
+        skills = selection.selected;
+        if (verbose) {
+          for (const excluded of selection.excluded) {
+            process.stderr.write(`Skipping ${excluded.name}: ${excluded.reason}.\n`);
+          }
+        }
       }
 
       if (skills.length === 0) {
-        this.error(`No default Limrun skills found in ${source.owner}/${source.repo}@${source.commit}.`, {
+        this.error(`No Limrun skills found in ${source.owner}/${source.repo}@${source.commit}.`, {
           exit: 1,
         });
       }
 
+      let agents: AgentId[];
       if (flags.agents && flags.agents.length > 0) {
         agents = Array.from(new Set(flags.agents)) as AgentId[];
-      } else if (interactive) {
-        // Pre-check based on project-local presence only. Global installs of
-        // agents (e.g. ~/.claude on a dev machine) are too weak a signal to
-        // auto-select them for this specific project's install.
-        agents = await promptAgents(detectAgentsForScope('project'));
       } else {
-        this.error(`--agents requires at least one of: ${AGENT_IDS.join(', ')}.`, { exit: 2 });
-      }
-
-      if (flags.scope) {
-        scope = flags.scope as Scope;
-      } else if (interactive) {
-        scope = await promptScope();
-      } else {
-        this.error('Specify --agents and --scope in non-interactive mode.', { exit: 2 });
+        const adopted = detectAdoptedAgents(scope);
+        if (adopted.length > 0) {
+          agents = adopted;
+          if (verbose) {
+            process.stderr.write(
+              `Found existing skills structure for ${adopted
+                .map((id) => AGENTS[id].displayName)
+                .join(', ')}; installing only there.\n`,
+            );
+          }
+        } else {
+          agents = [...AGENT_IDS];
+        }
       }
 
       const sources = new Map<SkillName, string>();

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -23,7 +23,7 @@ export const SAMPLE_NATIVE_APP_DIR = 'sample-native-app';
 const SAMPLE_CLONE_TIMEOUT_MS = 300_000;
 
 type OnboardingAgent = Extract<AgentId, 'claude' | 'cursor'>;
-type SkillStatus = 'installed' | 'unchanged' | 'skipped';
+type SkillStatus = 'installed' | 'updated' | 'unchanged';
 const ONBOARDING_AGENTS: OnboardingAgent[] = ['cursor', 'claude'];
 const PROJECT_ENV_FILES = ['.env', '.env.local'];
 
@@ -292,11 +292,10 @@ function applySkillDecision(kind: PlanKind, sourceDir: string, targetDir: string
   if (kind === 'unchanged') {
     return 'unchanged';
   }
-  if (kind === 'conflict') {
-    return 'skipped';
-  }
+  // Differing directories are updated in place; the previous content stays
+  // reviewable in the user's VCS diff.
   applySkillDirectoryCopy(sourceDir, targetDir);
-  return 'installed';
+  return kind === 'conflict' ? 'updated' : 'installed';
 }
 
 function normalizeGitRemote(remote: string): string {

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -42,8 +42,8 @@ export const SAMPLE_APPS: Record<SampleKind, SampleApp> = {
   bazel: {
     kind: 'bazel',
     displayName: 'Bazel (native iOS)',
-    repo: 'https://github.com/limrun-inc/sample-bazel-native-app',
-    dir: 'sample-bazel-native-app',
+    repo: 'https://github.com/limrun-inc/sample-native-bazel-app',
+    dir: 'sample-native-bazel-app',
   },
 };
 

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -17,8 +17,37 @@ import { loadRemoteSkills, type LoadedRemoteSkills } from './remote-skills';
 
 const execFileAsync = promisify(execFile);
 
-export const SAMPLE_NATIVE_APP_REPO = 'https://github.com/limrun-inc/sample-native-app';
-export const SAMPLE_NATIVE_APP_DIR = 'sample-native-app';
+export type SampleKind = 'swift' | 'expo56' | 'bazel';
+
+export interface SampleApp {
+  kind: SampleKind;
+  displayName: string;
+  repo: string;
+  dir: string;
+}
+
+export const SAMPLE_APPS: Record<SampleKind, SampleApp> = {
+  swift: {
+    kind: 'swift',
+    displayName: 'Swift (native iOS)',
+    repo: 'https://github.com/limrun-inc/sample-native-app',
+    dir: 'sample-native-app',
+  },
+  expo56: {
+    kind: 'expo56',
+    displayName: 'Expo 56 (React Native)',
+    repo: 'https://github.com/limrun-inc/sample-expo56-app',
+    dir: 'sample-expo56-app',
+  },
+  bazel: {
+    kind: 'bazel',
+    displayName: 'Bazel (native iOS)',
+    repo: 'https://github.com/limrun-inc/sample-bazel-native-app',
+    dir: 'sample-bazel-native-app',
+  },
+};
+
+export const DEFAULT_SAMPLE_KIND: SampleKind = 'swift';
 
 const SAMPLE_CLONE_TIMEOUT_MS = 300_000;
 
@@ -50,6 +79,7 @@ type GitRunner = (args: string[], cwd?: string) => Promise<string>;
 
 interface SampleRepoOptions {
   cwd: string;
+  sample?: SampleApp;
   git?: GitRunner;
 }
 
@@ -312,8 +342,8 @@ function normalizeGitRemote(remote: string): string {
   return value.toLowerCase();
 }
 
-function isExpectedSampleRemote(remote: string): boolean {
-  return normalizeGitRemote(remote) === normalizeGitRemote(SAMPLE_NATIVE_APP_REPO);
+function isExpectedSampleRemote(remote: string, expectedRepo: string): boolean {
+  return normalizeGitRemote(remote) === normalizeGitRemote(expectedRepo);
 }
 
 async function runGit(args: string[], cwd?: string): Promise<string> {
@@ -336,17 +366,17 @@ async function runGit(args: string[], cwd?: string): Promise<string> {
   }
 }
 
-async function verifySampleRemote(sampleDir: string, git: GitRunner): Promise<void> {
+async function verifySampleRemote(sampleDir: string, git: GitRunner, expectedRepo: string): Promise<void> {
   let remote: string;
   try {
     remote = await git(['remote', 'get-url', 'origin'], sampleDir);
   } catch (err) {
     if (err instanceof OnboardingError) throw err;
     throw new OnboardingError(
-      `${sampleDir} already exists but is not a git checkout of ${SAMPLE_NATIVE_APP_REPO}. Move or delete it, then rerun \`lim run\`.`,
+      `${sampleDir} already exists but is not a git checkout of ${expectedRepo}. Move or delete it, then rerun \`lim run\`.`,
     );
   }
-  if (!isExpectedSampleRemote(remote)) {
+  if (!isExpectedSampleRemote(remote, expectedRepo)) {
     throw new OnboardingError(
       `${sampleDir} already exists with origin ${remote}. Move or delete it, then rerun \`lim run\`.`,
     );
@@ -355,20 +385,21 @@ async function verifySampleRemote(sampleDir: string, git: GitRunner): Promise<vo
 
 export async function ensureSampleRepo({
   cwd,
+  sample = SAMPLE_APPS[DEFAULT_SAMPLE_KIND],
   git = runGit,
 }: SampleRepoOptions): Promise<{ path: string; reused: boolean }> {
-  const sampleDir = path.join(cwd, SAMPLE_NATIVE_APP_DIR);
+  const sampleDir = path.join(cwd, sample.dir);
   if (fs.existsSync(sampleDir)) {
     if (!fs.lstatSync(sampleDir).isDirectory()) {
       throw new OnboardingError(
         `${sampleDir} already exists and is not a directory. Move or delete it, then rerun \`lim run\`.`,
       );
     }
-    await verifySampleRemote(sampleDir, git);
+    await verifySampleRemote(sampleDir, git, sample.repo);
     return { path: sampleDir, reused: true };
   }
 
-  await git(['clone', '--depth', '1', SAMPLE_NATIVE_APP_REPO, SAMPLE_NATIVE_APP_DIR], cwd);
+  await git(['clone', '--depth', '1', sample.repo, sample.dir], cwd);
   return { path: sampleDir, reused: false };
 }
 

--- a/packages/cli/src/lib/project-detection.ts
+++ b/packages/cli/src/lib/project-detection.ts
@@ -77,17 +77,29 @@ function isPlainFile(filePath: string): boolean {
   }
 }
 
-function hasExpoDependency(packageJsonPath: string): boolean {
-  if (!isPlainFile(packageJsonPath)) return false;
+interface ParsedPackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+function readPackageJson(packageJsonPath: string): ParsedPackageJson | undefined {
+  if (!isPlainFile(packageJsonPath)) return undefined;
   try {
-    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    return Boolean(parsed.dependencies?.['expo'] || parsed.devDependencies?.['expo']);
+    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return parsed as ParsedPackageJson;
   } catch {
-    return false;
+    return undefined;
   }
+}
+
+function hasDependency(packageJson: ParsedPackageJson | undefined, name: string): boolean {
+  return Boolean(packageJson?.dependencies?.[name] || packageJson?.devDependencies?.[name]);
+}
+
+function hasExpoDependency(packageJsonPath: string): boolean {
+  return hasDependency(readPackageJson(packageJsonPath), 'expo');
 }
 
 function isExpoAppDir(dir: string): boolean {
@@ -110,15 +122,35 @@ function isBazelWorkspaceDir(dir: string): boolean {
   return BAZEL_MARKERS.some((marker) => isPlainFile(path.join(dir, marker)));
 }
 
+// Detox reads its config from a package.json dependency plus one of these
+// config locations (https://wix.github.io/Detox/docs/config/overview).
+const DETOX_CONFIG_FILES = [
+  '.detoxrc',
+  '.detoxrc.js',
+  '.detoxrc.json',
+  '.detoxrc.cjs',
+  'detox.config.js',
+  'detox.config.json',
+  'detox.config.cjs',
+  'detox.config.ts',
+];
+
+function isDetoxDir(dir: string): boolean {
+  const packageJson = readPackageJson(path.join(dir, 'package.json'));
+  if (hasDependency(packageJson, 'detox') || packageJson?.['detox'] !== undefined) return true;
+  return DETOX_CONFIG_FILES.some((name) => isPlainFile(path.join(dir, name)));
+}
+
 /**
  * Scan the folder for clues that decide whether conditional skills (Expo,
- * Bazel) should be installed by default.
+ * Bazel, Detox) should be installed by default.
  */
 export function scanSkillHints(root = process.cwd()): SkillHints {
   const dirs = walkDirs(root);
   return {
     expo: dirs.some((dir) => hasExpoDependency(path.join(dir, 'package.json'))),
     bazel: dirs.some(isBazelWorkspaceDir),
+    detox: dirs.some(isDetoxDir),
   };
 }
 

--- a/packages/cli/src/lib/project-detection.ts
+++ b/packages/cli/src/lib/project-detection.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import type { SkillHints } from './skills';
+
 export type ProjectDetection =
   | {
       kind: 'native-ios';
@@ -91,6 +93,33 @@ function hasExpoDependency(packageJsonPath: string): boolean {
 function isExpoAppDir(dir: string): boolean {
   if (!hasExpoDependency(path.join(dir, 'package.json'))) return false;
   return ['app.json', 'app.config.js', 'app.config.ts'].some((name) => fs.existsSync(path.join(dir, name)));
+}
+
+// Unambiguous Bazel workspace markers. Bare BUILD files are intentionally not
+// on this list because they are too weak a signal on their own.
+const BAZEL_MARKERS = [
+  'WORKSPACE',
+  'WORKSPACE.bazel',
+  'WORKSPACE.bzlmod',
+  'MODULE.bazel',
+  '.bazelrc',
+  '.bazelversion',
+];
+
+function isBazelWorkspaceDir(dir: string): boolean {
+  return BAZEL_MARKERS.some((marker) => isPlainFile(path.join(dir, marker)));
+}
+
+/**
+ * Scan the folder for clues that decide whether conditional skills (Expo,
+ * Bazel) should be installed by default.
+ */
+export function scanSkillHints(root = process.cwd()): SkillHints {
+  const dirs = walkDirs(root);
+  return {
+    expo: dirs.some((dir) => hasExpoDependency(path.join(dir, 'package.json'))),
+    bazel: dirs.some(isBazelWorkspaceDir),
+  };
 }
 
 function iosProjectFiles(dir: string): { workspaces: string[]; projects: string[] } {

--- a/packages/cli/src/lib/project-detection.ts
+++ b/packages/cli/src/lib/project-detection.ts
@@ -142,13 +142,12 @@ function isDetoxDir(dir: string): boolean {
 }
 
 /**
- * Scan the folder for clues that decide whether conditional skills (Expo,
- * Bazel, Detox) should be installed by default.
+ * Scan the folder for clues that decide whether conditional skills (Bazel,
+ * Detox) should be installed by default.
  */
 export function scanSkillHints(root = process.cwd()): SkillHints {
   const dirs = walkDirs(root);
   return {
-    expo: dirs.some((dir) => hasExpoDependency(path.join(dir, 'package.json'))),
     bazel: dirs.some(isBazelWorkspaceDir),
     detox: dirs.some(isDetoxDir),
   };

--- a/packages/cli/src/lib/skills.ts
+++ b/packages/cli/src/lib/skills.ts
@@ -87,7 +87,6 @@ export function detectAdoptedAgents(scope: Scope, projectRoot?: string): AgentId
 }
 
 export interface SkillHints {
-  expo: boolean;
   bazel: boolean;
   detox: boolean;
 }
@@ -98,8 +97,8 @@ export interface DefaultSkillSelection {
 }
 
 /**
- * Default selection installs every catalog skill, except that Expo-, Bazel-,
- * and Detox-specific skills are only included when the project scan found
+ * Default selection installs every catalog skill, except that Bazel- and
+ * Detox-specific skills are only included when the project scan found
  * matching clues.
  */
 export function selectDefaultSkills(skillNames: string[], hints: SkillHints): DefaultSkillSelection {
@@ -107,9 +106,7 @@ export function selectDefaultSkills(skillNames: string[], hints: SkillHints): De
   const excluded: Array<{ name: string; reason: string }> = [];
   for (const name of skillNames) {
     const tokens = name.split('-');
-    if (tokens.includes('expo') && !hints.expo) {
-      excluded.push({ name, reason: 'no Expo project detected in this folder' });
-    } else if (tokens.includes('bazel') && !hints.bazel) {
+    if (tokens.includes('bazel') && !hints.bazel) {
       excluded.push({ name, reason: 'no Bazel workspace detected in this folder' });
     } else if (tokens.includes('detox') && !hints.detox) {
       excluded.push({ name, reason: 'no Detox setup detected in this folder' });

--- a/packages/cli/src/lib/skills.ts
+++ b/packages/cli/src/lib/skills.ts
@@ -64,7 +64,11 @@ export const AGENTS: Record<AgentId, AgentSpec> = {
 
 function isExistingDirectory(candidatePath: string): boolean {
   try {
-    return fs.lstatSync(candidatePath).isDirectory();
+    // statSync follows symlinks: a skills dir that is a symlink to a real
+    // directory is a valid existing structure and must be adopted rather
+    // than duplicated at the preferred path. Broken symlinks throw and
+    // count as missing.
+    return fs.statSync(candidatePath).isDirectory();
   } catch {
     return false;
   }

--- a/packages/cli/src/lib/skills.ts
+++ b/packages/cli/src/lib/skills.ts
@@ -89,6 +89,7 @@ export function detectAdoptedAgents(scope: Scope, projectRoot?: string): AgentId
 export interface SkillHints {
   expo: boolean;
   bazel: boolean;
+  detox: boolean;
 }
 
 export interface DefaultSkillSelection {
@@ -97,8 +98,8 @@ export interface DefaultSkillSelection {
 }
 
 /**
- * Default selection installs every catalog skill, except that Expo- and
- * Bazel-specific skills are only included when the project scan found
+ * Default selection installs every catalog skill, except that Expo-, Bazel-,
+ * and Detox-specific skills are only included when the project scan found
  * matching clues.
  */
 export function selectDefaultSkills(skillNames: string[], hints: SkillHints): DefaultSkillSelection {
@@ -110,6 +111,8 @@ export function selectDefaultSkills(skillNames: string[], hints: SkillHints): De
       excluded.push({ name, reason: 'no Expo project detected in this folder' });
     } else if (tokens.includes('bazel') && !hints.bazel) {
       excluded.push({ name, reason: 'no Bazel workspace detected in this folder' });
+    } else if (tokens.includes('detox') && !hints.detox) {
+      excluded.push({ name, reason: 'no Detox setup detected in this folder' });
     } else {
       selected.push(name);
     }

--- a/packages/cli/src/lib/skills.ts
+++ b/packages/cli/src/lib/skills.ts
@@ -10,8 +10,12 @@ export const AGENT_IDS: AgentId[] = ['claude', 'cursor', 'codex'];
 export interface AgentSpec {
   id: AgentId;
   displayName: string;
-  skillsDir(scope: Scope, projectRoot?: string): string;
-  detectionPaths(scope: Scope): string[];
+  /**
+   * Skills directories this agent reads, preferred location first. Installs
+   * adopt the first candidate that already exists on disk so we extend an
+   * existing skills structure instead of creating a parallel one.
+   */
+  skillsDirCandidates(scope: Scope, projectRoot?: string): string[];
 }
 
 function claudeGlobalRoot(): string {
@@ -30,12 +34,10 @@ export const AGENTS: Record<AgentId, AgentSpec> = {
   claude: {
     id: 'claude',
     displayName: 'Claude Code',
-    skillsDir: (scope, projectRoot = process.cwd()) =>
+    skillsDirCandidates: (scope, projectRoot = process.cwd()) =>
       scope === 'project' ?
-        path.join(projectRoot, '.claude', 'skills')
-      : path.join(claudeGlobalRoot(), 'skills'),
-    detectionPaths: (scope) =>
-      scope === 'project' ? [path.join(process.cwd(), '.claude')] : [claudeGlobalRoot()],
+        [path.join(projectRoot, '.claude', 'skills')]
+      : [path.join(claudeGlobalRoot(), 'skills')],
   },
   cursor: {
     id: 'cursor',
@@ -43,28 +45,77 @@ export const AGENTS: Record<AgentId, AgentSpec> = {
     // Cursor auto-discovers .agents/skills/ natively, same as .cursor/skills/.
     // Installing into .agents/skills/ also reaches OpenCode and any other
     // AGENTS.md-aware tool with a single copy, so prefer the broader path.
-    skillsDir: (scope, projectRoot = process.cwd()) =>
+    // When only .cursor/skills/ already exists we adopt it instead of
+    // creating a second structure.
+    skillsDirCandidates: (scope, projectRoot = process.cwd()) =>
       scope === 'project' ?
-        path.join(projectRoot, '.agents', 'skills')
-      : path.join(os.homedir(), '.agents', 'skills'),
-    // Detect either .cursor/ or .agents/: both are reliable signs the user
-    // is on a tool that auto-loads .agents/skills/.
-    detectionPaths: (scope) =>
-      scope === 'project' ?
-        [path.join(process.cwd(), '.cursor'), path.join(process.cwd(), '.agents')]
-      : [path.join(os.homedir(), '.cursor'), path.join(os.homedir(), '.agents')],
+        [path.join(projectRoot, '.agents', 'skills'), path.join(projectRoot, '.cursor', 'skills')]
+      : [path.join(os.homedir(), '.agents', 'skills'), path.join(os.homedir(), '.cursor', 'skills')],
   },
   codex: {
     id: 'codex',
     displayName: 'Codex',
-    skillsDir: (scope, projectRoot = process.cwd()) =>
+    skillsDirCandidates: (scope, projectRoot = process.cwd()) =>
       scope === 'project' ?
-        path.join(projectRoot, '.codex', 'skills')
-      : path.join(codexGlobalRoot(), 'skills'),
-    detectionPaths: (scope) =>
-      scope === 'project' ? [path.join(process.cwd(), '.codex')] : [codexGlobalRoot()],
+        [path.join(projectRoot, '.codex', 'skills')]
+      : [path.join(codexGlobalRoot(), 'skills')],
   },
 };
+
+function isExistingDirectory(candidatePath: string): boolean {
+  try {
+    return fs.lstatSync(candidatePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveSkillsDir(agent: AgentSpec, scope: Scope, projectRoot?: string): string {
+  const candidates = agent.skillsDirCandidates(scope, projectRoot);
+  return candidates.find(isExistingDirectory) ?? candidates[0]!;
+}
+
+/**
+ * Agents that already have a skills directory on disk for the given scope.
+ * When any exist, installs adopt that structure instead of creating skill
+ * directories for every supported agent.
+ */
+export function detectAdoptedAgents(scope: Scope, projectRoot?: string): AgentId[] {
+  return AGENT_IDS.filter((id) =>
+    AGENTS[id].skillsDirCandidates(scope, projectRoot).some(isExistingDirectory),
+  );
+}
+
+export interface SkillHints {
+  expo: boolean;
+  bazel: boolean;
+}
+
+export interface DefaultSkillSelection {
+  selected: string[];
+  excluded: Array<{ name: string; reason: string }>;
+}
+
+/**
+ * Default selection installs every catalog skill, except that Expo- and
+ * Bazel-specific skills are only included when the project scan found
+ * matching clues.
+ */
+export function selectDefaultSkills(skillNames: string[], hints: SkillHints): DefaultSkillSelection {
+  const selected: string[] = [];
+  const excluded: Array<{ name: string; reason: string }> = [];
+  for (const name of skillNames) {
+    const tokens = name.split('-');
+    if (tokens.includes('expo') && !hints.expo) {
+      excluded.push({ name, reason: 'no Expo project detected in this folder' });
+    } else if (tokens.includes('bazel') && !hints.bazel) {
+      excluded.push({ name, reason: 'no Bazel workspace detected in this folder' });
+    } else {
+      selected.push(name);
+    }
+  }
+  return { selected, excluded };
+}
 
 export function targetSkillDir(
   agent: AgentSpec,
@@ -72,7 +123,7 @@ export function targetSkillDir(
   skillName: string,
   projectRoot?: string,
 ): string {
-  return path.join(agent.skillsDir(scope, projectRoot), skillName);
+  return path.join(resolveSkillsDir(agent, scope, projectRoot), skillName);
 }
 
 export type PlanKind = 'install' | 'unchanged' | 'conflict';

--- a/tests/cli-onboarding.test.ts
+++ b/tests/cli-onboarding.test.ts
@@ -9,8 +9,7 @@ import {
   ensureSampleRepo,
   ensureProjectEnvApiKey,
   installProjectSkills,
-  SAMPLE_NATIVE_APP_DIR,
-  SAMPLE_NATIVE_APP_REPO,
+  SAMPLE_APPS,
 } from '../packages/cli/src/lib/onboarding';
 import type { LoadedRemoteSkills } from '../packages/cli/src/lib/remote-skills';
 
@@ -324,7 +323,7 @@ describe('lim run project env setup', () => {
 });
 
 describe('lim run sample repo handling', () => {
-  test('clones missing sample dir with the expected repository', async () => {
+  test('clones missing sample dir with the Swift repository by default', async () => {
     const root = makeTempDir();
     const calls: Array<{ args: string[]; cwd?: string }> = [];
     try {
@@ -336,10 +335,35 @@ describe('lim run sample repo handling', () => {
         },
       });
 
-      expect(sample).toEqual({ path: path.join(root, SAMPLE_NATIVE_APP_DIR), reused: false });
+      expect(sample).toEqual({ path: path.join(root, SAMPLE_APPS.swift.dir), reused: false });
       expect(calls).toEqual([
         {
-          args: ['clone', '--depth', '1', SAMPLE_NATIVE_APP_REPO, SAMPLE_NATIVE_APP_DIR],
+          args: ['clone', '--depth', '1', SAMPLE_APPS.swift.repo, SAMPLE_APPS.swift.dir],
+          cwd: root,
+        },
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test.each(['expo56', 'bazel'] as const)('clones the %s sample into its own directory', async (kind) => {
+    const root = makeTempDir();
+    const calls: Array<{ args: string[]; cwd?: string }> = [];
+    try {
+      const sample = await ensureSampleRepo({
+        cwd: root,
+        sample: SAMPLE_APPS[kind],
+        git: async (args, cwd) => {
+          calls.push(cwd === undefined ? { args } : { args, cwd });
+          return '';
+        },
+      });
+
+      expect(sample).toEqual({ path: path.join(root, SAMPLE_APPS[kind].dir), reused: false });
+      expect(calls).toEqual([
+        {
+          args: ['clone', '--depth', '1', SAMPLE_APPS[kind].repo, SAMPLE_APPS[kind].dir],
           cwd: root,
         },
       ]);
@@ -351,26 +375,51 @@ describe('lim run sample repo handling', () => {
   test('reuses existing sample dir only when origin matches', async () => {
     const root = makeTempDir();
     try {
-      fs.mkdirSync(path.join(root, SAMPLE_NATIVE_APP_DIR), { recursive: true });
+      fs.mkdirSync(path.join(root, SAMPLE_APPS.swift.dir), { recursive: true });
 
       await expect(
         ensureSampleRepo({
           cwd: root,
-          git: async () => `${SAMPLE_NATIVE_APP_REPO}.git`,
+          git: async () => `${SAMPLE_APPS.swift.repo}.git`,
         }),
-      ).resolves.toEqual({ path: path.join(root, SAMPLE_NATIVE_APP_DIR), reused: true });
+      ).resolves.toEqual({ path: path.join(root, SAMPLE_APPS.swift.dir), reused: true });
 
       await expect(
         ensureSampleRepo({
           cwd: root,
           git: async () => 'ssh://git@github.com/limrun-inc/sample-native-app',
         }),
-      ).resolves.toEqual({ path: path.join(root, SAMPLE_NATIVE_APP_DIR), reused: true });
+      ).resolves.toEqual({ path: path.join(root, SAMPLE_APPS.swift.dir), reused: true });
 
       await expect(
         ensureSampleRepo({
           cwd: root,
           git: async () => 'https://github.com/example/not-the-sample.git',
+        }),
+      ).rejects.toThrow('already exists with origin');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('verifies the reused checkout against the selected sample repository', async () => {
+    const root = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(root, SAMPLE_APPS.expo56.dir), { recursive: true });
+
+      await expect(
+        ensureSampleRepo({
+          cwd: root,
+          sample: SAMPLE_APPS.expo56,
+          git: async () => `${SAMPLE_APPS.expo56.repo}.git`,
+        }),
+      ).resolves.toEqual({ path: path.join(root, SAMPLE_APPS.expo56.dir), reused: true });
+
+      await expect(
+        ensureSampleRepo({
+          cwd: root,
+          sample: SAMPLE_APPS.expo56,
+          git: async () => SAMPLE_APPS.swift.repo,
         }),
       ).rejects.toThrow('already exists with origin');
     } finally {

--- a/tests/cli-onboarding.test.ts
+++ b/tests/cli-onboarding.test.ts
@@ -133,7 +133,7 @@ describe('lim run project detection', () => {
 });
 
 describe('lim run skill installation', () => {
-  test('installs selected skills into project-local agents and skips divergent conflicts', async () => {
+  test('installs selected skills into project-local agents and updates divergent directories', async () => {
     const projectRoot = makeTempDir();
     const sourceRoot = makeTempDir();
     try {
@@ -149,7 +149,7 @@ describe('lim run skill installation', () => {
       expect(results).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ skill: 'limrun-xcode', agent: 'cursor', status: 'installed' }),
-          expect.objectContaining({ skill: 'limrun-xcode', agent: 'claude', status: 'skipped' }),
+          expect.objectContaining({ skill: 'limrun-xcode', agent: 'claude', status: 'updated' }),
           expect.objectContaining({ skill: 'limrun-ios-simulator', agent: 'cursor', status: 'installed' }),
           expect.objectContaining({ skill: 'limrun-ios-simulator', agent: 'claude', status: 'installed' }),
         ]),
@@ -159,7 +159,7 @@ describe('lim run skill installation', () => {
       ).toBe('limrun-xcode');
       expect(
         fs.readFileSync(path.join(projectRoot, '.claude', 'skills', 'limrun-xcode', 'SKILL.md'), 'utf8'),
-      ).toBe('local changes');
+      ).toBe('limrun-xcode');
       expect(
         fs.readFileSync(
           path.join(projectRoot, '.agents', 'skills', 'limrun-ios-simulator', 'SKILL.md'),

--- a/tests/cli-skills.test.ts
+++ b/tests/cli-skills.test.ts
@@ -164,11 +164,7 @@ describe('default skill selection', () => {
 
   test('keeps only the matching conditional skill', () => {
     const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: false, detox: false });
-    expect(selection.selected).toEqual([
-      'limrun-xcode',
-      'limrun-ios-simulator',
-      'limrun-expo-development',
-    ]);
+    expect(selection.selected).toEqual(['limrun-xcode', 'limrun-ios-simulator', 'limrun-expo-development']);
   });
 });
 
@@ -236,10 +232,7 @@ describe('skill hint scanning', () => {
   test('detects a Detox config section in package.json', () => {
     const root = makeTempDir();
     try {
-      fs.writeFileSync(
-        path.join(root, 'package.json'),
-        JSON.stringify({ detox: { configurations: {} } }),
-      );
+      fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ detox: { configurations: {} } }));
       expect(scanSkillHints(root).detox).toBe(true);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });

--- a/tests/cli-skills.test.ts
+++ b/tests/cli-skills.test.ts
@@ -143,30 +143,31 @@ describe('default skill selection', () => {
     'limrun-xcode-bazel',
   ];
 
-  test('selects every skill when Expo and Bazel clues are present', () => {
-    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: true });
+  test('selects every skill when Expo, Bazel, and Detox clues are present', () => {
+    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: true, detox: true });
     expect(selection.selected).toEqual(CATALOG);
     expect(selection.excluded).toEqual([]);
   });
 
-  test('excludes Expo and Bazel skills when the folder has no matching clues', () => {
-    const selection = selectDefaultSkills(CATALOG, { expo: false, bazel: false });
-    expect(selection.selected).toEqual(['limrun-xcode', 'limrun-ios-simulator', 'limrun-detox-testing']);
+  test('excludes conditional skills when the folder has no matching clues', () => {
+    const selection = selectDefaultSkills(CATALOG, { expo: false, bazel: false, detox: false });
+    expect(selection.selected).toEqual(['limrun-xcode', 'limrun-ios-simulator']);
     expect(selection.excluded.map((entry) => entry.name)).toEqual([
       'limrun-expo-development',
+      'limrun-detox-testing',
       'limrun-xcode-bazel',
     ]);
     expect(selection.excluded[0]!.reason).toContain('Expo');
-    expect(selection.excluded[1]!.reason).toContain('Bazel');
+    expect(selection.excluded[1]!.reason).toContain('Detox');
+    expect(selection.excluded[2]!.reason).toContain('Bazel');
   });
 
   test('keeps only the matching conditional skill', () => {
-    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: false });
+    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: false, detox: false });
     expect(selection.selected).toEqual([
       'limrun-xcode',
       'limrun-ios-simulator',
       'limrun-expo-development',
-      'limrun-detox-testing',
     ]);
   });
 });
@@ -175,7 +176,7 @@ describe('skill hint scanning', () => {
   test('finds no clues in an empty folder', () => {
     const root = makeTempDir();
     try {
-      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false });
+      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false, detox: false });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
@@ -188,7 +189,7 @@ describe('skill hint scanning', () => {
         path.join(root, 'package.json'),
         JSON.stringify({ dependencies: { expo: '~52.0.0' } }),
       );
-      expect(scanSkillHints(root)).toEqual({ expo: true, bazel: false });
+      expect(scanSkillHints(root)).toEqual({ expo: true, bazel: false, detox: false });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
@@ -213,17 +214,53 @@ describe('skill hint scanning', () => {
     const root = makeTempDir();
     try {
       fs.writeFileSync(path.join(root, 'MODULE.bazel'), 'module(name = "app")\n');
-      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: true });
+      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: true, detox: false });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
 
-  test('does not treat a package.json without expo as an Expo clue', () => {
+  test('detects a Detox dependency in package.json', () => {
+    const root = makeTempDir();
+    try {
+      fs.writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify({ devDependencies: { detox: '^20.0.0' } }),
+      );
+      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false, detox: true });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('detects a Detox config section in package.json', () => {
+    const root = makeTempDir();
+    try {
+      fs.writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify({ detox: { configurations: {} } }),
+      );
+      expect(scanSkillHints(root).detox).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('detects a .detoxrc.js config file', () => {
+    const root = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(root, '.detoxrc.js'), 'module.exports = {};\n');
+      expect(scanSkillHints(root).detox).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('does not treat a package.json without expo or detox as a clue', () => {
     const root = makeTempDir();
     try {
       fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ dependencies: { react: '18' } }));
-      expect(scanSkillHints(root).expo).toBe(false);
+      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false, detox: false });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/tests/cli-skills.test.ts
+++ b/tests/cli-skills.test.ts
@@ -2,7 +2,16 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { applySkillDirectoryCopy, planSkillDirectoryCopy } from '../packages/cli/src/lib/skills';
+import {
+  AGENTS,
+  applySkillDirectoryCopy,
+  detectAdoptedAgents,
+  planSkillDirectoryCopy,
+  resolveSkillsDir,
+  selectDefaultSkills,
+  targetSkillDir,
+} from '../packages/cli/src/lib/skills';
+import { scanSkillHints } from '../packages/cli/src/lib/project-detection';
 import { __remoteSkillsTestUtils, loadRemoteSkills } from '../packages/cli/src/lib/remote-skills';
 
 function makeTempDir(): string {
@@ -121,6 +130,161 @@ description: ${description}
       }
     } finally {
       fs.rmSync(checkoutDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('default skill selection', () => {
+  const CATALOG = [
+    'limrun-xcode',
+    'limrun-ios-simulator',
+    'limrun-expo-development',
+    'limrun-detox-testing',
+    'limrun-xcode-bazel',
+  ];
+
+  test('selects every skill when Expo and Bazel clues are present', () => {
+    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: true });
+    expect(selection.selected).toEqual(CATALOG);
+    expect(selection.excluded).toEqual([]);
+  });
+
+  test('excludes Expo and Bazel skills when the folder has no matching clues', () => {
+    const selection = selectDefaultSkills(CATALOG, { expo: false, bazel: false });
+    expect(selection.selected).toEqual(['limrun-xcode', 'limrun-ios-simulator', 'limrun-detox-testing']);
+    expect(selection.excluded.map((entry) => entry.name)).toEqual([
+      'limrun-expo-development',
+      'limrun-xcode-bazel',
+    ]);
+    expect(selection.excluded[0]!.reason).toContain('Expo');
+    expect(selection.excluded[1]!.reason).toContain('Bazel');
+  });
+
+  test('keeps only the matching conditional skill', () => {
+    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: false });
+    expect(selection.selected).toEqual([
+      'limrun-xcode',
+      'limrun-ios-simulator',
+      'limrun-expo-development',
+      'limrun-detox-testing',
+    ]);
+  });
+});
+
+describe('skill hint scanning', () => {
+  test('finds no clues in an empty folder', () => {
+    const root = makeTempDir();
+    try {
+      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('detects an Expo dependency in package.json', () => {
+    const root = makeTempDir();
+    try {
+      fs.writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify({ dependencies: { expo: '~52.0.0' } }),
+      );
+      expect(scanSkillHints(root)).toEqual({ expo: true, bazel: false });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('detects an Expo app nested one level down', () => {
+    const root = makeTempDir();
+    try {
+      const appDir = path.join(root, 'apps', 'mobile');
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(appDir, 'package.json'),
+        JSON.stringify({ devDependencies: { expo: '~52.0.0' } }),
+      );
+      expect(scanSkillHints(root).expo).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('detects a Bazel workspace via MODULE.bazel', () => {
+    const root = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(root, 'MODULE.bazel'), 'module(name = "app")\n');
+      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: true });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('does not treat a package.json without expo as an Expo clue', () => {
+    const root = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ dependencies: { react: '18' } }));
+      expect(scanSkillHints(root).expo).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('existing skills structure adoption', () => {
+  test('reports no adopted agents when nothing exists', () => {
+    const root = makeTempDir();
+    try {
+      expect(detectAdoptedAgents('project', root)).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('adopts only agents with an existing skills directory', () => {
+    const root = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(root, '.claude', 'skills'), { recursive: true });
+      expect(detectAdoptedAgents('project', root)).toEqual(['claude']);
+
+      fs.mkdirSync(path.join(root, '.codex', 'skills'), { recursive: true });
+      expect(detectAdoptedAgents('project', root)).toEqual(['claude', 'codex']);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('recognizes an existing .cursor/skills structure for the cursor agent', () => {
+    const root = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(root, '.cursor', 'skills'), { recursive: true });
+      expect(detectAdoptedAgents('project', root)).toEqual(['cursor']);
+      expect(resolveSkillsDir(AGENTS.cursor, 'project', root)).toBe(path.join(root, '.cursor', 'skills'));
+      expect(targetSkillDir(AGENTS.cursor, 'project', 'limrun-xcode', root)).toBe(
+        path.join(root, '.cursor', 'skills', 'limrun-xcode'),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('prefers .agents/skills over .cursor/skills when both exist', () => {
+    const root = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(root, '.cursor', 'skills'), { recursive: true });
+      fs.mkdirSync(path.join(root, '.agents', 'skills'), { recursive: true });
+      expect(resolveSkillsDir(AGENTS.cursor, 'project', root)).toBe(path.join(root, '.agents', 'skills'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('defaults to the preferred directory when nothing exists', () => {
+    const root = makeTempDir();
+    try {
+      expect(resolveSkillsDir(AGENTS.cursor, 'project', root)).toBe(path.join(root, '.agents', 'skills'));
+      expect(resolveSkillsDir(AGENTS.claude, 'project', root)).toBe(path.join(root, '.claude', 'skills'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/tests/cli-skills.test.ts
+++ b/tests/cli-skills.test.ts
@@ -287,6 +287,33 @@ describe('existing skills structure adoption', () => {
     }
   });
 
+  test('adopts a skills directory that is a symlink to a real directory', () => {
+    const root = makeTempDir();
+    try {
+      const realSkills = path.join(root, 'shared-skills');
+      fs.mkdirSync(realSkills, { recursive: true });
+      fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+      fs.symlinkSync(realSkills, path.join(root, '.claude', 'skills'), 'dir');
+
+      expect(detectAdoptedAgents('project', root)).toEqual(['claude']);
+      expect(resolveSkillsDir(AGENTS.claude, 'project', root)).toBe(path.join(root, '.claude', 'skills'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('ignores a broken skills directory symlink', () => {
+    const root = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+      fs.symlinkSync(path.join(root, 'does-not-exist'), path.join(root, '.claude', 'skills'), 'dir');
+
+      expect(detectAdoptedAgents('project', root)).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('prefers .agents/skills over .cursor/skills when both exist', () => {
     const root = makeTempDir();
     try {

--- a/tests/cli-skills.test.ts
+++ b/tests/cli-skills.test.ts
@@ -143,28 +143,31 @@ describe('default skill selection', () => {
     'limrun-xcode-bazel',
   ];
 
-  test('selects every skill when Expo, Bazel, and Detox clues are present', () => {
-    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: true, detox: true });
+  test('selects every skill when Bazel and Detox clues are present', () => {
+    const selection = selectDefaultSkills(CATALOG, { bazel: true, detox: true });
     expect(selection.selected).toEqual(CATALOG);
     expect(selection.excluded).toEqual([]);
   });
 
-  test('excludes conditional skills when the folder has no matching clues', () => {
-    const selection = selectDefaultSkills(CATALOG, { expo: false, bazel: false, detox: false });
-    expect(selection.selected).toEqual(['limrun-xcode', 'limrun-ios-simulator']);
+  test('excludes conditional skills but always keeps Expo when the folder has no clues', () => {
+    const selection = selectDefaultSkills(CATALOG, { bazel: false, detox: false });
+    expect(selection.selected).toEqual(['limrun-xcode', 'limrun-ios-simulator', 'limrun-expo-development']);
     expect(selection.excluded.map((entry) => entry.name)).toEqual([
-      'limrun-expo-development',
       'limrun-detox-testing',
       'limrun-xcode-bazel',
     ]);
-    expect(selection.excluded[0]!.reason).toContain('Expo');
-    expect(selection.excluded[1]!.reason).toContain('Detox');
-    expect(selection.excluded[2]!.reason).toContain('Bazel');
+    expect(selection.excluded[0]!.reason).toContain('Detox');
+    expect(selection.excluded[1]!.reason).toContain('Bazel');
   });
 
   test('keeps only the matching conditional skill', () => {
-    const selection = selectDefaultSkills(CATALOG, { expo: true, bazel: false, detox: false });
-    expect(selection.selected).toEqual(['limrun-xcode', 'limrun-ios-simulator', 'limrun-expo-development']);
+    const selection = selectDefaultSkills(CATALOG, { bazel: true, detox: false });
+    expect(selection.selected).toEqual([
+      'limrun-xcode',
+      'limrun-ios-simulator',
+      'limrun-expo-development',
+      'limrun-xcode-bazel',
+    ]);
   });
 });
 
@@ -172,35 +175,7 @@ describe('skill hint scanning', () => {
   test('finds no clues in an empty folder', () => {
     const root = makeTempDir();
     try {
-      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false, detox: false });
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  test('detects an Expo dependency in package.json', () => {
-    const root = makeTempDir();
-    try {
-      fs.writeFileSync(
-        path.join(root, 'package.json'),
-        JSON.stringify({ dependencies: { expo: '~52.0.0' } }),
-      );
-      expect(scanSkillHints(root)).toEqual({ expo: true, bazel: false, detox: false });
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  test('detects an Expo app nested one level down', () => {
-    const root = makeTempDir();
-    try {
-      const appDir = path.join(root, 'apps', 'mobile');
-      fs.mkdirSync(appDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(appDir, 'package.json'),
-        JSON.stringify({ devDependencies: { expo: '~52.0.0' } }),
-      );
-      expect(scanSkillHints(root).expo).toBe(true);
+      expect(scanSkillHints(root)).toEqual({ bazel: false, detox: false });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
@@ -210,7 +185,7 @@ describe('skill hint scanning', () => {
     const root = makeTempDir();
     try {
       fs.writeFileSync(path.join(root, 'MODULE.bazel'), 'module(name = "app")\n');
-      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: true, detox: false });
+      expect(scanSkillHints(root)).toEqual({ bazel: true, detox: false });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
@@ -223,7 +198,22 @@ describe('skill hint scanning', () => {
         path.join(root, 'package.json'),
         JSON.stringify({ devDependencies: { detox: '^20.0.0' } }),
       );
-      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false, detox: true });
+      expect(scanSkillHints(root)).toEqual({ bazel: false, detox: true });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('detects a Detox setup nested one level down', () => {
+    const root = makeTempDir();
+    try {
+      const appDir = path.join(root, 'apps', 'mobile');
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(appDir, 'package.json'),
+        JSON.stringify({ devDependencies: { detox: '^20.0.0' } }),
+      );
+      expect(scanSkillHints(root).detox).toBe(true);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
@@ -249,11 +239,11 @@ describe('skill hint scanning', () => {
     }
   });
 
-  test('does not treat a package.json without expo or detox as a clue', () => {
+  test('does not treat a package.json without detox as a clue', () => {
     const root = makeTempDir();
     try {
       fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ dependencies: { react: '18' } }));
-      expect(scanSkillHints(root)).toEqual({ expo: false, bazel: false, detox: false });
+      expect(scanSkillHints(root)).toEqual({ bazel: false, detox: false });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### `lim skills install` defaults

Running it without flags now:

- **Installs all catalog skills for all agents by default.** The interactive multiselect prompts are gone; `--skills` and `--agents` remain as overrides, and `--scope` now defaults to `project`.
- **Includes Bazel and Detox skills only when the folder scan finds matching clues (project scope).** Skills whose name contains a `bazel` token (e.g. `limrun-xcode-bazel`) require Bazel workspace markers (`WORKSPACE`, `MODULE.bazel`, `.bazelrc`, ...); skills with a `detox` token (e.g. `limrun-detox-testing`) require a `detox` dependency, a `detox` section in `package.json`, or a Detox config file (`.detoxrc*`, `detox.config.*`). The Expo skill is always included. Global installs (`--scope global`) are not tied to a project folder, so they skip the scan and install every skill. The scan reuses the same directory walk (depth 2, common excludes) as `lim run` project detection.
- **Adopts an existing skills structure instead of installing all agent variations.** If any agent already has a skills directory for the chosen scope (`.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `.codex/skills/`), skills are installed only for those agents. When only `.cursor/skills/` exists, Cursor installs go there instead of creating a parallel `.agents/skills/` structure.
- **Updates differing skill directories in place by default.** Byte-identical targets are reported as `Unchanged`; differing ones are overwritten and reported as `Updated`, with a note pointing at the VCS diff so users can review or ask their agent to reconcile local edits. `--keep-existing` opts out and leaves differing directories untouched. The `--force` flag is removed entirely. `lim run` onboarding follows the same policy (it previously skipped divergent directories and pointed at `--force`).
- **Summarizes one line per skill.** All target folders are combined on the skill's line, with per-folder status annotations only when statuses differ:

  ```
    Limrun skills
      limrun-xcode          ->  .claude/skills, .agents/skills, .codex/skills    Installed
      limrun-ios-simulator  ->  .claude/skills (updated), .agents/skills (unchanged), .codex/skills (unchanged)
  ```

### `lim run` sample picker

When no project is detected, `lim run` now asks which sample project to run — Swift (`limrun-inc/sample-native-app`), Expo 56 (`limrun-inc/sample-expo56-app`), or Bazel (`limrun-inc/sample-native-bazel-app`). Non-interactive sessions skip the prompt and default to the Swift sample, matching the previous behavior. The chosen sample clones into its own directory, the origin check verifies against the selected repo, the instance `repo` label reflects the chosen sample, and the Expo 56 sample uses the longer Expo build estimate label.

## Changes

- `packages/cli/src/lib/skills.ts`: replaced `detectionPaths` with `skillsDirCandidates` (preferred dir first); added `resolveSkillsDir`, `detectAdoptedAgents`, and `selectDefaultSkills`; `targetSkillDir` now resolves to an existing candidate directory, so `lim run` onboarding also adopts `.cursor/skills/` when present.
- `packages/cli/src/lib/project-detection.ts`: added `scanSkillHints` for the Bazel/Detox folder scan.
- `packages/cli/src/commands/skills/install.ts`: removed all prompts (selection and overwrite confirmation) and the `--force` flag; wired in default selection (all skills for global scope, hint-gated for project scope), adoption, and update-by-default with explanatory stderr notes; the human summary groups results per skill.
- `packages/cli/src/lib/onboarding.ts`: divergent skill directories are updated instead of skipped; replaced the single sample-repo constants with a `SAMPLE_APPS` catalog (swift/expo56/bazel) and parametrized `ensureSampleRepo`.
- `packages/cli/src/commands/run.ts`: added the interactive sample picker (Swift default, non-interactive falls back to Swift); the skill summary lists updated paths and suggests reviewing the diff.
- `packages/cli/README.md`: updated the Skills and Run sections.
- `tests/cli-skills.test.ts`, `tests/cli-onboarding.test.ts`: coverage for default skill selection, hint scanning (Bazel markers; Detox dependency/config-section/config-file, incl. nested), adoption/dir resolution, update-on-conflict, and per-sample clone/reuse verification.

## Testing

- `npx jest`: 524 passed, 26 skipped, 0 failed.
- `./scripts/lint` (per AGENTS.md) and CLI package `tsc --noEmit` + `eslint src/` clean.
- All three sample repos verified reachable on GitHub (`sample-native-app`, `sample-expo56-app`, `sample-native-bazel-app`).
- Manual runs with `bin/dev.js`:
  - `skills install` in an empty folder → xcode/ios-simulator/expo installed for Claude Code, Cursor (`.agents/skills/`), and Codex; Detox/Bazel skills skipped with notes; one summary line per skill
  - `skills install --scope global` (isolated `$HOME`) → all five skills installed into the home skills directories with no scan notes
  - folder with `MODULE.bazel` → Bazel skill installed; folder with `detox` devDependency → `limrun-detox-testing` installed
  - folder with only `.cursor/skills/` → installs only for Cursor, into `.cursor/skills/`
  - locally edited skill + rerun → `Updated` with a reconcile hint and per-folder annotations on the mixed line; with `--keep-existing` → `Skipped` and the local edit preserved
  - `--force` → rejected with `Nonexistent flag: --force`
  - `lim run` in a TTY (tmux) → shows the "Which sample project do you want to run?" select with Swift/Expo 56/Bazel and proceeds after selection; with piped stdin → no prompt, defaults to the Swift sample
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f847f-2106-768b-b5c6-d78e01329033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f847f-2106-768b-b5c6-d78e01329033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

