### PR TITLE
cli: update CI and limx-from for yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,15 +116,15 @@ jobs:
 
       - name: Install CLI dependencies
         working-directory: packages/cli
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Build CLI
         working-directory: packages/cli
-        run: npm run build
+        run: yarn build
 
       - name: Test CLI
         working-directory: packages/cli
-        run: npm test
+        run: yarn test
 
       - name: Smoke test lim run help
         working-directory: packages/cli

--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/cli
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Build
         working-directory: packages/cli
-        run: npm run build
+        run: yarn build
 
       - name: Publish lim
         working-directory: packages/cli

--- a/hack/limx-from
+++ b/hack/limx-from
@@ -17,7 +17,7 @@
 #   - CLI change:  `yarn --cwd packages/cli build`
 #   - check state: `limx --where`
 #
-# Note: any `npm ci`/`npm install` inside packages/cli restores the registry copy
+# Note: any `yarn install`/`npm install` inside packages/cli restores the registry copy
 # of @limrun/api. Re-run `limx-from` to re-link the local build.
 
 set -euo pipefail
@@ -85,12 +85,11 @@ cmd_link() {
   [ -f "$repo/packages/cli/package.json" ] || die "no packages/cli in $repo"
 
   # Ensure dependencies are installed (fresh worktrees have no node_modules).
-  # Root SDK is yarn-managed; the CLI is npm-managed (CI runs `npm ci` in packages/cli).
   [ -d "$repo/node_modules" ] || yarn --cwd "$repo" install
-  [ -d "$repo/packages/cli/node_modules" ] || npm --prefix "$repo/packages/cli" ci
+  [ -d "$repo/packages/cli/node_modules" ] || yarn --cwd "$repo/packages/cli" install --frozen-lockfile
 
   # Build SDK (via the CLI's prebuild, which runs yarn at the root) then the CLI.
-  npm --prefix "$repo/packages/cli" run build
+  yarn --cwd "$repo/packages/cli" build
 
   # Link the locally built SDK into the CLI's node_modules.
   local link="$repo/packages/cli/node_modules/@limrun/api"
@@ -115,7 +114,7 @@ esac
 link="$LIMX_SOURCE/packages/cli/node_modules/@limrun/api"
 if [ ! -L "$link" ]; then
   echo "limx: local SDK link missing at $link" >&2
-  echo "limx: an 'npm ci'/install likely restored the published copy; run 'limx-from \"$LIMX_SOURCE\"' to relink" >&2
+  echo "limx: a 'yarn install' likely restored the published copy; run 'limx-from \"$LIMX_SOURCE\"' to relink" >&2
   exit 1
 fi
 exec node "$LIMX_SOURCE/packages/cli/bin/run.js" "$@"
@@ -130,7 +129,7 @@ EOF
   echo "  SDK: $repo/dist (linked into packages/cli/node_modules/@limrun/api)"
   echo "  CLI: built (bin/run.js)"
   echo "check anytime:  limx --where"
-  echo "note: re-run limx-from after any \`npm ci\`/install in packages/cli (it restores the registry copy)"
+  echo "note: re-run limx-from after any \`yarn install\` in packages/cli (it restores the registry copy)"
 
   case ":$PATH:" in
     *":$BIN_DIR:"*) ;;

--- a/tests/xcode-client-webhook.test.ts
+++ b/tests/xcode-client-webhook.test.ts
@@ -8,7 +8,7 @@ jest.mock('eventsource-client', () => ({
 import Limrun from '@limrun/api';
 import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
 import type { RequestInfo } from '../src/internal/builtin-types';
-import { createEventSource } from 'eventsource-client';
+import { createEventSource, type EventSourceOptions } from 'eventsource-client';
 
 const originalFetch = nodeProxyTransport.fetch;
 
@@ -89,20 +89,17 @@ describe('xcode client build-finish webhook', () => {
       }
       throw new Error(`unexpected request: ${input}`);
     });
-    jest
-      .mocked(createEventSource)
-      .mockImplementationOnce(
-        (options: { onMessage: (message: { event: string; data: string }) => void }) => {
-          setTimeout(() => {
-            options.onMessage({
-              event: 'testflight',
-              data: JSON.stringify({ state: 'accepted', uploadId: 'upload-1' }),
-            });
-            options.onMessage({ event: 'exitCode', data: '0' });
-          }, 0);
-          return { close: jest.fn() } as never;
-        },
-      );
+    jest.mocked(createEventSource).mockImplementationOnce((optionsOrUrl) => {
+      const { onMessage } = optionsOrUrl as EventSourceOptions;
+      setTimeout(() => {
+        onMessage?.({
+          event: 'testflight',
+          data: JSON.stringify({ state: 'accepted', uploadId: 'upload-1' }),
+        });
+        onMessage?.({ event: 'exitCode', data: '0' });
+      }, 0);
+      return { close: jest.fn() } as never;
+    });
 
     const client = new Limrun({ apiKey: 'key' });
     const xcode = await client.xcodeInstances.createClient({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tooling and test-only changes; no runtime SDK or auth behavior changes, with publish still using npm publish.
> 
> **Overview**
> **`packages/cli` is now installed and built with Yarn** across CI, publish, and local dev tooling, replacing `npm ci` / `npm run` with `yarn install --frozen-lockfile`, `yarn build`, and `yarn test`. The **cli** and **Publish lim CLI** workflows follow that pattern; **`npm pack --dry-run`** and **`npm publish --provenance`** are unchanged.
> 
> **`hack/limx-from`** matches the same workflow: it bootstraps CLI deps with Yarn, builds via `yarn --cwd packages/cli build`, and updates help/error text so relinking is needed after `yarn install` in `packages/cli`.
> 
> A small test fix in **`xcode-client-webhook.test.ts`** types the `createEventSource` mock with **`EventSourceOptions`** and uses optional `onMessage` when simulating TestFlight SSE events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4d8dae7036b008f8423a51b2f6ad6678760565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->