### PR TITLE
ios,cli: run stock Maestro against remote simulators via a forward proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ packages/xdelta3-wasm/native/build/
 .idea/
 .eslintcache
 .env
-examples/detox-ios/artifacts/
+examples/*/artifacts/
+examples/maestro-ios/video.mp4
+examples/maestro-ios/*.png

--- a/examples/maestro-ios/README.md
+++ b/examples/maestro-ios/README.md
@@ -1,7 +1,9 @@
 # Maestro with Expo Go on Limrun iOS
 
 This example runs an upstream Maestro YAML flow against a small Expo Go sample
-app on a Limrun remote iOS simulator.
+app on a Limrun remote iOS simulator. It works with stock Maestro 2.5.x and
+2.6+ (the driver port handling changed in 2.6.0; the example detects the
+installed version and adapts).
 
 It targets
 [github.com/limrun-inc/sample-expo-test-app](https://github.com/limrun-inc/sample-expo-test-app),
@@ -52,7 +54,11 @@ yarn start
 
 1. Creates or reuses a remote iOS simulator with Expo Go 54 and Maestro Runner installed.
 1. Launches the compatible Maestro XCTest runner if it is not already running.
-1. Starts a scoped `xcrun` shim and local HTTP proxy from the iOS client for upstream Maestro.
+1. Starts a scoped `xcrun` shim and a local HTTP forward proxy from the iOS client. The
+   JVM proxy settings route Maestro's driver traffic through the proxy to the remote
+   runner, so the local driver port never needs to exist.
 1. Runs `maestro test --platform ios` against the Limrun simulator.
+
+The same wiring is available as a single CLI command: `lim ios maestro test <flow>`.
 
 The default flow lives in `flows/expo-sample.yaml`.

--- a/examples/maestro-ios/README.md
+++ b/examples/maestro-ios/README.md
@@ -56,7 +56,9 @@ yarn start
 1. Launches the compatible Maestro XCTest runner if it is not already running.
 1. Starts a scoped `xcrun` shim and a local HTTP forward proxy from the iOS client. The
    JVM proxy settings route Maestro's driver traffic through the proxy to the remote
-   runner, so the local driver port never needs to exist.
+   runner, so the local driver port never needs to exist. The proxy forwards only the
+   driver port, so flows that call out from `runScript`/`evalScript` should use `https`
+   URLs (those bypass the proxy); plain `http` calls are refused.
 1. Runs `maestro test --platform ios` against the Limrun simulator.
 
 The same wiring is available as a single CLI command: `lim ios maestro test <flow>`.

--- a/examples/maestro-ios/index.ts
+++ b/examples/maestro-ios/index.ts
@@ -8,6 +8,7 @@ import {
   isMaestroRunnerRunning,
   maestroSpawnOptions,
   prepareMaestroRun,
+  waitForMaestroRunner,
 } from '@limrun/api';
 
 const apiKey = process.env['LIM_API_KEY'];
@@ -73,6 +74,9 @@ try {
       .wait();
     if (launch.code !== 0) {
       throw new Error(`Failed to launch the Maestro runner (exit code ${launch.code}): ${launch.stderr}`);
+    }
+    if (!(await waitForMaestroRunner(runnerUrl, instance.status.token))) {
+      throw new Error('The Maestro runner did not become ready in time.');
     }
     console.log('Runner launched');
   }

--- a/examples/maestro-ios/index.ts
+++ b/examples/maestro-ios/index.ts
@@ -1,10 +1,14 @@
-import path from 'node:path';
 import { spawn } from 'node:child_process';
 
-import { Limrun, Ios } from '@limrun/api';
-
-const MAESTRO_DRIVER_PORT = 7001;
-const MAESTRO_RUNNER_PORT = 22087;
+import {
+  Limrun,
+  Ios,
+  MAESTRO_RUNNER_BUNDLE_ID,
+  MAESTRO_RUNNER_PORT,
+  isMaestroRunnerRunning,
+  maestroSpawnOptions,
+  prepareMaestroRun,
+} from '@limrun/api';
 
 const apiKey = process.env['LIM_API_KEY'];
 const expoUrl = process.env['EXPO_URL'];
@@ -45,98 +49,69 @@ console.timeEnd('create');
 if (instance.status.signedStreamUrl) {
   console.log('Limrun stream:', instance.status.signedStreamUrl);
 }
-if (!instance.status.apiUrl || !instance.status.targetHttpPortUrlPrefix) {
-  throw new Error('Necessary URLs are missing');
-}
-const lim = await Ios.createInstanceClient({
-  apiUrl: instance.status.apiUrl,
-  token: instance.status.token,
-});
-console.log('Device UDID:', lim.deviceInfo.udid);
-// targetHttpPortUrlPrefix allows us to append any port to the URL to connect to that port
-// on the simulator and the patched Maestro runner listens on MAESTRO_RUNNER_PORT.
-const runnerUrl = instance.status.targetHttpPortUrlPrefix + String(MAESTRO_RUNNER_PORT);
-
-// The runner may crash during the test and launchMode in initialAssets is effective only for
-// the first installation. So, we make sure the runner is running before the test starts.
-let wdaRunning = true;
+let lim: Ios.InstanceClient | undefined;
 try {
-  const controller = new AbortController();
-  setTimeout(() => controller.abort(), 3000);
-  await fetch(runnerUrl + '/status', {
-    headers: {
-      Authorization: `Bearer ${instance.status.token}`,
-    },
-    signal: controller.signal,
-  });
-} catch (_) {
-  wdaRunning = false;
-}
-if (!wdaRunning) {
-  console.log('Runner is not running, launching it...');
-  // The patched runner listens on MAESTRO_RUNNER_PORT by default, so launching it is enough.
-  const launch = await lim
-    .simctl([
-      'launch',
-      '--terminate-running-process',
-      'booted',
-      'dev.mobile.maestro-driver-iosUITests.xctrunner',
-    ])
-    .wait();
-  if (launch.code !== 0) {
-    throw new Error(`Failed to launch the Maestro runner (exit code ${launch.code}): ${launch.stderr}`);
+  if (!instance.status.apiUrl || !instance.status.targetHttpPortUrlPrefix) {
+    throw new Error('Necessary URLs are missing');
   }
-  console.log('Runner launched');
-}
-
-const shimDir = await lim.startXcrunShim();
-const proxyPort = await lim.startHttpProxy({
-  remoteBaseUrl: instance.status.targetHttpPortUrlPrefix + String(MAESTRO_RUNNER_PORT),
-  localPort: MAESTRO_DRIVER_PORT,
-});
-console.log(`Proxying local port ${proxyPort} to remote runner port ${MAESTRO_RUNNER_PORT}`);
-await lim.startRecording();
-console.log('Recording started');
-try {
-  const env = {
-    ...process.env,
-    MAESTRO_EXPO_URL: expoUrl,
-    PATH: `${shimDir}${path.delimiter}${process.env['PATH'] ?? ''}`,
-    USE_XCODE_TEST_RUNNER: '1',
-  };
-  const proc = spawn(
-    'maestro',
-    [
-      'test',
-      '--platform',
-      'ios',
-      '--device',
-      lim.deviceInfo.udid,
-      '--no-reinstall-driver',
-      '--test-output-dir',
-      'artifacts',
-      'flows/expo-sample.yaml',
-    ],
-    {
-      cwd: process.cwd(),
-      env,
-      stdio: 'inherit',
-    },
-  );
-  await new Promise<void>((resolve, reject) => {
-    proc.once('error', reject);
-    proc.once('close', (code, signal) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(new Error(`maestro exited with ${signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`}`));
-    });
+  lim = await Ios.createInstanceClient({
+    apiUrl: instance.status.apiUrl,
+    token: instance.status.token,
   });
+  console.log('Device UDID:', lim.deviceInfo.udid);
+  // targetHttpPortUrlPrefix allows us to append any port to the URL to connect to that port
+  // on the simulator and the patched Maestro runner listens on MAESTRO_RUNNER_PORT.
+  const runnerUrl = instance.status.targetHttpPortUrlPrefix + String(MAESTRO_RUNNER_PORT);
+
+  // The runner may crash during the test and launchMode in initialAssets is effective only for
+  // the first installation. So, we make sure the runner is running before the test starts.
+  if (!(await isMaestroRunnerRunning(runnerUrl, instance.status.token))) {
+    console.log('Runner is not running, launching it...');
+    // The patched runner listens on MAESTRO_RUNNER_PORT by default, so launching it is enough.
+    const launch = await lim
+      .simctl(['launch', '--terminate-running-process', 'booted', MAESTRO_RUNNER_BUNDLE_ID])
+      .wait();
+    if (launch.code !== 0) {
+      throw new Error(`Failed to launch the Maestro runner (exit code ${launch.code}): ${launch.stderr}`);
+    }
+    console.log('Runner launched');
+  }
+
+  // Wires the local stock maestro CLI to the remote runner: xcrun shim on PATH
+  // plus JVM proxy settings that route the driver's HTTP to the instance.
+  const run = await prepareMaestroRun(lim, { runnerUrl });
+  console.log(
+    `Maestro ${run.maestroVersion}: driver port ${run.driverPort} -> remote runner port ${MAESTRO_RUNNER_PORT}`,
+  );
+  await lim.startRecording();
+  console.log('Recording started');
+  try {
+    const proc = spawn(
+      'maestro',
+      ['test', ...run.args, '--test-output-dir', 'artifacts', 'flows/expo-sample.yaml'],
+      {
+        ...maestroSpawnOptions,
+        cwd: process.cwd(),
+        env: { ...process.env, ...run.env, MAESTRO_EXPO_URL: expoUrl },
+        stdio: 'inherit',
+      },
+    );
+    await new Promise<void>((resolve, reject) => {
+      proc.once('error', reject);
+      proc.once('close', (code, signal) => {
+        if (code === 0) {
+          resolve();
+          return;
+        }
+        reject(new Error(`maestro exited with ${signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`}`));
+      });
+    });
+  } finally {
+    await lim.stopRecording({ localPath: 'video.mp4' });
+    console.log('Recording stopped');
+  }
 } finally {
-  await lim.stopRecording({ localPath: 'video.mp4' });
-  console.log('Recording stopped');
-  lim.disconnect();
+  lim?.disconnect();
   await limrun.iosInstances.delete(instance.metadata.id);
   console.log('Instance deleted');
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -309,6 +309,23 @@ lim ios sync ./MyApp.app --watch --launch-mode RelaunchIfRunning
 lim ios sync ./MyApp.app --basis-cache-dir ./.limsync-cache
 ```
 
+#### Maestro (iOS only)
+
+Run the locally installed [Maestro](https://docs.maestro.dev) CLI against a remote
+Limrun simulator. The command installs and launches the Maestro XCTest runner on
+the instance when needed, then wires `maestro test` to it transparently.
+
+```bash
+lim ios maestro test flow.yaml
+lim ios maestro test flows/
+
+# Extra maestro flags go after --
+lim ios maestro -- test flow.yaml --include-tags smoke --test-output-dir artifacts
+
+# Creating the instance with the runner preinstalled skips the install step
+lim ios create --install-asset appstore/maestro-ios-runner-2.5.1.tar.gz
+```
+
 ---
 
 ### Android

--- a/packages/cli/src/commands/ios/maestro.ts
+++ b/packages/cli/src/commands/ios/maestro.ts
@@ -7,6 +7,7 @@ import {
   isMaestroRunnerRunning,
   maestroSpawnOptions,
   prepareMaestroRun,
+  waitForMaestroRunner,
 } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
 import { getIosInstanceClient } from '../../lib/instance-client-factory';
@@ -103,6 +104,9 @@ export default class IosMaestro extends BaseCommand {
             .wait();
           if (launch.code !== 0) {
             this.error(`Failed to launch the Maestro runner (exit code ${launch.code}): ${launch.stderr}`);
+          }
+          if (!(await waitForMaestroRunner(runnerUrl, token))) {
+            this.error('The Maestro runner did not become ready in time.');
           }
         }
 

--- a/packages/cli/src/commands/ios/maestro.ts
+++ b/packages/cli/src/commands/ios/maestro.ts
@@ -1,0 +1,130 @@
+import { spawn } from 'node:child_process';
+
+import { Flags } from '@oclif/core';
+import {
+  MAESTRO_RUNNER_BUNDLE_ID,
+  MAESTRO_RUNNER_PORT,
+  isMaestroRunnerRunning,
+  maestroSpawnOptions,
+  prepareMaestroRun,
+} from '@limrun/api';
+import { BaseCommand } from '../../base-command';
+import { getIosInstanceClient } from '../../lib/instance-client-factory';
+import { INJECTED_MAESTRO_FLAGS, MAESTRO_RUNNER_ASSET_NAME } from '../../lib/maestro';
+
+export default class IosMaestro extends BaseCommand {
+  static summary = 'Run Maestro flows against a running iOS instance';
+  static description =
+    'Run the locally installed Maestro CLI against a remote Limrun iOS simulator. ' +
+    'Ensures the Maestro XCTest runner is installed and running on the instance, then wires ' +
+    'the local `maestro test` invocation to it transparently. Pass Maestro arguments after `--`. ' +
+    `Creating the instance with \`--install-asset ${MAESTRO_RUNNER_ASSET_NAME}\` skips the install step here.`;
+  static examples = [
+    '<%= config.bin %> ios maestro test flow.yaml',
+    '<%= config.bin %> ios maestro test flows/',
+    '<%= config.bin %> ios maestro -- test flow.yaml --include-tags smoke --test-output-dir artifacts',
+  ];
+
+  static strict = false;
+
+  static args = {};
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const parsed = await this.parse(IosMaestro as any);
+    const flags = parsed.flags as Record<string, any>;
+    const rawArgs = (parsed.argv as string[]) ?? [];
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      if (rawArgs[0] !== 'test') {
+        this.error(
+          'Provide a maestro test invocation, for example `lim ios maestro test flow.yaml`. ' +
+            'Only the `test` subcommand is supported.',
+        );
+      }
+      const passthroughArgs = rawArgs.slice(1);
+      for (const arg of passthroughArgs) {
+        const flagName = arg.split('=')[0];
+        if (flagName && INJECTED_MAESTRO_FLAGS.includes(flagName)) {
+          this.error(`${flagName} is set by lim automatically, remove it from the maestro arguments.`);
+        }
+      }
+
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const id = resolvedInstance.id;
+
+      let { targetHttpPortUrlPrefix, token } = resolvedInstance;
+      if (!targetHttpPortUrlPrefix || !token) {
+        const instance = await this.client.iosInstances.get(id);
+        targetHttpPortUrlPrefix = instance.status.targetHttpPortUrlPrefix;
+        token = instance.status.token;
+        // Forward the fresh endpoints so getIosInstanceClient connects directly
+        // instead of fetching the instance a second time.
+        resolvedInstance.apiUrl = instance.status.apiUrl;
+        resolvedInstance.token = token;
+      }
+      if (!targetHttpPortUrlPrefix || !token) {
+        this.error(`Instance ${id} does not expose the HTTP port URL required for Maestro.`);
+      }
+      const runnerUrl = targetHttpPortUrlPrefix + String(MAESTRO_RUNNER_PORT);
+
+      // A responding runner proves it is installed, so the common path skips
+      // the listApps round trip entirely.
+      const [{ client, disconnect }, runnerRunning] = await Promise.all([
+        getIosInstanceClient(this.client, resolvedInstance),
+        isMaestroRunnerRunning(runnerUrl, token),
+      ]);
+      try {
+        if (!runnerRunning) {
+          const apps = await client.listApps();
+          if (!apps.some((app) => app.bundleId === MAESTRO_RUNNER_BUNDLE_ID)) {
+            this.info('Installing the Maestro runner on the instance...');
+            const assets = await this.client.assets.list({
+              nameFilter: MAESTRO_RUNNER_ASSET_NAME,
+              includeAppStore: true,
+              includeDownloadUrl: true,
+            });
+            const runnerAsset = assets.find((asset) => asset.name === MAESTRO_RUNNER_ASSET_NAME);
+            if (!runnerAsset?.signedDownloadUrl) {
+              this.error(`Maestro runner asset ${MAESTRO_RUNNER_ASSET_NAME} is not available.`);
+            }
+            await client.installApp(runnerAsset.signedDownloadUrl);
+          }
+          this.info('Launching the Maestro runner...');
+          const launch = await client
+            .simctl(['launch', '--terminate-running-process', 'booted', MAESTRO_RUNNER_BUNDLE_ID])
+            .wait();
+          if (launch.code !== 0) {
+            this.error(`Failed to launch the Maestro runner (exit code ${launch.code}): ${launch.stderr}`);
+          }
+        }
+
+        const run = await prepareMaestroRun(client, { runnerUrl });
+        this.info(`Running maestro ${run.maestroVersion} against ${id}...`);
+        const exitCode = await new Promise<number>((resolve, reject) => {
+          const proc = spawn('maestro', ['test', ...run.args, ...passthroughArgs], {
+            ...maestroSpawnOptions,
+            env: { ...process.env, ...run.env },
+            stdio: 'inherit',
+          });
+          proc.once('error', reject);
+          // Maestro already reported to the inherited stdio; a signal death
+          // simply becomes a nonzero exit.
+          proc.once('close', (code, signal) => resolve(signal ? 1 : code ?? 1));
+        });
+        if (exitCode !== 0) {
+          this.exit(exitCode);
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/src/lib/maestro.ts
+++ b/packages/cli/src/lib/maestro.ts
@@ -1,0 +1,16 @@
+// The patched runner has proven version-agnostic so far: Maestro CLI 2.7.0
+// drives this 2.5.1-built runner including the newer endpoints (swipeV2,
+// isScreenStatic, setOrientation). Bump only when a CLI release actually
+// requires a newer runner.
+export const MAESTRO_RUNNER_ASSET_NAME = 'appstore/maestro-ios-runner-2.5.1.tar.gz';
+
+// Flags `lim ios maestro` injects itself; user-provided duplicates would make
+// maestro's picocli parser fail with a confusing error.
+export const INJECTED_MAESTRO_FLAGS = [
+  '--platform',
+  '-p',
+  '--device',
+  '--udid',
+  '--no-reinstall-driver',
+  '--driver-host-port',
+];

--- a/src/http-proxy.ts
+++ b/src/http-proxy.ts
@@ -87,10 +87,10 @@ function withoutHopByHop(headers: http.IncomingHttpHeaders): http.IncomingHttpHe
 }
 
 /**
- * Loopback-only HTTP forward proxy (absolute-form request targets, as sent by
- * clients configured with e.g. JVM -Dhttp.proxyHost) that rewrites loopback
- * requests on `matchPort` to `remoteBaseUrl`, passes other loopback targets
- * through untouched, and refuses everything else.
+ * Single-destination HTTP forward proxy (absolute-form request targets, as sent
+ * by clients configured with e.g. JVM -Dhttp.proxyHost). Loopback requests on
+ * `matchPort` are forwarded to `remoteBaseUrl`; every other target is refused,
+ * so the proxy can only ever reach the destination it was configured with.
  */
 export async function startForwardHttpProxy({
   matchPort,
@@ -117,19 +117,17 @@ export async function startForwardHttpProxy({
       return;
     }
 
-    // Only loopback targets are ever proxied: the driver port rewrite plus a
-    // client's own local plain-HTTP services. Anything else is refused so this
-    // proxy cannot be used to reach arbitrary hosts.
-    if (!isLoopbackHost(target.hostname)) {
+    // matchPort is always explicit (an ephemeral port or 7001), so a target
+    // without a port can never match. Anything else is refused rather than
+    // forwarded: the requested host never selects the destination, so this
+    // proxy cannot be pointed at another host.
+    if (!isLoopbackHost(target.hostname) || Number(target.port) !== matchPort) {
       res.writeHead(403, { 'content-type': 'text/plain' });
-      res.end('Limrun forward proxy only forwards loopback targets.');
+      res.end(`Limrun forward proxy only forwards 127.0.0.1:${matchPort}.`);
       return;
     }
 
-    // matchPort is always explicit (an ephemeral port or 7001), so a target
-    // without a port can never match.
-    const matched = Number(target.port) === matchPort;
-    const upstreamUrl = matched ? new URL(`${base}${target.pathname}${target.search}`) : target;
+    const upstreamUrl = new URL(`${base}${target.pathname}${target.search}`);
     const transport = upstreamUrl.protocol === 'https:' ? https : http;
     const upstream = transport.request(
       upstreamUrl,
@@ -139,7 +137,7 @@ export async function startForwardHttpProxy({
         headers: {
           ...withoutHopByHop(req.headers),
           host: upstreamUrl.host,
-          ...(matched ? headers : {}),
+          ...headers,
         },
       },
       (upstreamResponse) => {

--- a/src/http-proxy.ts
+++ b/src/http-proxy.ts
@@ -87,9 +87,10 @@ function withoutHopByHop(headers: http.IncomingHttpHeaders): http.IncomingHttpHe
 }
 
 /**
- * Standard HTTP forward proxy (absolute-form request targets, as sent by clients
- * configured with e.g. JVM -Dhttp.proxyHost) that rewrites loopback requests on
- * `matchPort` to `remoteBaseUrl` and passes every other target through untouched.
+ * Loopback-only HTTP forward proxy (absolute-form request targets, as sent by
+ * clients configured with e.g. JVM -Dhttp.proxyHost) that rewrites loopback
+ * requests on `matchPort` to `remoteBaseUrl`, passes other loopback targets
+ * through untouched, and refuses everything else.
  */
 export async function startForwardHttpProxy({
   matchPort,
@@ -116,9 +117,18 @@ export async function startForwardHttpProxy({
       return;
     }
 
+    // Only loopback targets are ever proxied: the driver port rewrite plus a
+    // client's own local plain-HTTP services. Anything else is refused so this
+    // proxy cannot be used to reach arbitrary hosts.
+    if (!isLoopbackHost(target.hostname)) {
+      res.writeHead(403, { 'content-type': 'text/plain' });
+      res.end('Limrun forward proxy only forwards loopback targets.');
+      return;
+    }
+
     // matchPort is always explicit (an ephemeral port or 7001), so a target
     // without a port can never match.
-    const matched = isLoopbackHost(target.hostname) && Number(target.port) === matchPort;
+    const matched = Number(target.port) === matchPort;
     const upstreamUrl = matched ? new URL(`${base}${target.pathname}${target.search}`) : target;
     const transport = upstreamUrl.protocol === 'https:' ? https : http;
     const upstream = transport.request(
@@ -141,9 +151,13 @@ export async function startForwardHttpProxy({
     );
 
     upstream.on('error', (error) => {
-      if (!res.headersSent) {
-        res.writeHead(502, { 'content-type': 'text/plain' });
+      if (res.headersSent) {
+        // Mid-stream failure: abort instead of appending error text to a
+        // partial body.
+        res.destroy(error);
+        return;
       }
+      res.writeHead(502, { 'content-type': 'text/plain' });
       res.end(error.message);
     });
     // A client that aborts mid-call must not leak the upstream socket.

--- a/src/http-proxy.ts
+++ b/src/http-proxy.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import https from 'https';
+import { pipeline } from 'stream';
 
 export type HttpProxy = {
   port: number;
@@ -12,6 +13,10 @@ export type StartHttpProxyOptions = {
   headers?: Record<string, string>;
 };
 
+/**
+ * Legacy origin-form reverse proxy: forwards every request on the local port
+ * to `remoteBaseUrl`. New callers should prefer `startForwardHttpProxy`.
+ */
 export async function startHttpProxy({
   localPort = 0,
   remoteBaseUrl,
@@ -56,6 +61,127 @@ export async function startHttpProxy({
     port: address.port,
     close: () => closeServer(server),
   };
+}
+
+export type StartForwardHttpProxyOptions = {
+  /** Loopback requests to this port are rewritten to remoteBaseUrl; everything else passes through. */
+  matchPort: number;
+  remoteBaseUrl: string;
+  headers?: Record<string, string>;
+};
+
+// Hop-by-hop headers must not be forwarded by an HTTP proxy (RFC 9110 §7.6.1).
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'proxy-connection',
+  'keep-alive',
+  'proxy-authorization',
+  'proxy-authenticate',
+  'te',
+  'trailer',
+  'upgrade',
+]);
+
+function withoutHopByHop(headers: http.IncomingHttpHeaders): http.IncomingHttpHeaders {
+  return Object.fromEntries(Object.entries(headers).filter(([name]) => !HOP_BY_HOP_HEADERS.has(name)));
+}
+
+/**
+ * Standard HTTP forward proxy (absolute-form request targets, as sent by clients
+ * configured with e.g. JVM -Dhttp.proxyHost) that rewrites loopback requests on
+ * `matchPort` to `remoteBaseUrl` and passes every other target through untouched.
+ */
+export async function startForwardHttpProxy({
+  matchPort,
+  remoteBaseUrl,
+  headers = {},
+}: StartForwardHttpProxyOptions): Promise<HttpProxy> {
+  const base = trimTrailingSlashes(remoteBaseUrl);
+  // The driver polls the runner continuously, so upstream connections must be
+  // reused instead of paying a TCP/TLS handshake per driver call.
+  const agents = {
+    'http:': new http.Agent({ keepAlive: true }),
+    'https:': new https.Agent({ keepAlive: true }),
+  };
+  const server = http.createServer((req, res) => {
+    let target: URL | undefined;
+    try {
+      target = new URL(req.url ?? '');
+    } catch {
+      // Falls through to the guard below.
+    }
+    if (!target || (target.protocol !== 'http:' && target.protocol !== 'https:')) {
+      res.writeHead(400, { 'content-type': 'text/plain' });
+      res.end('Limrun forward proxy only accepts absolute-form request targets.');
+      return;
+    }
+
+    // matchPort is always explicit (an ephemeral port or 7001), so a target
+    // without a port can never match.
+    const matched = isLoopbackHost(target.hostname) && Number(target.port) === matchPort;
+    const upstreamUrl = matched ? new URL(`${base}${target.pathname}${target.search}`) : target;
+    const transport = upstreamUrl.protocol === 'https:' ? https : http;
+    const upstream = transport.request(
+      upstreamUrl,
+      {
+        agent: agents[upstreamUrl.protocol as keyof typeof agents],
+        method: req.method,
+        headers: {
+          ...withoutHopByHop(req.headers),
+          host: upstreamUrl.host,
+          ...(matched ? headers : {}),
+        },
+      },
+      (upstreamResponse) => {
+        res.writeHead(upstreamResponse.statusCode ?? 502, withoutHopByHop(upstreamResponse.headers));
+        // pipeline tears down whichever side is still alive when the other one
+        // dies, instead of leaking it or raising an unhandled 'error'.
+        pipeline(upstreamResponse, res, () => {});
+      },
+    );
+
+    upstream.on('error', (error) => {
+      if (!res.headersSent) {
+        res.writeHead(502, { 'content-type': 'text/plain' });
+      }
+      res.end(error.message);
+    });
+    // A client that aborts mid-call must not leak the upstream socket.
+    res.on('close', () => {
+      if (!res.writableFinished) {
+        upstream.destroy();
+      }
+    });
+    pipeline(req, upstream, () => {});
+  });
+
+  // HTTPS clients open CONNECT tunnels; we deliberately keep TLS traffic off this
+  // proxy (only http.proxyHost is set on the JVM side), so refuse loudly instead
+  // of tunneling blind.
+  server.on('connect', (_req, socket) => {
+    socket.end('HTTP/1.1 501 Not Implemented\r\n\r\nLimrun forward proxy does not tunnel CONNECT.\r\n');
+  });
+
+  await listen(server, 0);
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to start HTTP forward proxy.');
+  }
+  return {
+    port: address.port,
+    close: async () => {
+      await closeServer(server);
+      agents['http:'].destroy();
+      agents['https:'].destroy();
+    },
+  };
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  // URL.hostname keeps brackets around IPv6 hosts.
+  return (
+    hostname === 'localhost' || hostname === '[::1]' || /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
+  );
 }
 
 function trimTrailingSlashes(value: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
 export {
   prepareMaestroRun,
   isMaestroRunnerRunning,
+  waitForMaestroRunner,
   maestroSpawnOptions,
   MAESTRO_RUNNER_BUNDLE_ID,
   MAESTRO_RUNNER_PORT,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,21 @@ export { Limrun, type ClientOptions } from './client';
 export { PagePromise } from './core/pagination';
 export * from './instance-client';
 export * as Ios from './ios-client';
-export { startHttpProxy, type HttpProxy, type StartHttpProxyOptions } from './http-proxy';
+export {
+  startHttpProxy,
+  startForwardHttpProxy,
+  type HttpProxy,
+  type StartHttpProxyOptions,
+  type StartForwardHttpProxyOptions,
+} from './http-proxy';
+export {
+  prepareMaestroRun,
+  isMaestroRunnerRunning,
+  maestroSpawnOptions,
+  MAESTRO_RUNNER_BUNDLE_ID,
+  MAESTRO_RUNNER_PORT,
+  type MaestroRun,
+} from './ios-maestro';
 export { buildSettingKeyPattern, parseBuildSettingEntries, validateBuildSettings } from './build-settings';
 export {
   exec,

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -10,7 +10,11 @@ import { createIgnoreFn } from './folder-sync-ignore';
 import { prepareAppBundlePath, watchAppArchive } from './app-archive';
 import { downloadFileToLocalPath } from './internal/download-file';
 import { nodeProxyTransport } from './internal/proxy-transport';
-import { startHttpProxy as startLocalHttpProxy } from './http-proxy';
+import {
+  startHttpProxy as startLocalHttpProxy,
+  startForwardHttpProxy as startLocalForwardHttpProxy,
+  type StartForwardHttpProxyOptions,
+} from './http-proxy';
 import { startXcrunShim as startClientXcrunShim } from './ios-shim';
 
 /**
@@ -209,6 +213,8 @@ export type HttpProxyOptions = {
   remoteBaseUrl: string;
   localPort: number;
 };
+
+export type ForwardHttpProxyOptions = Omit<StartForwardHttpProxyOptions, 'headers'>;
 
 /**
  * Targets a file operation at an installed app's container instead of the
@@ -748,6 +754,16 @@ export type InstanceClient = {
    * the client disconnects.
    */
   startHttpProxy: (options: HttpProxyOptions) => Promise<number>;
+
+  /**
+   * Start a local HTTP forward proxy (for clients driven by JVM/system proxy
+   * settings, like Maestro) that rewrites loopback requests on `matchPort` to a
+   * port exposed by the iOS instance and passes other targets through.
+   *
+   * Returns the local port the proxy is listening on. The proxy is closed when
+   * the client disconnects.
+   */
+  startForwardHttpProxy: (options: ForwardHttpProxyOptions) => Promise<number>;
 
   /**
    * Disconnect from the Limrun instance
@@ -1861,6 +1877,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             softReset,
             startReverseTunnel,
             startHttpProxy,
+            startForwardHttpProxy,
             disconnect,
             getConnectionState,
             onConnectionStateChange,
@@ -2498,6 +2515,20 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
       const proxy = await startLocalHttpProxy({
         localPort: proxyOptions.localPort,
+        remoteBaseUrl: proxyOptions.remoteBaseUrl,
+        headers: {
+          authorization: `Bearer ${options.token}`,
+        },
+      });
+      httpProxyCleanups.push(proxy.close);
+      return proxy.port;
+    };
+
+    const startForwardHttpProxy = async (proxyOptions: ForwardHttpProxyOptions): Promise<number> => {
+      assertPort(proxyOptions.matchPort, 'matchPort', 1, 65535);
+
+      const proxy = await startLocalForwardHttpProxy({
+        matchPort: proxyOptions.matchPort,
         remoteBaseUrl: proxyOptions.remoteBaseUrl,
         headers: {
           authorization: `Bearer ${options.token}`,

--- a/src/ios-maestro.ts
+++ b/src/ios-maestro.ts
@@ -88,17 +88,19 @@ export async function waitForMaestroRunner(
 
 /** Probe the remote Maestro XCTest runner's /status endpoint. */
 export async function isMaestroRunnerRunning(runnerUrl: string, token: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 3000);
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
     const response = await fetch(`${runnerUrl}/status`, {
       headers: { Authorization: `Bearer ${token}` },
       signal: controller.signal,
     });
-    clearTimeout(timeout);
     return response.ok;
   } catch {
     return false;
+  } finally {
+    // Also on failure: a pending timer keeps the event loop alive.
+    clearTimeout(timeout);
   }
 }
 

--- a/src/ios-maestro.ts
+++ b/src/ios-maestro.ts
@@ -70,6 +70,22 @@ export async function prepareMaestroRun(
   };
 }
 
+/** Poll the remote Maestro XCTest runner until it responds, e.g. right after launching it. */
+export async function waitForMaestroRunner(
+  runnerUrl: string,
+  token: string,
+  timeoutMs = 15000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isMaestroRunnerRunning(runnerUrl, token)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  return false;
+}
+
 /** Probe the remote Maestro XCTest runner's /status endpoint. */
 export async function isMaestroRunnerRunning(runnerUrl: string, token: string): Promise<boolean> {
   try {

--- a/src/ios-maestro.ts
+++ b/src/ios-maestro.ts
@@ -1,0 +1,136 @@
+import path from 'path';
+import net from 'net';
+import { execFile } from 'child_process';
+
+import type { InstanceClient } from './ios-client';
+
+export const MAESTRO_RUNNER_BUNDLE_ID = 'dev.mobile.maestro-driver-iosUITests.xctrunner';
+/** Port the patched Maestro XCTest runner listens on inside the simulator. */
+export const MAESTRO_RUNNER_PORT = 22087;
+
+// Maestro installs as a .bat/.cmd wrapper on Windows, which spawn can only
+// execute through a shell.
+export const maestroSpawnOptions = { shell: process.platform === 'win32' } as const;
+
+export type MaestroRun = {
+  maestroVersion: string;
+  driverPort: number;
+  /** Environment overrides for the `maestro` process; merge over process.env. */
+  env: Record<string, string>;
+  /** Arguments to place between `maestro test` and the flow arguments. */
+  args: string[];
+};
+
+/**
+ * Wire a locally installed stock Maestro CLI to this instance's remote XCTest
+ * runner: starts the xcrun shim and an HTTP forward proxy, and returns the
+ * environment and `maestro test` arguments that route the driver traffic to
+ * the remote runner. Both are torn down when the client disconnects.
+ *
+ * Maestro's driver talks plain HTTP to 127.0.0.1:<driverPort>. Nothing listens
+ * there: the JVM proxy settings route those requests (absolute-form) to the
+ * forward proxy, which rewrites them to the remote runner and passes other
+ * targets through.
+ */
+export async function prepareMaestroRun(
+  client: InstanceClient,
+  options: { runnerUrl: string },
+): Promise<MaestroRun> {
+  const [maestroVersion, shimDir] = await Promise.all([detectMaestroVersion(), client.startXcrunShim()]);
+  // Maestro 2.5.x hardcodes driver port 7001 and has no --driver-host-port
+  // flag; 2.6+ picks a random port unless the flag is passed.
+  const withDriverHostPortFlag = supportsDriverHostPort(maestroVersion);
+  const driverPort = withDriverHostPortFlag ? await findFreePort() : 7001;
+  const proxyPort = await client.startForwardHttpProxy({
+    remoteBaseUrl: options.runnerUrl,
+    matchPort: driverPort,
+  });
+  const maestroOpts = [
+    process.env['MAESTRO_OPTS'],
+    `-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=${proxyPort} -Dhttp.nonProxyHosts=`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return {
+    maestroVersion,
+    driverPort,
+    env: {
+      MAESTRO_OPTS: maestroOpts,
+      PATH: `${shimDir}${path.delimiter}${process.env['PATH'] ?? ''}`,
+      USE_XCODE_TEST_RUNNER: '1',
+    },
+    args: [
+      '--platform',
+      'ios',
+      '--device',
+      client.deviceInfo.udid,
+      '--no-reinstall-driver',
+      ...(withDriverHostPortFlag ? ['--driver-host-port', String(driverPort)] : []),
+    ],
+  };
+}
+
+/** Probe the remote Maestro XCTest runner's /status endpoint. */
+export async function isMaestroRunnerRunning(runnerUrl: string, token: string): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const response = await fetch(`${runnerUrl}/status`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function detectMaestroVersion(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('maestro', ['--version'], { encoding: 'utf8', ...maestroSpawnOptions }, (error, stdout) => {
+      if (error) {
+        reject(
+          new Error(
+            'Failed to run `maestro --version`. Install the Maestro CLI first: https://docs.maestro.dev/getting-started/installing-maestro',
+          ),
+        );
+        return;
+      }
+      // stdout only: update notices can also start with a version string and
+      // land on stderr or after the real version.
+      const version = stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .find((line) => /^\d+\.\d+\.\d+/.test(line));
+      if (!version) {
+        reject(new Error('Could not parse the Maestro CLI version from `maestro --version` output.'));
+        return;
+      }
+      resolve(version);
+    });
+  });
+}
+
+function supportsDriverHostPort(version: string): boolean {
+  const [major = 0, minor = 0] = version.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  return major > 2 || (major === 2 && minor >= 6);
+}
+
+// Finds a free port and releases it immediately: Maestro validates that the
+// driver port is bindable, so it must stay unbound on our side.
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to find a free port.'));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+  });
+}

--- a/src/ios-shim.ts
+++ b/src/ios-shim.ts
@@ -153,8 +153,19 @@ async function handleShimmedXcrun(
 
 // There are never physical devices behind the shim, so `devicectl list
 // devices` gets an empty device list in the shape Maestro's picker parses.
+// Flags can precede the subcommand (devicectl --json-output <path> list
+// devices), so match on positionals.
 function devicectlListDevices(args: string[]): IosShimSimctlResult {
-  if (args[1] !== 'list' || args[2] !== 'devices') {
+  const positionals: string[] = [];
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--json-output') {
+      i++;
+      continue;
+    }
+    if (args[i]!.startsWith('-')) continue;
+    positionals.push(args[i]!);
+  }
+  if (positionals[0] !== 'list' || positionals[1] !== 'devices') {
     return { code: 127, stdout: '', stderr: `unsupported devicectl command: ${args.join(' ')}` };
   }
   const payload = JSON.stringify({ result: { devices: [] } });
@@ -326,8 +337,22 @@ function fail(message) {
 
 // Physical-device enumeration (e.g. Maestro's device picker) is answered by
 // the shim server; real devicectl does not exist off macOS. Every other
-// devicectl subcommand delegates.
-const isDevicectlListDevices = args[0] === 'devicectl' && args[1] === 'list' && args[2] === 'devices';
+// devicectl subcommand delegates. Flags can precede the subcommand
+// (devicectl --json-output <path> list devices), so match on positionals.
+function devicectlPositionals(args) {
+  const positionals = [];
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--json-output') {
+      i++;
+      continue;
+    }
+    if (args[i].startsWith('-')) continue;
+    positionals.push(args[i]);
+  }
+  return positionals;
+}
+const devicectlSubcommand = args[0] === 'devicectl' ? devicectlPositionals(args) : [];
+const isDevicectlListDevices = devicectlSubcommand[0] === 'list' && devicectlSubcommand[1] === 'devices';
 
 if (args[0] !== 'simctl' && !isDevicectlListDevices) {
   delegate();

--- a/src/ios-shim.ts
+++ b/src/ios-shim.ts
@@ -100,6 +100,9 @@ async function handleShimmedXcrun(
   udid: string,
   args: string[],
 ): Promise<IosShimSimctlResult> {
+  if (args[0] === 'devicectl') {
+    return devicectlListDevices(args);
+  }
   if (args[0] !== 'simctl') {
     return { code: 127, stdout: '', stderr: `unsupported xcrun command: ${args.join(' ')}` };
   }
@@ -146,6 +149,32 @@ async function handleShimmedXcrun(
   }
 
   return await client.simctl(simctlArgs).wait();
+}
+
+// There are never physical devices behind the shim, so `devicectl list
+// devices` gets an empty device list in the shape Maestro's picker parses.
+function devicectlListDevices(args: string[]): IosShimSimctlResult {
+  if (args[1] !== 'list' || args[2] !== 'devices') {
+    return { code: 127, stdout: '', stderr: `unsupported devicectl command: ${args.join(' ')}` };
+  }
+  const payload = JSON.stringify({ result: { devices: [] } });
+  const jsonOutIndex = args.indexOf('--json-output');
+  const jsonOutPath = jsonOutIndex === -1 ? undefined : args[jsonOutIndex + 1];
+  if (jsonOutPath && jsonOutPath !== '-') {
+    try {
+      fs.writeFileSync(jsonOutPath, payload);
+    } catch (error) {
+      return {
+        code: 1,
+        stdout: '',
+        stderr: `could not write devicectl output to ${jsonOutPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+    return { code: 0, stdout: '', stderr: '' };
+  }
+  return { code: 0, stdout: `${payload}\n`, stderr: '' };
 }
 
 function simctlList(udid: string, simctlArgs: string[]): IosShimSimctlResult {
@@ -269,8 +298,9 @@ function toSimctlListApps(
 
 function xcrunShimSource(options?: { shimUrl: string; udid: string }): string {
   // Keep the executable tiny: it decides whether this is a Limrun-targeted
-  // simctl call, then asks the local shim server to perform the real work.
-  // Non-Limrun calls still delegate to the host xcrun.
+  // simctl call (or a devicectl device enumeration), then asks the local shim
+  // server to perform the real work. Non-Limrun calls still delegate to the
+  // host xcrun.
   const embeddedShimUrl = options ? JSON.stringify(options.shimUrl) : 'process.env.LIMRUN_XCRUN_SHIM_URL';
   const embeddedUdid = options ? JSON.stringify(options.udid) : 'process.env.LIMRUN_IOS_UDID';
   return `#!/usr/bin/env node
@@ -294,7 +324,12 @@ function fail(message) {
   process.exit(64);
 }
 
-if (args[0] !== 'simctl') {
+// Physical-device enumeration (e.g. Maestro's device picker) is answered by
+// the shim server; real devicectl does not exist off macOS. Every other
+// devicectl subcommand delegates.
+const isDevicectlListDevices = args[0] === 'devicectl' && args[1] === 'list' && args[2] === 'devices';
+
+if (args[0] !== 'simctl' && !isDevicectlListDevices) {
   delegate();
 }
 
@@ -304,21 +339,23 @@ if (!shimUrl || !udid) {
   fail('LIMRUN_XCRUN_SHIM_URL and LIMRUN_IOS_UDID are required.');
 }
 
-const simctlArgs = args.slice(1);
-const command = simctlArgs[0];
 function simctlTarget(command, simctlArgs) {
   if (command === 'launch') {
     return simctlArgs.slice(1).find((arg) => !arg.startsWith('-'));
   }
   return simctlArgs[1];
 }
-const target = simctlTarget(command, simctlArgs);
 function isLimrunTarget(value) {
   return value === udid || value === 'booted';
 }
 
-if (command !== 'list' && !isLimrunTarget(target)) {
-  delegate();
+if (args[0] === 'simctl') {
+  const simctlArgs = args.slice(1);
+  const command = simctlArgs[0];
+  const target = simctlTarget(command, simctlArgs);
+  if (command !== 'list' && !isLimrunTarget(target)) {
+    delegate();
+  }
 }
 
 const parsed = new URL(shimUrl);

--- a/tests/http-proxy.test.ts
+++ b/tests/http-proxy.test.ts
@@ -6,8 +6,8 @@ type ReceivedRequest = {
   headers: http.IncomingHttpHeaders;
 };
 
-// Simulates the remote runner endpoint (and pass-through targets): records the
-// request and answers with a marker body.
+// Stands in for the remote runner (and for a target the proxy must refuse):
+// records the request and answers with a marker body.
 function startRecordingServer(marker: string): Promise<{
   port: number;
   requests: ReceivedRequest[];
@@ -69,14 +69,14 @@ function requestViaProxy(
 
 describe('startForwardHttpProxy', () => {
   let remote: Awaited<ReturnType<typeof startRecordingServer>>;
-  let passthrough: Awaited<ReturnType<typeof startRecordingServer>>;
+  let other: Awaited<ReturnType<typeof startRecordingServer>>;
   let proxy: HttpProxy;
   const matchPort = 47001;
 
   beforeAll(async () => {
-    [remote, passthrough] = await Promise.all([
+    [remote, other] = await Promise.all([
       startRecordingServer('remote-runner'),
-      startRecordingServer('passthrough-target'),
+      startRecordingServer('other-target'),
     ]);
     proxy = await startForwardHttpProxy({
       matchPort,
@@ -87,13 +87,13 @@ describe('startForwardHttpProxy', () => {
 
   beforeEach(() => {
     remote.requests.length = 0;
-    passthrough.requests.length = 0;
+    other.requests.length = 0;
   });
 
   afterAll(async () => {
     await proxy.close();
     await remote.close();
-    await passthrough.close();
+    await other.close();
   });
 
   test('rewrites loopback requests on matchPort to the remote base URL with injected headers', async () => {
@@ -118,14 +118,11 @@ describe('startForwardHttpProxy', () => {
     expect(remote.requests[0]!.url).toBe('/base/deviceInfo');
   });
 
-  test('passes non-matching targets through untouched', async () => {
-    const response = await requestViaProxy(proxy.port, `http://127.0.0.1:${passthrough.port}/other`);
-    expect(response.status).toBe(200);
-    expect(response.body).toBe('passthrough-target');
-
-    const received = passthrough.requests[0]!;
-    expect(received.url).toBe('/other');
-    expect(received.headers['authorization']).toBeUndefined();
+  test('refuses loopback targets on other ports instead of forwarding them', async () => {
+    const response = await requestViaProxy(proxy.port, `http://127.0.0.1:${other.port}/other`);
+    expect(response.status).toBe(403);
+    // The proxy has exactly one destination, so nothing reaches the other server.
+    expect(other.requests).toHaveLength(0);
   });
 
   test('rejects origin-form request targets', async () => {
@@ -133,8 +130,8 @@ describe('startForwardHttpProxy', () => {
     expect(response.status).toBe(400);
   });
 
-  test('refuses non-loopback targets', async () => {
-    const response = await requestViaProxy(proxy.port, 'http://example.com/anything');
-    expect(response.status).toBe(403);
+  test('refuses non-loopback targets, including on the matched port', async () => {
+    expect((await requestViaProxy(proxy.port, 'http://example.com/anything')).status).toBe(403);
+    expect((await requestViaProxy(proxy.port, `http://example.com:${matchPort}/status`)).status).toBe(403);
   });
 });

--- a/tests/http-proxy.test.ts
+++ b/tests/http-proxy.test.ts
@@ -132,4 +132,9 @@ describe('startForwardHttpProxy', () => {
     const response = await requestViaProxy(proxy.port, '/not-absolute');
     expect(response.status).toBe(400);
   });
+
+  test('refuses non-loopback targets', async () => {
+    const response = await requestViaProxy(proxy.port, 'http://example.com/anything');
+    expect(response.status).toBe(403);
+  });
 });

--- a/tests/http-proxy.test.ts
+++ b/tests/http-proxy.test.ts
@@ -1,0 +1,135 @@
+import http from 'http';
+import { startForwardHttpProxy, type HttpProxy } from '@limrun/api';
+
+type ReceivedRequest = {
+  url: string;
+  headers: http.IncomingHttpHeaders;
+};
+
+// Simulates the remote runner endpoint (and pass-through targets): records the
+// request and answers with a marker body.
+function startRecordingServer(marker: string): Promise<{
+  port: number;
+  requests: ReceivedRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: ReceivedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    requests.push({ url: req.url ?? '', headers: req.headers });
+    res.writeHead(200, {
+      'content-type': 'text/plain',
+      // A hop-by-hop response header the proxy must not forward.
+      'proxy-authenticate': 'Basic realm="upstream"',
+    });
+    res.end(marker);
+  });
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('listen failed'));
+        return;
+      }
+      resolve({
+        port: address.port,
+        requests,
+        close: () => new Promise((res2, rej) => server.close((err) => (err ? rej(err) : res2()))),
+      });
+    });
+  });
+}
+
+// Sends an absolute-form request through the proxy, the way HTTP clients
+// configured with a forward proxy (e.g. JVM -Dhttp.proxyHost) do.
+function requestViaProxy(
+  proxyPort: number,
+  absoluteUrl: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port: proxyPort, path: absoluteUrl, method: 'GET', headers },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+            headers: res.headers,
+          }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('startForwardHttpProxy', () => {
+  let remote: Awaited<ReturnType<typeof startRecordingServer>>;
+  let passthrough: Awaited<ReturnType<typeof startRecordingServer>>;
+  let proxy: HttpProxy;
+  const matchPort = 47001;
+
+  beforeAll(async () => {
+    [remote, passthrough] = await Promise.all([
+      startRecordingServer('remote-runner'),
+      startRecordingServer('passthrough-target'),
+    ]);
+    proxy = await startForwardHttpProxy({
+      matchPort,
+      remoteBaseUrl: `http://127.0.0.1:${remote.port}/base`,
+      headers: { authorization: 'Bearer test-token' },
+    });
+  });
+
+  beforeEach(() => {
+    remote.requests.length = 0;
+    passthrough.requests.length = 0;
+  });
+
+  afterAll(async () => {
+    await proxy.close();
+    await remote.close();
+    await passthrough.close();
+  });
+
+  test('rewrites loopback requests on matchPort to the remote base URL with injected headers', async () => {
+    const response = await requestViaProxy(proxy.port, `http://127.0.0.1:${matchPort}/status?x=1`, {
+      'proxy-connection': 'keep-alive',
+    });
+    expect(response.status).toBe(200);
+    expect(response.body).toBe('remote-runner');
+
+    const received = remote.requests[0]!;
+    expect(received.url).toBe('/base/status?x=1');
+    expect(received.headers['authorization']).toBe('Bearer test-token');
+    // Hop-by-hop headers must not leak in either direction.
+    expect(received.headers['proxy-connection']).toBeUndefined();
+    expect(response.headers['proxy-authenticate']).toBeUndefined();
+  });
+
+  test('matches localhost as loopback', async () => {
+    const response = await requestViaProxy(proxy.port, `http://localhost:${matchPort}/deviceInfo`);
+    expect(response.status).toBe(200);
+    expect(response.body).toBe('remote-runner');
+    expect(remote.requests[0]!.url).toBe('/base/deviceInfo');
+  });
+
+  test('passes non-matching targets through untouched', async () => {
+    const response = await requestViaProxy(proxy.port, `http://127.0.0.1:${passthrough.port}/other`);
+    expect(response.status).toBe(200);
+    expect(response.body).toBe('passthrough-target');
+
+    const received = passthrough.requests[0]!;
+    expect(received.url).toBe('/other');
+    expect(received.headers['authorization']).toBeUndefined();
+  });
+
+  test('rejects origin-form request targets', async () => {
+    const response = await requestViaProxy(proxy.port, '/not-absolute');
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/ios-shim.test.ts
+++ b/tests/ios-shim.test.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { startXcrunShimServer, type IosXcrunShimClient, type IosXcrunShimServer } from '@limrun/api/ios-shim';
+
+const client = {
+  deviceInfo: { udid: 'TEST-UDID' },
+  listApps: async () => [],
+  simctl: () => ({ wait: async () => ({ code: 0, stdout: '', stderr: '' }) }),
+  syncApp: async () => ({}),
+} as unknown as IosXcrunShimClient;
+
+async function callShim(
+  url: string,
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ args }),
+  });
+  return (await response.json()) as { code: number; stdout: string; stderr: string };
+}
+
+describe('xcrun shim server devicectl handling', () => {
+  let server: IosXcrunShimServer;
+
+  beforeAll(async () => {
+    server = await startXcrunShimServer({ client, udid: 'TEST-UDID' });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  test('answers list devices with an empty device list, flags-before-subcommand order', async () => {
+    // Maestro invokes `devicectl --json-output <path> list devices`.
+    const jsonOut = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'limrun-shim-test-')), 'devices.json');
+    const result = await callShim(server.url, ['devicectl', '--json-output', jsonOut, 'list', 'devices']);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(fs.readFileSync(jsonOut, 'utf8'))).toEqual({ result: { devices: [] } });
+  });
+
+  test('answers list devices on stdout when no --json-output is given', async () => {
+    const result = await callShim(server.url, ['devicectl', 'list', 'devices']);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ result: { devices: [] } });
+  });
+
+  test('rejects other devicectl subcommands', async () => {
+    const result = await callShim(server.url, ['devicectl', 'device', 'install', 'app', 'App.ipa']);
+    expect(result.code).toBe(127);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a local forward proxy and JVM proxy wiring on the automation path; mitigations limit forwarding to a single loopback port, but misconfiguration or future callers could still affect how Maestro traffic reaches the remote runner.
> 
> **Overview**
> Adds end-to-end support for driving **stock Maestro** against a **remote Limrun iOS simulator**, including a first-class **`lim ios maestro test`** command and shared SDK helpers used by the example.
> 
> **Driver networking** switches from binding a local reverse proxy on the driver port to a **scoped HTTP forward proxy**: Maestro’s JVM is pointed at `http.proxyHost`/`http.proxyPort`, and only **absolute-form** requests to **loopback on the configured driver port** are rewritten to the remote XCTest runner; other targets are **refused** (CONNECT is not implemented). `prepareMaestroRun` also starts the **xcrun shim**, sets **`USE_XCODE_TEST_RUNNER`**, and adapts to **Maestro 2.5.x (port 7001)** vs **2.6+ (`--driver-host-port`)**.
> 
> The **CLI** ensures the runner app is installed (from a fixed app-store asset when missing), launches it, waits on `/status`, then spawns `maestro test` with injected platform/device flags and blocks duplicate user flags.
> 
> The **xcrun shim** now stubs **`devicectl list devices`** (including `--json-output`) so Maestro’s device picker works off-macOS. Docs, `.gitignore`, and tests cover the proxy and shim behavior; the **maestro-ios example** is refactored onto the shared API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf1b8e044b105fce1ecbea7e504b7979af0545d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->