### PR TITLE
ci: publish lim via npm trusted publishing

### DIFF
--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -16,7 +16,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+
+      # npm OIDC trusted publishing needs npm >= 11.5; Node 22 bundles npm 10.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Bootstrap root SDK
         run: ./scripts/bootstrap
@@ -32,8 +35,8 @@ jobs:
         working-directory: packages/cli
         run: yarn build
 
+      # Authenticates via the npm trusted publisher configured for this
+      # workflow (OIDC); a configured token would take precedence and fail.
       - name: Publish lim
         working-directory: packages/cli
-        run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Publishing auth for the CLI package changes from a secret token to OIDC; releases will fail until npm trusted publishing is configured correctly, and any leftover `NPM_TOKEN` in the job would block OIDC.
> 
> **Overview**
> Switches the **Publish lim CLI** workflow from publishing with `NPM_TOKEN` and `--provenance` to **npm OIDC trusted publishing**, so the job authenticates through the trusted publisher bound to this workflow instead of a repository secret.
> 
> To support that, it **drops** `registry-url` on `setup-node`, **adds** a global `npm@latest` install (Node 22’s bundled npm is too old for trusted publishing), and runs plain `npm publish` with comments noting that a token would override OIDC and break the flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e128f0d9636377bdc3863bfdb04ce532a371dbce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->