### PR TITLE
cli: add --disable-xcbeautify flag to xcode build

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -43,6 +43,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./MyProject --id <xcode-instance-ID>',
     '<%= config.bin %> xcode build --scheme MyApp --workspace MyApp.xcworkspace',
     '<%= config.bin %> xcode build --configuration Debug',
+    '<%= config.bin %> xcode build ./MyProject --disable-xcbeautify',
     '<%= config.bin %> xcode build ./ExpoApp --configuration Debug --dev-server-url https://abc123.exp.direct',
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
@@ -109,6 +110,11 @@ export default class XcodeBuild extends BaseCommand {
     'git-init': Flags.boolean({
       description:
         'Run git init in the synced workspace before project generation, dependency resolution, and xcodebuild.',
+      default: false,
+    }),
+    'disable-xcbeautify': Flags.boolean({
+      description:
+        'Stream raw xcodebuild output instead of piping it through xcbeautify. Useful when the full, unformatted log is needed for debugging or CI log parsers.',
       default: false,
     }),
     'dev-server-url': Flags.string({
@@ -250,6 +256,9 @@ export default class XcodeBuild extends BaseCommand {
       const options: XcodeBuildOptions = {};
       if (flags['git-init']) {
         options.gitInit = true;
+      }
+      if (flags['disable-xcbeautify']) {
+        options.disableXcbeautify = true;
       }
       if (flags['xcodegen-spec'] || flags['xcodegen-project'] || flags['xcodegen-project-root']) {
         options.xcodegen = {

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -41,6 +41,8 @@ export type XcodeBuildExecRequest = {
   testflight?: AppStoreUploadConfig;
   buildSettings?: Record<string, string>;
   gitInit?: boolean;
+  /** Stream raw xcodebuild output instead of piping it through xcbeautify. */
+  disableXcbeautify?: boolean;
   signedUploadUrl?: string;
   webhook?: WebhookConfig;
   additionalMetadata?: {

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -167,6 +167,12 @@ export type XcodeBuildOptions = {
    */
   gitInit?: boolean;
   /**
+   * Stream raw xcodebuild output instead of piping it through xcbeautify.
+   * Useful when the full, unformatted log is needed for debugging or CI log
+   * parsers. Older limbuild servers silently ignore this option.
+   */
+  disableXcbeautify?: boolean;
+  /**
    * HTTP callback fired once the build reaches a terminal state (SUCCEEDED,
    * FAILED, or CANCELLED). The payload carries the result (execId, status,
    * exitCode, timing), the instance's identity with a Limrun Console debug
@@ -718,6 +724,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ...(options?.appstore && { testflight: options.appstore }),
           ...(options?.buildSettings && { buildSettings: options.buildSettings }),
           ...(options?.gitInit !== undefined && { gitInit: options.gitInit }),
+          ...(options?.disableXcbeautify !== undefined && { disableXcbeautify: options.disableXcbeautify }),
           ...(options?.webhook && { webhook: options.webhook }),
         };
 

--- a/tests/xcode-client-build-settings.test.ts
+++ b/tests/xcode-client-build-settings.test.ts
@@ -36,6 +36,7 @@ describe('xcode client build settings', () => {
       { scheme: 'Scripty' },
       {
         gitInit: true,
+        disableXcbeautify: true,
         buildSettings: {
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: '$(inherited) LIMRUN',
           APP_CONFIG_DEV_LOGIN_SECRET: 'abc=def',
@@ -49,6 +50,7 @@ describe('xcode client build settings', () => {
       command: 'xcodebuild',
       xcodebuild: { scheme: 'Scripty' },
       gitInit: true,
+      disableXcbeautify: true,
       buildSettings: {
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: '$(inherited) LIMRUN',
         APP_CONFIG_DEV_LOGIN_SECRET: 'abc=def',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the ability to disable xcbeautify formatting for `lim xcode build`, streaming raw xcodebuild output instead.

- **CLI**: new `--disable-xcbeautify` boolean flag on `lim xcode build` (with a usage example in `--help`).
- **SDK**: new `disableXcbeautify?: boolean` field on `XcodeBuildOptions`, forwarded to the limbuild exec API as `disableXcbeautify` on the `xcodebuild` exec request (already supported server-side; older servers silently ignore it, consistent with `webhook` and `appstore`).

## Testing

- Extended `tests/xcode-client-build-settings.test.ts` to assert the field is serialized into the `POST /exec` body.
- `./scripts/lint` passes, root test suite passes (554 tests), CLI package builds and its tests pass, and the flag renders correctly in `lim xcode build --help`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a2ca256-2387-41dd-90d1-8acaf3af9e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a2ca256-2387-41dd-90d1-8acaf3af9e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

