### PR TITLE
cli: release 0.22.0 with the ios maestro command

### DIFF
--- a/examples/maestro-ios/package.json
+++ b/examples/maestro-ios/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@limrun/api": "^0.28.7"
+    "@limrun/api": "^0.45.3"
   },
   "devDependencies": {
     "tsx": "^4.20.5",

--- a/examples/maestro-ios/yarn.lock
+++ b/examples/maestro-ios/yarn.lock
@@ -132,18 +132,24 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz#04d90d5752b4ce65d2b6ac25eba08ff7624fe07c"
   integrity sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==
 
-"@limrun/api@^0.28.7":
-  version "0.28.7"
-  resolved "https://registry.npmjs.org/@limrun/api/-/api-0.28.7.tgz#6877fe8203a748b0a2ece75253bc829137660f62"
-  integrity sha512-YqbLNlAfik2RmP/dvNt+DxykBDzXGPuXMZL91UO+0Tg7348Sf2doPqkk8WiR60g5OWN+pOS3wIrF2q0uQLZQ5w==
+"@limrun/api@^0.45.3":
+  version "0.45.3"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.3.tgz#406b1f6af636a7ef413243861aeb267115d0845c"
+  integrity sha512-gSBiNUcuKjSjoP7WCQqto8+xz4VMfdPcO+Msb3lBPloyMhqxMHtleNXvV8LinmDZ0KFTzBYvPxBz8LF5ljTzvQ==
   dependencies:
+    "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"
     ignore "^7.0.5"
     proxy-from-env "^2.1.0"
     undici "7.24.7"
     ws "^8.18.3"
-    xdelta3-wasm "^1.0.0"
+    yauzl "^3.4.0"
+
+"@limrun/xdelta3-wasm@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
+  integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
 agent-base@^7.1.2:
   version "7.1.4"
@@ -224,6 +230,11 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 proxy-from-env@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
@@ -253,7 +264,9 @@ ws@^8.18.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
   integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
-xdelta3-wasm@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/xdelta3-wasm/-/xdelta3-wasm-1.0.0.tgz#43b6ef9e9649830e25713914e40324217f8565fd"
-  integrity sha512-vhS28BhVaE3S/PGG1KQIwjBVqJecuS5Sdh82UAZysbnYaU93KS6l8ZPtsqonNZMeuyFgrGW9D44hh2lwQCsidA==
+yauzl@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.4.0.tgz#88b2a21455f37ca7dccf2eeb33bacb4392322719"
+  integrity sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
+  dependencies:
+    pend "~1.2.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.45.2",
+    "@limrun/api": "0.45.3",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@0.45.2":
-  version "0.45.2"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.2.tgz#39fc213112594dc29f91350e573d9ce6897814e3"
-  integrity sha512-MObfpKJ8Vg+qnHU+FGNIFOmUI8QAnmKWiTCudy9ap7Wozl/Su3kgwPDBXY7LiD9IjjR95kbOL3Y+LaPGBbKPAQ==
+"@limrun/api@0.45.3":
+  version "0.45.3"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.3.tgz#406b1f6af636a7ef413243861aeb267115d0845c"
+  integrity sha512-gSBiNUcuKjSjoP7WCQqto8+xz4VMfdPcO+Msb3lBPloyMhqxMHtleNXvV8LinmDZ0KFTzBYvPxBz8LF5ljTzvQ==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and lockfile-only changes with no application source edits in this diff.
> 
> **Overview**
> **Bumps the `lim` CLI to 0.22.0** (from 0.21.3) and pins **`@limrun/api` to 0.45.3** in `packages/cli`, with matching lockfile updates.
> 
> The **`examples/maestro-ios`** example is updated from **`@limrun/api` ^0.28.7 to ^0.45.3**, pulling in the current SDK dependency graph (`@limrun/xdelta3-wasm`, `yauzl`, etc.) instead of the older `xdelta3-wasm` package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae29e0ec6bc2fa8e3a41df5b4ea0eeeb80d812f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->