### PR TITLE
tunnel: add send backpressure to the reverse tunnel

### DIFF
--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -228,7 +228,9 @@ export async function startReverseTcpTunnel(
 
     const sendCloseSignal = (connId: number): void => {
       if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(encodeConnectionHeader(connId));
+        // The drain check on completion keeps resume reachable even when the
+        // last frames in the queue are close signals rather than data.
+        ws.send(encodeConnectionHeader(connId), () => resumeIfDrained());
       }
     };
 
@@ -406,6 +408,8 @@ export async function startReverseTcpTunnel(
       connecting.add(connId);
 
       const socket = net.createConnection({ host: localHost, port: localPort });
+      // Self-heal a stale pause before applying it to the new socket.
+      resumeIfDrained();
       if (pausedForBackpressure) {
         socket.pause();
       }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -109,6 +109,12 @@ export interface ReverseTcpTunnelOptions {
    */
   maxPendingBytesPerConnection?: number;
   /**
+   * Maximum bytes queued in the WebSocket before local reads pause. Bounds
+   * memory when the local service produces data faster than the tunnel drains.
+   * @default 4194304
+   */
+  maxBufferedBytes?: number;
+  /**
    * Local TCP connect timeout in milliseconds.
    * @default 10000
    */
@@ -167,6 +173,9 @@ export async function startReverseTcpTunnel(
   const logLevel = options.logLevel ?? 'info';
   const maxConnections = options.maxConnections ?? 64;
   const maxPendingBytesPerConnection = options.maxPendingBytesPerConnection ?? 16 * 1024 * 1024;
+  const maxBufferedBytes = options.maxBufferedBytes ?? 4 * 1024 * 1024;
+  // Hysteresis: resume well below the pause threshold to avoid flapping.
+  const resumeBelowBufferedBytes = maxBufferedBytes / 4;
   const connectTimeoutMs = options.connectTimeoutMs ?? 10_000;
 
   const logger = {
@@ -200,6 +209,8 @@ export async function startReverseTcpTunnel(
     let connectionState: TunnelConnectionState = 'connecting';
     let hasResolved = false;
     let remoteAddress: ReverseTunnel['remoteAddress'] | undefined;
+    // The WebSocket is shared by all connections, so backpressure is tunnel-wide.
+    let pausedForBackpressure = false;
 
     const updateConnectionState = (newState: TunnelConnectionState): void => {
       if (connectionState !== newState) {
@@ -218,6 +229,28 @@ export async function startReverseTcpTunnel(
     const sendCloseSignal = (connId: number): void => {
       if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(encodeConnectionHeader(connId));
+      }
+    };
+
+    const pauseForBackpressure = (): void => {
+      if (pausedForBackpressure) return;
+      pausedForBackpressure = true;
+      logger.debug('WebSocket send buffer full, pausing local reads');
+      for (const socket of connections.values()) {
+        if (!socket.destroyed) socket.pause();
+      }
+    };
+
+    // Called from ws.send completion callbacks. Sends and callbacks are 1:1
+    // and pausing happens after at least one send is queued, so the callback
+    // that observes a drained buffer is guaranteed to exist; no polling needed.
+    const resumeIfDrained = (): void => {
+      if (!pausedForBackpressure) return;
+      if (!ws || ws.bufferedAmount >= resumeBelowBufferedBytes) return;
+      pausedForBackpressure = false;
+      logger.debug('WebSocket send buffer drained, resuming local reads');
+      for (const socket of connections.values()) {
+        if (!socket.destroyed) socket.resume();
       }
     };
 
@@ -266,6 +299,7 @@ export async function startReverseTcpTunnel(
       for (const connId of Array.from(connections.keys())) {
         removeConnection(connId, false);
       }
+      pausedForBackpressure = false;
       connections.clear();
       connecting.clear();
       pendingPerConn.clear();
@@ -372,6 +406,9 @@ export async function startReverseTcpTunnel(
       connecting.add(connId);
 
       const socket = net.createConnection({ host: localHost, port: localPort });
+      if (pausedForBackpressure) {
+        socket.pause();
+      }
       connections.set(connId, socket);
       const connectTimer = setTimeout(() => {
         logger.error(`Local TCP connect timed out conn=${connId} after ${connectTimeoutMs}ms`);
@@ -387,13 +424,22 @@ export async function startReverseTcpTunnel(
         flushPending(connId, socket);
       });
 
+      const header = encodeConnectionHeader(connId);
+      const onSent = (err?: Error): void => {
+        if (err) {
+          logger.error(`Failed to send conn=${connId} data: ${err.message}`);
+        }
+        resumeIfDrained();
+      };
       socket.on('data', (chunk: Buffer) => {
         if (ws && ws.readyState === WebSocket.OPEN) {
-          ws.send(Buffer.concat([encodeConnectionHeader(connId), chunk]), (err) => {
-            if (err) {
-              logger.error(`Failed to send conn=${connId} data: ${err.message}`);
-            }
-          });
+          const framed = Buffer.allocUnsafe(4 + chunk.length);
+          header.copy(framed, 0);
+          chunk.copy(framed, 4);
+          ws.send(framed, onSent);
+          if (!pausedForBackpressure && ws.bufferedAmount > maxBufferedBytes) {
+            pauseForBackpressure();
+          }
         }
       });
 

--- a/tests/reverse-tunnel.test.ts
+++ b/tests/reverse-tunnel.test.ts
@@ -1,5 +1,21 @@
+import net from 'net';
+import { WebSocketServer, type WebSocket } from 'ws';
 import { deriveReverseTunnelUrl } from '../src/ios-client';
-import { decodeConnectionHeader, encodeConnectionHeader } from '../src/tunnel';
+import {
+  startReverseTcpTunnel,
+  decodeConnectionHeader,
+  encodeConnectionHeader,
+  type ReverseTunnel,
+} from '../src/tunnel';
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
 
 describe('reverse tunnel helpers', () => {
   test('deriveReverseTunnelUrl preserves the iOS api path', () => {
@@ -19,4 +35,133 @@ describe('reverse tunnel helpers', () => {
       expect(decodeConnectionHeader(encodeConnectionHeader(connId))).toBe(connId);
     }
   });
+});
+
+// Mock of limulator's reverse-tunnel side: sends the ready control message on
+// connect and counts the bytes of every [4-byte connID][payload] frame the
+// client sends. Empty payloads are close signals.
+function mockRemote(socket: WebSocket): {
+  bytesByConn: Map<number, number>;
+  closedConns: number[];
+} {
+  const bytesByConn = new Map<number, number>();
+  const closedConns: number[] = [];
+  socket.on('message', (data: Buffer, isBinary: boolean) => {
+    if (!isBinary) return;
+    const connId = decodeConnectionHeader(data.subarray(0, 4));
+    const payloadLength = data.length - 4;
+    if (payloadLength === 0) {
+      closedConns.push(connId);
+      return;
+    }
+    bytesByConn.set(connId, (bytesByConn.get(connId) ?? 0) + payloadLength);
+  });
+  socket.send(JSON.stringify({ type: 'ready', remoteHost: '10.0.0.1', remotePort: 57090 }));
+  return { bytesByConn, closedConns };
+}
+
+describe('reverse tunnel data path', () => {
+  let server: WebSocketServer;
+  let remoteWs: WebSocket | undefined;
+  let remoteState: ReturnType<typeof mockRemote> | undefined;
+  let localServer: net.Server | undefined;
+  let localPort: number;
+  let tunnel: ReverseTunnel | undefined;
+
+  beforeEach(async () => {
+    server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    server.on('connection', (socket) => {
+      remoteWs = socket;
+      remoteState = mockRemote(socket);
+    });
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+  });
+
+  afterEach(async () => {
+    tunnel?.close();
+    tunnel = undefined;
+    remoteWs = undefined;
+    remoteState = undefined;
+    if (localServer) {
+      await new Promise<void>((resolve) => localServer!.close(() => resolve()));
+      localServer = undefined;
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function serverUrl(): string {
+    const addr = server.address() as net.AddressInfo;
+    return `ws://127.0.0.1:${addr.port}/reverse-tunnel?remotePort=57090`;
+  }
+
+  async function startLocalServer(onConnection: (socket: net.Socket) => void): Promise<void> {
+    const server = net.createServer(onConnection);
+    localServer = server;
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    localPort = (server.address() as net.AddressInfo).port;
+  }
+
+  function frame(connId: number, payload: Buffer | string): Buffer {
+    return Buffer.concat([encodeConnectionHeader(connId), Buffer.from(payload)]);
+  }
+
+  function receivedBytes(connId: number): number {
+    return remoteState?.bytesByConn.get(connId) ?? 0;
+  }
+
+  test('relays a response and signals close only after the local source closes', async () => {
+    const reply = Buffer.alloc(64 * 1024, 0x42);
+    await startLocalServer((socket) => {
+      socket.once('data', () => {
+        // HTTP/1.0-style source: write the full response, then close.
+        socket.end(reply);
+      });
+    });
+
+    tunnel = await startReverseTcpTunnel(serverUrl(), 'test-token', {
+      localPort,
+      logLevel: 'none',
+    });
+    expect(tunnel.remoteAddress).toEqual({ address: '10.0.0.1', port: 57090 });
+
+    remoteWs!.send(frame(1, 'GET /bundle'));
+    await waitFor(() => (remoteState?.closedConns ?? []).includes(1));
+
+    // Every response byte must have arrived before the close signal.
+    expect(receivedBytes(1)).toBe(reply.length);
+  });
+
+  test('pauses local reads when the WebSocket buffer fills and still delivers everything', async () => {
+    const total = 8 * 1024 * 1024;
+    let sourceFlushed = false;
+    await startLocalServer((socket) => {
+      socket.once('data', () => {
+        socket.write(Buffer.alloc(total, 0x37), () => {
+          sourceFlushed = true;
+        });
+      });
+    });
+
+    tunnel = await startReverseTcpTunnel(serverUrl(), 'test-token', {
+      localPort,
+      logLevel: 'none',
+      maxBufferedBytes: 256 * 1024,
+    });
+
+    // Stall the remote's raw TCP socket so the client's bufferedAmount grows.
+    const rawRemoteSocket = (remoteWs as any)._socket as net.Socket;
+    rawRemoteSocket.pause();
+
+    remoteWs!.send(frame(1, 'GET /bundle'));
+
+    // With backpressure the client stops reading, so the source cannot flush
+    // 8MB into it: only the buffer cap plus kernel buffers fit. Without the
+    // fix the whole payload is consumed immediately and the flush completes.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(sourceFlushed).toBe(false);
+
+    rawRemoteSocket.resume();
+    await waitFor(() => receivedBytes(1) === total, 15000);
+    await waitFor(() => sourceFlushed);
+  }, 20000);
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes hot-path forwarding and flow control for multiplexed reverse tunnels; mis-tuned thresholds or pause/resume bugs could stall or drop large transfers, though defaults and tests target memory safety without altering the wire protocol.
> 
> **Overview**
> Adds **tunnel-wide backpressure** on the reverse TCP tunnel when the shared WebSocket send queue grows too large, so a fast local dev server cannot unboundedly buffer outbound frames in memory.
> 
> New option **`maxBufferedBytes`** (default 4MB) caps `ws.bufferedAmount`. Above that threshold the client **pauses all active local TCP sockets**; it **resumes** once the queue drains below one quarter of that limit (hysteresis). Drain detection uses **`ws.send` completion callbacks**, including for header-only close frames, so resume still runs when the last queued messages are closes rather than data. New local connections inherit the paused state when backpressure is active.
> 
> Outbound framing now **reuses the connection header** and writes into a single buffer per chunk instead of `Buffer.concat` on every `data` event. Integration tests cover full relay/close ordering and the pause-until-drain behavior when the remote TCP socket is stalled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2628919c83cf79911b7b6b261135941006557e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->