### PR TITLE
feat(api): add gradleInstances.listBuildLogs

### DIFF
--- a/api.md
+++ b/api.md
@@ -66,6 +66,7 @@ Methods:
 - <code title="get /v1/gradle_instances">client.gradleInstances.<a href="./src/resources/gradle-instances.ts">list</a>({ ...params }) -> GradleInstancesItems</code>
 - <code title="delete /v1/gradle_instances/{id}">client.gradleInstances.<a href="./src/resources/gradle-instances.ts">delete</a>(id) -> void</code>
 - <code title="get /v1/gradle_instances/{id}">client.gradleInstances.<a href="./src/resources/gradle-instances.ts">get</a>(id) -> GradleInstance</code>
+- <code title="get /v1/gradle_instances/{id}/build_logs">client.gradleInstances.<a href="./src/resources/gradle-instances-helpers.ts">listBuildLogs</a>(id) -> GradleBuildLog[]</code>
 
 # Analytics
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,6 +67,7 @@ import {
   GradleClient,
   GradleSyncOptions,
   GradleBuildOptions,
+  GradleBuildLog,
 } from './resources/gradle-instances-helpers';
 import {
   XcodeInstances,
@@ -917,6 +918,7 @@ export declare namespace Limrun {
     type GradleClient as GradleClient,
     type GradleSyncOptions as GradleSyncOptions,
     type GradleBuildOptions as GradleBuildOptions,
+    type GradleBuildLog as GradleBuildLog,
   };
 
   export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export {
   type GradleClient,
   type GradleSyncOptions,
   type GradleBuildOptions,
+  type GradleBuildLog,
 } from './resources/gradle-instances-helpers';
 export {
   LIMRUN_DIR,

--- a/src/resources/daemon-client-shared.ts
+++ b/src/resources/daemon-client-shared.ts
@@ -7,6 +7,39 @@ import crypto from 'crypto';
 
 export type LogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug';
 
+// BuildLog is one persisted build record from the director's per-platform
+// GET /v1/{platform}_instances/{id}/build_logs endpoints. The xcode and
+// gradle responses share this exact shape (their OpenAPI schemas are
+// structurally identical), so it is defined once here and aliased per
+// resource; a platform gaining a field of its own is the signal to split the
+// aliases back into real interfaces. Hand-written against
+// api/public/director/openapiv3.yaml; if a Stainless regeneration ever picks
+// those paths up, reconcile with the generated surface instead of
+// duplicating it.
+export interface BuildLog {
+  /** Exec ID assigned by the build daemon, e.g. build-1776140344112378000. */
+  id: string;
+
+  /** Terminal status reported by the build daemon (e.g. SUCCEEDED, FAILED, CANCELLED). */
+  status: string;
+
+  /** Exit code of the build tool invocation, if the build reached completion. */
+  exitCode?: number;
+
+  startedAt?: string;
+
+  finishedAt?: string;
+
+  /** Time spent running the build tool, in milliseconds. */
+  buildDurationMs?: number;
+
+  /** Error message captured by the build daemon on failure, if any. */
+  error?: string;
+
+  /** Short-lived presigned URL for fetching the full .jsonl log from object storage. */
+  downloadUrl: string;
+}
+
 /**
  * Derives the client-side folder-sync cache location for a local project.
  * The key format is a compatibility contract: changing it orphans every

--- a/src/resources/gradle-instances-helpers.ts
+++ b/src/resources/gradle-instances-helpers.ts
@@ -1,4 +1,7 @@
 import { GradleInstances as GeneratedGradleInstances, type GradleInstance } from './gradle-instances';
+import { APIPromise } from '../core/api-promise';
+import { RequestOptions } from '../internal/request-options';
+import { path } from '../internal/utils/path';
 import {
   exec,
   type ExecChildProcess,
@@ -73,7 +76,43 @@ function gradleDefaultIgnore(relativePath: string): boolean {
   return segments.length === 1 && (trimmed === '.gradle' || trimmed === '.kotlin' || trimmed === 'build');
 }
 
+// GradleBuildLog is one persisted build record from the director's
+// GET /v1/gradle_instances/{id}/build_logs (operationId
+// listGradleInstanceBuildLogs). Hand-written against
+// api/public/director/openapiv3.yaml; if a Stainless regeneration ever picks
+// that path up, reconcile with the generated surface instead of duplicating it.
+export interface GradleBuildLog {
+  /** Exec ID assigned by gradlebuild, e.g. build-1776140344112378000. */
+  id: string;
+
+  /** Terminal status reported by gradlebuild (e.g. SUCCEEDED, FAILED, CANCELLED). */
+  status: string;
+
+  /** Exit code of gradlew, if the build reached completion. */
+  exitCode?: number;
+
+  startedAt?: string;
+
+  finishedAt?: string;
+
+  /** Time spent running gradlew, in milliseconds. */
+  buildDurationMs?: number;
+
+  /** Error message captured by gradlebuild on failure, if any. */
+  error?: string;
+
+  /** Short-lived presigned URL for fetching the full .jsonl log from object storage. */
+  downloadUrl: string;
+}
+
 export class GradleInstances extends GeneratedGradleInstances {
+  /**
+   * List the instance's persisted build logs.
+   */
+  listBuildLogs(id: string, options?: RequestOptions): APIPromise<GradleBuildLog[]> {
+    return this._client.get(path`/v1/gradle_instances/${id}/build_logs`, options);
+  }
+
   async createClient(params: GradleCreateClientParams): Promise<GradleClient> {
     let apiUrl: string;
     let token: string;

--- a/src/resources/gradle-instances-helpers.ts
+++ b/src/resources/gradle-instances-helpers.ts
@@ -15,6 +15,7 @@ import {
   createDaemonLogger,
   deriveBasisCache,
   mintAssetUploadUrls,
+  type BuildLog,
   type LogLevel,
   type SyncResult,
 } from './daemon-client-shared';
@@ -78,32 +79,9 @@ function gradleDefaultIgnore(relativePath: string): boolean {
 
 // GradleBuildLog is one persisted build record from the director's
 // GET /v1/gradle_instances/{id}/build_logs (operationId
-// listGradleInstanceBuildLogs). Hand-written against
-// api/public/director/openapiv3.yaml; if a Stainless regeneration ever picks
-// that path up, reconcile with the generated surface instead of duplicating it.
-export interface GradleBuildLog {
-  /** Exec ID assigned by gradlebuild, e.g. build-1776140344112378000. */
-  id: string;
-
-  /** Terminal status reported by gradlebuild (e.g. SUCCEEDED, FAILED, CANCELLED). */
-  status: string;
-
-  /** Exit code of gradlew, if the build reached completion. */
-  exitCode?: number;
-
-  startedAt?: string;
-
-  finishedAt?: string;
-
-  /** Time spent running gradlew, in milliseconds. */
-  buildDurationMs?: number;
-
-  /** Error message captured by gradlebuild on failure, if any. */
-  error?: string;
-
-  /** Short-lived presigned URL for fetching the full .jsonl log from object storage. */
-  downloadUrl: string;
-}
+// listGradleInstanceBuildLogs). The record shape is shared with xcode; see
+// BuildLog.
+export type GradleBuildLog = BuildLog;
 
 export class GradleInstances extends GeneratedGradleInstances {
   /**

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -73,4 +73,5 @@ export {
   type GradleClient,
   type GradleSyncOptions,
   type GradleBuildOptions,
+  type GradleBuildLog,
 } from './gradle-instances-helpers';

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -16,6 +16,7 @@ import {
   createDaemonLogger,
   deriveBasisCache,
   mintAssetUploadUrls,
+  type BuildLog,
   type LogLevel,
   type SyncResult,
 } from './daemon-client-shared';
@@ -515,32 +516,8 @@ async function readJsonResponse<T>(res: Response, operation: string): Promise<T>
 
 // XcodeBuildLog is one persisted build record from the director's
 // GET /v1/xcode_instances/{id}/build_logs (operationId listXcodeInstanceBuildLogs).
-// Hand-written against api/public/director/openapiv3.yaml; if a Stainless
-// regeneration ever picks that path up, reconcile with the generated surface
-// instead of duplicating it.
-export interface XcodeBuildLog {
-  /** Exec ID assigned by limbuild, e.g. build-1776140344112378000. */
-  id: string;
-
-  /** Terminal status reported by limbuild (e.g. SUCCEEDED, FAILED, CANCELLED). */
-  status: string;
-
-  /** Exit code of xcodebuild, if the build reached completion. */
-  exitCode?: number;
-
-  startedAt?: string;
-
-  finishedAt?: string;
-
-  /** Time spent running xcodebuild, in milliseconds. */
-  buildDurationMs?: number;
-
-  /** Error message captured by limbuild on failure, if any. */
-  error?: string;
-
-  /** Short-lived presigned URL for fetching the full .jsonl log from object storage. */
-  downloadUrl: string;
-}
+// The record shape is shared with gradle; see BuildLog.
+export type XcodeBuildLog = BuildLog;
 
 // BazelBuildLog is one persisted Bazel RBE invocation record from the
 // director's GET /v1/xcode_instances/{id}/bazel_build_logs (operationId


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive read-only API and a type-alias refactor with no runtime behavior change for existing Xcode callers.
> 
> **Overview**
> **Gradle instances** can now list persisted build history via `client.gradleInstances.listBuildLogs(id)`, matching the existing Xcode `listBuildLogs` pattern against `GET /v1/gradle_instances/{id}/build_logs`.
> 
> The **build log record type** is centralized as `BuildLog` in `daemon-client-shared`, with `GradleBuildLog` and `XcodeBuildLog` as aliases. Xcode’s previously duplicated inline `XcodeBuildLog` interface is removed in favor of that shared definition. `GradleBuildLog` is exported from the package surface (`api.md`, `client`, `index`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b29e4509cc325e664f5dd44807bd7cbbd1e935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->