### PR TITLE
Add detached build log commands

### DIFF
--- a/examples/device-install/backend/install.ts
+++ b/examples/device-install/backend/install.ts
@@ -189,8 +189,7 @@ export function receiveInstallWebhook(token: string | undefined, payload: unknow
     const status = (payload as { status?: string } | null)?.status;
     entry.status.state = status === 'SUCCEEDED' ? 'succeeded' : 'failed';
     if (entry.status.state === 'failed') {
-      entry.status.error =
-        (payload as { error?: string } | null)?.error ?? `Build finished with status ${status ?? 'unknown'}.`;
+      entry.status.error = `Build finished with status ${status ?? 'unknown'}. See the persisted build log.`;
     }
     return id;
   }

--- a/examples/device-install/frontend/src/lib/backend.ts
+++ b/examples/device-install/frontend/src/lib/backend.ts
@@ -132,7 +132,6 @@ export type InstallInput = {
 
 export type BuildWebhookPayload = {
   status?: string;
-  error?: string;
   buildDurationMs?: number;
   consoleUrl?: string;
   logsUrl?: string;

--- a/examples/publish-to-stores/backend/publish.ts
+++ b/examples/publish-to-stores/backend/publish.ts
@@ -219,8 +219,7 @@ export function receivePublishWebhook(token: string | undefined, payload: unknow
     const status = (payload as { status?: string } | null)?.status;
     entry.status.state = status === 'SUCCEEDED' ? 'succeeded' : 'failed';
     if (entry.status.state === 'failed') {
-      const buildError = (payload as { error?: string } | null)?.error;
-      entry.status.error = buildError ?? `Build finished with status ${status ?? 'unknown'}.`;
+      entry.status.error = `Build finished with status ${status ?? 'unknown'}. See the persisted build log.`;
     }
     return id;
   }

--- a/examples/publish-to-stores/frontend/src/lib/backend.ts
+++ b/examples/publish-to-stores/frontend/src/lib/backend.ts
@@ -81,7 +81,6 @@ export type BuildWebhookPayload = {
   startedAt?: string;
   finishedAt?: string;
   buildDurationMs?: number;
-  error?: string;
   instanceId?: string;
   /** Instance debug page in the Limrun Console. */
   consoleUrl?: string;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -457,7 +457,13 @@ lim xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 -
 lim xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"
 
 # Headless one-shot build: return after submission and reap the fresh instance shortly after completion
-lim xcode build ./MyProject --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun
+lim xcode build ./MyProject --detach --inactivity-timeout 3s
+
+# Snapshot the active build (or show the latest completed build)
+lim xcode logs
+
+# Replay the active build and follow it to completion
+lim xcode logs --follow
 
 # Attach an existing simulator so builds auto-install there
 lim xcode attach-simulator ios_abc123 --id sandbox_def456
@@ -696,7 +702,14 @@ lim asset pull my-app-build -o ./build-output
 
 `lim xcode build [PATH]` automatically performs a one-shot code sync for the given project path before invoking `xcodebuild`. The sync step automatically ignores build artifacts (`build/`, `DerivedData/`, `.build/`), dependency folders (`Pods/`, `Carthage/Build/`, `.swiftpm/`), and user-specific files (`xcuserdata/`, `.dSYM/`).
 
-For headless CI-style builds, pass `--detach --webhook-url <url>`. The command still creates or resolves the instance and syncs the project, but returns as soon as limbuild accepts the build rather than holding an SSE log stream open until completion. `--detach` requires a webhook so the terminal result remains observable. Pass `--inactivity-timeout <duration>` (for example `3s`) to skip any cached Xcode target and create a fresh one-shot instance with that timeout; it cannot be combined with `--id`. Active builds continually report activity, so a short timeout only starts expiring once build work stops. The inactivity controller checks approximately every 15 seconds, so actual teardown can lag the configured timeout by that interval.
+For headless CI-style builds, pass `--detach`. The command still creates or resolves the instance and syncs the project, but returns as soon as limbuild accepts the build rather than holding an SSE log stream open until completion. The detached summary includes the exact `lim xcode logs <exec-id> --id <instance-id>` command and a Console URL for observing the build; optionally pass `--webhook-url <url>` to receive the terminal result automatically. Pass `--inactivity-timeout <duration>` (for example `3s`) to skip any cached Xcode target and create a fresh one-shot instance with that timeout; it cannot be combined with `--id`. Active builds continually report activity, so a short timeout only starts expiring once build work stops. The inactivity controller checks approximately every 15 seconds, so actual teardown can lag the configured timeout by that interval.
+
+`lim xcode logs` and `lim gradle logs` print a point-in-time snapshot of the active build on the remembered instance, falling back to its latest persisted build when none is active. Pass the build exec ID to select a specific build, `--id <instance-id>` to override the remembered instance, or `--follow` to replay an active build and continue streaming until it finishes:
+
+```bash
+lim xcode logs build-1776140344112378000 --id sandbox_abc123
+lim gradle logs --follow
+```
 
 #### Run project commands
 

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -61,6 +61,13 @@ export abstract class BaseCommand extends Command {
     }),
   };
 
+  static readOnlyFlags = {
+    'api-key': BaseCommand.baseFlags['api-key'],
+    json: BaseCommand.baseFlags.json,
+    quiet: BaseCommand.baseFlags.quiet,
+    workspace: BaseCommand.baseFlags.workspace,
+  };
+
   private _client?: Limrun;
 
   protected get client(): Limrun {
@@ -524,7 +531,7 @@ export abstract class BaseCommand extends Command {
     // Read-only or lifecycle verbs must never conjure an instance: `lim
     // gradle get <typo>` should fail with not-found, not create-and-show a
     // brand new sandbox.
-    if (['create', 'delete', 'list', 'get'].includes(verb)) {
+    if (['create', 'delete', 'list', 'get', 'logs'].includes(verb)) {
       return false;
     }
     return true;

--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -21,7 +21,7 @@ export default class GradleBuild extends BaseCommand {
   static summary = 'Build an Android project on a gradle instance';
   static description =
     'Sync a local Android project once, then run its Gradle wrapper remotely with streaming output. ' +
-    'Use `--upload` to store the artifact, or `--detach` with a webhook for a headless build that returns as soon as the build starts.';
+    'Use `--upload` to store the artifact, or `--detach` for a headless build that returns as soon as the build starts, optionally with a webhook for the terminal result.';
 
   static examples = [
     '<%= config.bin %> gradle build',
@@ -32,7 +32,7 @@ export default class GradleBuild extends BaseCommand {
     '<%= config.bin %> gradle build --sign --upload myapp.aab',
     '<%= config.bin %> gradle build --keystore upload.jks --keystore-password *** --key-alias upload --key-password *** --save-key',
     '<%= config.bin %> gradle build ./my-app --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
-    '<%= config.bin %> gradle build ./my-app --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun',
+    '<%= config.bin %> gradle build ./my-app --detach --inactivity-timeout 3s',
     '<%= config.bin %> gradle build --sign --upload-to-playstore --playstore-service-account service-account.json',
   ];
 
@@ -138,7 +138,7 @@ export default class GradleBuild extends BaseCommand {
     }),
     detach: Flags.boolean({
       description:
-        'Return after the remote build is accepted instead of streaming logs and waiting for completion. Requires --webhook-url; use its callback to observe the terminal result.',
+        'Return after the remote build is accepted instead of streaming logs and waiting for completion. Check it later with `lim gradle logs`; optionally use --webhook-url to receive the terminal result.',
       default: false,
     }),
     'auto-version-code': Flags.boolean({
@@ -194,9 +194,6 @@ export default class GradleBuild extends BaseCommand {
       return this.error(
         '--inactivity-timeout controls a newly created instance and cannot be combined with --id.',
       );
-    }
-    if (flags.detach && !flags['webhook-url']) {
-      return this.error('--detach requires --webhook-url so the terminal build result is observable.');
     }
     if (flags['upload-to-playstore']) {
       let credential: Pick<
@@ -271,15 +268,24 @@ export default class GradleBuild extends BaseCommand {
 
       if (flags.detach) {
         const execId = await proc.detach();
-        // --detach requires --webhook-url, validated above.
-        const webhookUrl = flags['webhook-url']!;
+        const webhookUrl = flags['webhook-url'];
         const consoleUrl = this.consoleBuildUrl(id);
+        const logsCommand = `lim gradle logs ${execId} --id ${id}`;
         if (this.isJsonEnabled()) {
-          this.outputJson({ instanceId: id, execId, consoleUrl, webhookUrl });
+          this.outputJson({
+            instanceId: id,
+            execId,
+            consoleUrl,
+            logsCommand,
+            ...(webhookUrl && { webhookUrl }),
+          });
         } else {
           this.output(`Build started (exec ID ${execId}) on instance ${id}.`);
           this.output(`Console: ${consoleUrl}`);
-          this.output(`Completion will be reported by webhook to ${webhookUrl}.`);
+          this.output(`Logs: ${logsCommand}`);
+          if (webhookUrl) {
+            this.output(`Completion will be reported by webhook to ${webhookUrl}.`);
+          }
         }
         return;
       }

--- a/packages/cli/src/commands/gradle/logs.ts
+++ b/packages/cli/src/commands/gradle/logs.ts
@@ -1,0 +1,73 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getBuildLogs } from '../../lib/build-logs';
+
+export default class GradleLogs extends BaseCommand {
+  static summary = 'Fetch logs for an active, recent, or specific Gradle build';
+  static description =
+    'Print the active build log, or the latest persisted log when no build is active. Pass an exec ID to select a specific build. Active logs are a point-in-time snapshot unless --follow is set.';
+  static baseFlags = BaseCommand.readOnlyFlags as unknown as typeof BaseCommand.baseFlags;
+
+  static examples = [
+    '<%= config.bin %> gradle logs',
+    '<%= config.bin %> gradle logs --follow',
+    '<%= config.bin %> gradle logs build-1776140344112378000',
+    '<%= config.bin %> gradle logs build-1776140344112378000 --id <gradle-instance-ID>',
+  ];
+
+  static args = {
+    execId: Args.string({
+      description: 'Build exec ID. Defaults to the active build, then the latest persisted build.',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    id: Flags.string({
+      description: 'Gradle instance ID. Defaults to the most recently used Gradle target.',
+    }),
+    follow: Flags.boolean({
+      description: 'Continue streaming an active build until it reaches a terminal state.',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(GradleLogs);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const target = this.resolveGradleTarget(flags.id);
+      const result = await getBuildLogs({
+        instanceId: target.id,
+        ...(args.execId && { execId: args.execId }),
+        follow: flags.follow,
+        listPersisted: () => this.client.gradleInstances.listBuildLogs(target.id),
+        observe: async (execId, options) => {
+          const gradleClient = await this.resolveGradleClient(target);
+          return gradleClient.observeBuildLogs(execId, options);
+        },
+        ...(!flags.json && {
+          onText: (text: string, stream: 'stdout' | 'stderr') => {
+            (stream === 'stderr' ? process.stderr : process.stdout).write(text);
+          },
+        }),
+      });
+
+      if (flags.json) {
+        this.outputJson(result);
+        return;
+      }
+      this.logToStderr(
+        `Build ${result.execId} is ${result.status}${
+          result.exitCode === undefined ? '' : ` (exit ${result.exitCode})`
+        }.`,
+      );
+      if (result.status === 'RUNNING' && !flags.follow) {
+        this.logToStderr(
+          'Re-run this command for a fresh snapshot, or pass --follow to wait for completion.',
+        );
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -33,7 +33,7 @@ type AppStoreFlags = {
 export default class XcodeBuild extends BaseCommand {
   static summary = 'Run xcodebuild on an Xcode sandbox';
   static description =
-    'Sync a local project path once (or the current working directory if omitted), then trigger a remote xcodebuild with streaming output. Use `--detach` with a webhook for headless builds that should return as soon as the build starts. Use `--ios` to build and run on an iOS simulator-backed Xcode target.';
+    'Sync a local project path once (or the current working directory if omitted), then trigger a remote xcodebuild with streaming output. Use `--detach` for headless builds that should return as soon as the build starts, optionally with a webhook for the terminal result. Use `--ios` to build and run on an iOS simulator-backed Xcode target.';
 
   static examples = [
     '<%= config.bin %> xcode build',
@@ -53,7 +53,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build --signed-upload-url <url>',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
     '<%= config.bin %> xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
-    '<%= config.bin %> xcode build ./MyProject --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun',
+    '<%= config.bin %> xcode build ./MyProject --detach --inactivity-timeout 3s',
     '<%= config.bin %> xcode build ./MyProject --basis-cache-dir ./.limsync-cache',
     '<%= config.bin %> xcode build ./MyProject --ignore "\\\\.xcuserdata/"',
     '<%= config.bin %> xcode build ./MyProject --additional-file ~/.netrc=~/.netrc',
@@ -175,7 +175,7 @@ export default class XcodeBuild extends BaseCommand {
     }),
     detach: Flags.boolean({
       description:
-        'Return after the remote build is accepted instead of streaming logs and waiting for completion. Requires --webhook-url; use its callback to observe the terminal result.',
+        'Return after the remote build is accepted instead of streaming logs and waiting for completion. Check it later with `lim xcode logs`; optionally use --webhook-url to receive the terminal result.',
       default: false,
     }),
     'basis-cache-dir': Flags.string({
@@ -226,10 +226,6 @@ export default class XcodeBuild extends BaseCommand {
     if (flags.id && flags['inactivity-timeout']) {
       this.error('--inactivity-timeout controls a newly created instance and cannot be combined with --id.');
     }
-    if (flags.detach && !flags['webhook-url']) {
-      this.error('--detach requires --webhook-url so the terminal build result is observable.');
-    }
-
     await this.withAuth(async () => {
       const target =
         flags.ios ?
@@ -343,15 +339,24 @@ export default class XcodeBuild extends BaseCommand {
 
       if (flags.detach) {
         const execId = await proc.detach();
-        // --detach requires --webhook-url, validated above.
-        const webhookUrl = flags['webhook-url']!;
+        const webhookUrl = flags['webhook-url'];
         const consoleUrl = this.consoleBuildUrl(id);
+        const logsCommand = `lim xcode logs ${execId} --id ${id}`;
         if (this.isJsonEnabled()) {
-          this.outputJson({ instanceId: id, execId, consoleUrl, webhookUrl });
+          this.outputJson({
+            instanceId: id,
+            execId,
+            consoleUrl,
+            logsCommand,
+            ...(webhookUrl && { webhookUrl }),
+          });
         } else {
           this.output(`Build started (exec ID ${execId}) on instance ${id}.`);
           this.output(`Console: ${consoleUrl}`);
-          this.output(`Completion will be reported by webhook to ${webhookUrl}.`);
+          this.output(`Logs: ${logsCommand}`);
+          if (webhookUrl) {
+            this.output(`Completion will be reported by webhook to ${webhookUrl}.`);
+          }
         }
         return;
       }

--- a/packages/cli/src/commands/xcode/logs.ts
+++ b/packages/cli/src/commands/xcode/logs.ts
@@ -1,0 +1,73 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getBuildLogs } from '../../lib/build-logs';
+
+export default class XcodeLogs extends BaseCommand {
+  static summary = 'Fetch logs for an active, recent, or specific Xcode build';
+  static description =
+    'Print the active build log, or the latest persisted log when no build is active. Pass an exec ID to select a specific build. Active logs are a point-in-time snapshot unless --follow is set.';
+  static baseFlags = BaseCommand.readOnlyFlags as unknown as typeof BaseCommand.baseFlags;
+
+  static examples = [
+    '<%= config.bin %> xcode logs',
+    '<%= config.bin %> xcode logs --follow',
+    '<%= config.bin %> xcode logs build-1776140344112378000',
+    '<%= config.bin %> xcode logs build-1776140344112378000 --id <xcode-instance-ID>',
+  ];
+
+  static args = {
+    execId: Args.string({
+      description: 'Build exec ID. Defaults to the active build, then the latest persisted build.',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    id: Flags.string({
+      description: 'Xcode or iOS-backed Xcode instance ID. Defaults to the most recently used Xcode target.',
+    }),
+    follow: Flags.boolean({
+      description: 'Continue streaming an active build until it reaches a terminal state.',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(XcodeLogs);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const target = await this.resolveXcodeTarget(flags.id);
+      const result = await getBuildLogs({
+        instanceId: target.id,
+        ...(args.execId && { execId: args.execId }),
+        follow: flags.follow,
+        listPersisted: () => this.client.xcodeInstances.listBuildLogs(target.id),
+        observe: async (execId, options) => {
+          const xcodeClient = await this.resolveXcodeClient(target);
+          return xcodeClient.observeBuildLogs(execId, options);
+        },
+        ...(!flags.json && {
+          onText: (text: string, stream: 'stdout' | 'stderr') => {
+            (stream === 'stderr' ? process.stderr : process.stdout).write(text);
+          },
+        }),
+      });
+
+      if (flags.json) {
+        this.outputJson(result);
+        return;
+      }
+      this.logToStderr(
+        `Build ${result.execId} is ${result.status}${
+          result.exitCode === undefined ? '' : ` (exit ${result.exitCode})`
+        }.`,
+      );
+      if (result.status === 'RUNNING' && !flags.follow) {
+        this.logToStderr(
+          'Re-run this command for a fresh snapshot, or pass --follow to wait for completion.',
+        );
+      }
+    });
+  }
+}

--- a/packages/cli/src/lib/build-logs.test.ts
+++ b/packages/cli/src/lib/build-logs.test.ts
@@ -1,0 +1,195 @@
+import { getBuildLogs, type PersistedBuildLog } from './build-logs';
+
+describe('getBuildLogs', () => {
+  test('returns an active build snapshot', async () => {
+    const onText = jest.fn();
+    const listPersisted = jest.fn(async (): Promise<PersistedBuildLog[]> => []);
+
+    await expect(
+      getBuildLogs({
+        instanceId: 'xcode_test',
+        follow: false,
+        listPersisted,
+        observe: async (execId, options) => {
+          options.onEvent({ type: 'command', data: 'xcodebuild -scheme App' });
+          options.onEvent({ type: 'stdout', data: 'Compiling' });
+          return { execId, status: 'RUNNING' };
+        },
+        onText,
+      }),
+    ).resolves.toEqual({
+      instanceId: 'xcode_test',
+      execId: 'active',
+      status: 'RUNNING',
+      logs: '$ xcodebuild -scheme App\nCompiling\n',
+      source: 'retained',
+    });
+    expect(listPersisted).not.toHaveBeenCalled();
+    expect(onText).toHaveBeenCalledTimes(2);
+  });
+
+  test('falls back from no active build to the latest persisted build', async () => {
+    const records: PersistedBuildLog[] = [
+      { id: 'build-1', status: 'FAILED', exitCode: 1, downloadUrl: 'https://logs/1' },
+      { id: 'build-2', status: 'SUCCEEDED', exitCode: 0, downloadUrl: 'https://logs/2' },
+      { id: 'run-3', status: 'SUCCEEDED', exitCode: 0, downloadUrl: 'https://logs/run' },
+    ];
+
+    await expect(
+      getBuildLogs({
+        instanceId: 'gradle_test',
+        follow: false,
+        listPersisted: async () => records,
+        observe: async () => {
+          throw notFound();
+        },
+        fetchText: async (url) => `downloaded ${url}\n`,
+      }),
+    ).resolves.toEqual({
+      instanceId: 'gradle_test',
+      execId: 'build-2',
+      status: 'SUCCEEDED',
+      exitCode: 0,
+      logs: 'downloaded https://logs/2\n',
+      source: 'persisted',
+    });
+  });
+
+  test('prefers durable logs for a specific completed build', async () => {
+    const observe = jest.fn();
+    const record = {
+      id: 'build-1',
+      status: 'CANCELLED',
+      exitCode: -1,
+      downloadUrl: 'https://logs/1',
+    };
+
+    const result = await getBuildLogs({
+      instanceId: 'xcode_test',
+      execId: 'build-1',
+      follow: true,
+      listPersisted: async () => [record],
+      observe,
+      fetchText: async () => 'cancelled\n',
+    });
+
+    expect(result.source).toBe('persisted');
+    expect(result.status).toBe('CANCELLED');
+    expect(observe).not.toHaveBeenCalled();
+  });
+
+  test('refreshes persisted logs after a terminal retention race', async () => {
+    const record = {
+      id: 'build-1',
+      status: 'SUCCEEDED',
+      exitCode: 0,
+      downloadUrl: 'https://logs/1',
+    };
+    const listPersisted = jest
+      .fn<Promise<PersistedBuildLog[]>, []>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([record]);
+
+    const result = await getBuildLogs({
+      instanceId: 'xcode_test',
+      execId: 'build-1',
+      follow: false,
+      listPersisted,
+      observe: async () => {
+        throw notFound();
+      },
+      fetchText: async () => 'finished\n',
+    });
+
+    expect(result.source).toBe('persisted');
+    expect(listPersisted).toHaveBeenCalledTimes(2);
+  });
+
+  test('uses the latest retained build during the durable upload gap', async () => {
+    const listPersisted = jest.fn(async (): Promise<PersistedBuildLog[]> => []);
+
+    const result = await getBuildLogs({
+      instanceId: 'xcode_test',
+      follow: false,
+      listPersisted,
+      observe: async (execId) => {
+        if (execId === 'active') throw notFound();
+        return { execId: 'build-9', status: 'SUCCEEDED', exitCode: 0 };
+      },
+    });
+
+    expect(result).toMatchObject({ execId: 'build-9', status: 'SUCCEEDED', source: 'retained' });
+    expect(listPersisted).not.toHaveBeenCalled();
+  });
+
+  test('does not mask active stream failures with stale logs', async () => {
+    const stale = { id: 'build-1', status: 'SUCCEEDED', downloadUrl: 'https://logs/1' };
+    const unavailable = Object.assign(new Error('daemon unavailable'), { status: 503 });
+    const listPersisted = jest.fn(async () => [stale]);
+
+    await expect(
+      getBuildLogs({
+        instanceId: 'xcode_test',
+        follow: false,
+        listPersisted,
+        observe: async () => {
+          throw unavailable;
+        },
+      }),
+    ).rejects.toBe(unavailable);
+    expect(listPersisted).not.toHaveBeenCalled();
+  });
+
+  test('reports a missing exec without an instance-level 404', async () => {
+    const error = await getBuildLogs({
+      instanceId: 'xcode_test',
+      execId: 'build-404',
+      follow: false,
+      listPersisted: async () => [],
+      observe: async () => {
+        throw notFound();
+      },
+    }).catch((err: unknown) => err);
+
+    expect(error).toEqual(new Error('Build build-404 was not found on instance xcode_test.'));
+    expect((error as { status?: number }).status).toBeUndefined();
+  });
+
+  test('preserves an instance-level 404 for BaseCommand handling', async () => {
+    const instanceMissing = Object.assign(
+      new Error('404 GET exec logs failed: 404 {"message":"instance not found"}'),
+      { status: 404 },
+    );
+
+    await expect(
+      getBuildLogs({
+        instanceId: 'xcode_missing',
+        execId: 'build-1',
+        follow: false,
+        listPersisted: async () => [],
+        observe: async () => {
+          throw instanceMissing;
+        },
+      }),
+    ).rejects.toBe(instanceMissing);
+  });
+
+  test('reports when an instance has no builds', async () => {
+    await expect(
+      getBuildLogs({
+        instanceId: 'xcode_empty',
+        follow: false,
+        listPersisted: async () => [],
+        observe: async () => {
+          throw notFound();
+        },
+      }),
+    ).rejects.toThrow('No active or persisted builds found for instance xcode_empty.');
+  });
+});
+
+function notFound(): Error {
+  return Object.assign(new Error('404 GET exec logs failed: 404 {"message":"build not found"}'), {
+    status: 404,
+  });
+}

--- a/packages/cli/src/lib/build-logs.ts
+++ b/packages/cli/src/lib/build-logs.ts
@@ -1,0 +1,181 @@
+export type PersistedBuildLog = {
+  id: string;
+  status: string;
+  exitCode?: number;
+  downloadUrl: string;
+};
+
+export type ObservedBuildLogEvent = {
+  type: string;
+  data: string;
+};
+
+export type ObservedBuildLogResult = {
+  execId: string;
+  status: string;
+  exitCode?: number;
+};
+
+export type BuildLogsResult = {
+  instanceId: string;
+  execId: string;
+  status: string;
+  exitCode?: number;
+  logs: string;
+  source: 'retained' | 'persisted';
+};
+
+type BuildLogsOptions = {
+  instanceId: string;
+  execId?: string;
+  follow: boolean;
+  listPersisted: () => Promise<PersistedBuildLog[]>;
+  observe: (
+    execId: string,
+    options: {
+      follow: boolean;
+      onEvent: (event: ObservedBuildLogEvent) => void;
+    },
+  ) => Promise<ObservedBuildLogResult>;
+  fetchText?: (url: string) => Promise<string>;
+  onText?: (text: string, stream: 'stdout' | 'stderr') => void;
+};
+
+/**
+ * Selects an active/latest/specific build and returns its user-facing logs.
+ * Retained SSE is preferred for active builds; durable object storage is
+ * preferred for a specific build once its metadata sidecar exists.
+ */
+export async function getBuildLogs(options: BuildLogsOptions): Promise<BuildLogsResult> {
+  if (options.execId) {
+    if (!isBuildExecId(options.execId)) {
+      throw new Error(`Invalid build exec ID ${options.execId}; expected build-<number>.`);
+    }
+    const persisted = await tryListPersisted(options.listPersisted);
+    const record = persisted.records.find((entry) => entry.id === options.execId);
+    if (record) {
+      return readPersisted(options, record);
+    }
+
+    try {
+      return await readRetained(options, options.execId);
+    } catch (retainedError) {
+      if (!isRetainedBuildNotFound(retainedError)) {
+        throw retainedError;
+      }
+      // Persistence commits just after the terminal event. Refresh once to
+      // close that race before reporting a missing/pruned exec.
+      const refreshed = await tryListPersisted(options.listPersisted);
+      const refreshedRecord = refreshed.records.find((entry) => entry.id === options.execId);
+      if (refreshedRecord) {
+        return readPersisted(options, refreshedRecord);
+      }
+      if (refreshed.error) {
+        throw refreshed.error;
+      }
+      throw new Error(`Build ${options.execId} was not found on instance ${options.instanceId}.`);
+    }
+  }
+
+  try {
+    return await readRetained(options, 'active');
+  } catch (activeError) {
+    if (!isRetainedBuildNotFound(activeError)) {
+      throw activeError;
+    }
+    try {
+      // The active pointer is cleared just before durable upload. The retained
+      // latest alias closes that gap and also avoids selecting a stale record.
+      return await readRetained(options, 'latest');
+    } catch (latestError) {
+      if (!isRetainedBuildNotFound(latestError)) {
+        throw latestError;
+      }
+      const persisted = await tryListPersisted(options.listPersisted);
+      const latest = persisted.records[persisted.records.length - 1];
+      if (latest) {
+        return readPersisted(options, latest);
+      }
+      if (persisted.error) {
+        throw persisted.error;
+      }
+      throw new Error(`No active or persisted builds found for instance ${options.instanceId}.`);
+    }
+  }
+}
+
+async function readRetained(options: BuildLogsOptions, execId: string): Promise<BuildLogsResult> {
+  const parts: string[] = [];
+  const observed = await options.observe(execId, {
+    follow: options.follow,
+    onEvent: (event) => {
+      let text: string | undefined;
+      let stream: 'stdout' | 'stderr' = 'stdout';
+      if (event.type === 'command') {
+        text = `$ ${event.data}`;
+      } else if (event.type === 'stdout') {
+        text = event.data;
+      } else if (event.type === 'stderr') {
+        text = event.data;
+        stream = 'stderr';
+      }
+      if (text === undefined) return;
+      const chunk = text.endsWith('\n') ? text : `${text}\n`;
+      parts.push(chunk);
+      options.onText?.(chunk, stream);
+    },
+  });
+  return {
+    instanceId: options.instanceId,
+    execId: observed.execId,
+    status: observed.status,
+    ...(observed.exitCode !== undefined && { exitCode: observed.exitCode }),
+    logs: parts.join(''),
+    source: 'retained',
+  };
+}
+
+async function readPersisted(options: BuildLogsOptions, record: PersistedBuildLog): Promise<BuildLogsResult> {
+  const logs = await (options.fetchText ?? fetchBuildLog)(record.downloadUrl);
+  options.onText?.(logs, 'stdout');
+  return {
+    instanceId: options.instanceId,
+    execId: record.id,
+    status: record.status,
+    ...(record.exitCode !== undefined && { exitCode: record.exitCode }),
+    logs,
+    source: 'persisted',
+  };
+}
+
+async function tryListPersisted(
+  listPersisted: () => Promise<PersistedBuildLog[]>,
+): Promise<{ records: PersistedBuildLog[]; error?: unknown }> {
+  try {
+    return { records: (await listPersisted()).filter((record) => isBuildExecId(record.id)) };
+  } catch (error) {
+    return { records: [], error };
+  }
+}
+
+async function fetchBuildLog(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download build log: ${response.status} ${response.statusText}`);
+  }
+  return response.text();
+}
+
+function isRetainedBuildNotFound(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as Error & { status?: number }).status === 404 &&
+    err.message.includes('GET exec logs failed: 404') &&
+    (err.message.includes('"message":"build not found"') ||
+      err.message.includes('"message":"no builds exist"'))
+  );
+}
+
+function isBuildExecId(execId: string): boolean {
+  return /^build-[0-9]+$/.test(execId);
+}

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -7,6 +7,8 @@
 
 import { createEventSource, type EventSourceClient, type EventSourceMessage } from 'eventsource-client';
 import { nodeProxyTransport } from './internal/proxy-transport';
+import { directInstanceHttpError } from './internal/direct-instance-errors';
+import type { Fetch } from './internal/builtin-types';
 
 // =============================================================================
 // Types
@@ -205,6 +207,27 @@ export type ExecResult = {
   timedOut?: boolean;
 };
 
+export type ExecLogEvent = {
+  id?: string;
+  type: string;
+  data: string;
+};
+
+export type ExecLogOptions = {
+  /** Keep streaming after replaying buffered events. Defaults to false. */
+  follow?: boolean;
+  /** Called for each replayed or live event in wire order. */
+  onEvent?: (event: ExecLogEvent) => void;
+  signal?: AbortSignal;
+};
+
+export type ExecLogResult = {
+  /** The requested exec ID. May be "active" when the daemon resolved that alias. */
+  execId: string;
+  status: 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELLED';
+  exitCode?: number;
+};
+
 export type AppStoreEvent = {
   /** 'unknown' means an App Store upload event arrived but its payload was unreadable. */
   state: 'uploading' | 'processing' | 'accepted' | 'failed' | 'unknown';
@@ -275,6 +298,113 @@ export class ReadableStream {
       for (const l of this.closeListeners) l();
     }
   }
+}
+
+type FollowExecEventStreamOptions<TResult> = {
+  eventsUrl: string;
+  token: string;
+  signal?: AbortSignal;
+  operation: string;
+  abortError: () => Error;
+  onEvent: (event: ExecLogEvent) => TResult | undefined;
+  /** Return an error to stop; return undefined to let EventSource reconnect. */
+  onDisconnect: () => Error | undefined;
+};
+
+/**
+ * Shared transport for replaying and following exec SSE. It owns HTTP error
+ * handling, message normalization, abort cleanup, callback failures, and
+ * connection settlement; callers only route events and define completion.
+ */
+function followExecEventStream<TResult>(options: FollowExecEventStreamOptions<TResult>): {
+  connection: EventSourceClient | null;
+  result: Promise<TResult>;
+} {
+  let connection: EventSourceClient | null = null;
+  let settled = false;
+  let onAbort = () => {};
+
+  const result = new Promise<TResult>((resolve, reject) => {
+    const cleanup = () => {
+      options.signal?.removeEventListener('abort', onAbort);
+      connection?.close();
+      connection = null;
+    };
+    const settleResolve = (value: TResult) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const settleReject = (err: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    };
+    onAbort = () => settleReject(options.abortError());
+
+    if (options.signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    const checkedFetch: Fetch = async (input, init) => {
+      let response: Response;
+      try {
+        response = await nodeProxyTransport.fetch(input, init);
+      } catch (err) {
+        settleReject(err);
+        throw err;
+      }
+      if (!response.ok) {
+        const text = await response.text();
+        const err = directInstanceHttpError(options.operation, response.status, text, response.headers);
+        settleReject(err);
+        throw err;
+      }
+      return response;
+    };
+
+    try {
+      connection = createEventSource({
+        url: options.eventsUrl,
+        fetch: checkedFetch,
+        headers: { Authorization: `Bearer ${options.token}` },
+        onMessage: (message: EventSourceMessage) => {
+          if (settled) return;
+          try {
+            const event: ExecLogEvent = {
+              ...(message.id && { id: message.id }),
+              type: message.event || 'message',
+              data: typeof message.data === 'string' ? message.data : String(message.data ?? ''),
+            };
+            const value = options.onEvent(event);
+            if (value !== undefined) {
+              settleResolve(value);
+            }
+          } catch (err) {
+            settleReject(err);
+          }
+        },
+        onDisconnect: () => {
+          if (settled) return;
+          const err = options.onDisconnect();
+          if (err) settleReject(err);
+        },
+      });
+      if (settled) {
+        connection.close();
+        connection = null;
+        return;
+      }
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+    } catch (err) {
+      settleReject(err);
+    }
+  });
+
+  return { connection, result };
 }
 
 /**
@@ -551,74 +681,182 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
    * Rejects when the abort signal fires (kill or cleanup).
    */
   private connectSSE(eventsUrl: string): Promise<number> {
-    return new Promise<number>((resolve, reject) => {
-      if (this.abortController.signal.aborted) {
-        reject(new Error('killed'));
-        return;
-      }
-
-      try {
-        const eventSource = createEventSource({
-          url: eventsUrl,
-          fetch: nodeProxyTransport.fetch,
-          headers: { Authorization: `Bearer ${this.options.token}` },
-          onMessage: (message: EventSourceMessage) => {
-            const data = typeof message.data === 'string' ? message.data : String(message.data ?? '');
-            const eventType = message.event;
-            if (eventType === 'command') {
-              this.command.emit('data', data);
-            } else if (eventType === 'stdout') {
-              this.stdout.emit('data', data);
-            } else if (eventType === 'stderr') {
-              this.stderr.emit('data', data);
-            } else if (eventType === 'testflight') {
-              try {
-                this.appStoreEvent = JSON.parse(data) as AppStoreEvent;
-              } catch {
-                // The wire event itself proves the server ran the App Store upload,
-                // so never let a payload glitch look like a missing feature.
-                this.appStoreEvent = { state: 'unknown' };
-                this.log('warn', `SSE testflight event has invalid data: ${data}`);
-              }
-            } else if (eventType === 'playstore') {
-              try {
-                this.playstoreEvent = JSON.parse(data) as PlaystoreEvent;
-              } catch {
-                // Same contract as the App Store upload event: its presence proves the server
-                // ran the Play Store step, so a payload glitch must not
-                // read as a missing feature.
-                this.playstoreEvent = { state: 'unknown' };
-                this.log('warn', `SSE playstore event has invalid data: ${data}`);
-              }
-            } else if (eventType === 'exitCode') {
-              const exitCode = parseInt(data, 10);
-              if (Number.isNaN(exitCode)) {
-                this.log('warn', `SSE exitCode event has invalid data: ${data}`);
-                return;
-              }
-              this.log('debug', `Execution completed via SSE: exitCode=${exitCode}`);
-              resolve(exitCode);
-            }
-          },
-          onDisconnect: () => {
-            if (!this.killed) {
-              this.log('warn', 'SSE disconnected');
-            }
-          },
-        });
-        this.sseConnection = eventSource;
-
-        this.abortController.signal.addEventListener('abort', () => reject(new Error('killed')), {
-          once: true,
-        });
-      } catch (err) {
-        if (!this.killed) {
-          this.log('warn', `SSE setup failed: ${err}`);
+    const stream = followExecEventStream<number>({
+      eventsUrl,
+      token: this.options.token,
+      signal: this.abortController.signal,
+      operation: 'GET exec events',
+      abortError: () => new Error('killed'),
+      onEvent: (event) => {
+        const { data } = event;
+        if (event.type === 'command') {
+          this.command.emit('data', data);
+        } else if (event.type === 'stdout') {
+          this.stdout.emit('data', data);
+        } else if (event.type === 'stderr') {
+          this.stderr.emit('data', data);
+        } else if (event.type === 'testflight') {
+          try {
+            this.appStoreEvent = JSON.parse(data) as AppStoreEvent;
+          } catch {
+            // The wire event itself proves the server ran the App Store upload,
+            // so never let a payload glitch look like a missing feature.
+            this.appStoreEvent = { state: 'unknown' };
+            this.log('warn', `SSE testflight event has invalid data: ${data}`);
+          }
+        } else if (event.type === 'playstore') {
+          try {
+            this.playstoreEvent = JSON.parse(data) as PlaystoreEvent;
+          } catch {
+            // Same contract as the App Store upload event: its presence proves the server
+            // ran the Play Store step, so a payload glitch must not
+            // read as a missing feature.
+            this.playstoreEvent = { state: 'unknown' };
+            this.log('warn', `SSE playstore event has invalid data: ${data}`);
+          }
+        } else if (event.type === 'exitCode') {
+          const exitCode = Number.parseInt(data, 10);
+          if (Number.isNaN(exitCode)) {
+            this.log('warn', `SSE exitCode event has invalid data: ${data}`);
+            return undefined;
+          }
+          this.log('debug', `Execution completed via SSE: exitCode=${exitCode}`);
+          return exitCode;
         }
-        reject(err);
+        return undefined;
+      },
+      onDisconnect: () => {
+        if (!this.killed) {
+          this.log('warn', 'SSE disconnected');
+        }
+        return undefined;
+      },
+    });
+    this.sseConnection = stream.connection;
+    return stream.result.catch((err) => {
+      if (!this.killed) {
+        this.log('warn', `SSE setup failed: ${err}`);
       }
+      throw err;
     });
   }
+}
+
+/**
+ * Replay logs for an existing execution, optionally following it to completion.
+ * Snapshot mode uses a finite SSE response; follow mode consumes the same
+ * replayable stream until its terminal exitCode event.
+ */
+export async function observeExecLogs(
+  execId: string,
+  options: ExecOptions & ExecLogOptions,
+): Promise<ExecLogResult> {
+  if (!execId.trim()) {
+    throw new Error('execId must not be empty');
+  }
+  const follow = options.follow ?? false;
+  const eventsUrl = new URL(
+    `${options.apiUrl.replace(/\/+$/, '')}/exec/${encodeURIComponent(execId)}/events`,
+  );
+  eventsUrl.searchParams.set('follow', String(follow));
+
+  if (!follow) {
+    const response = await nodeProxyTransport.fetch(eventsUrl, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${options.token}` },
+      ...(options.signal && { signal: options.signal }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw directInstanceHttpError('GET exec logs', response.status, text, response.headers);
+    }
+    const events = parseSSE(await response.text());
+    let exitCode: number | undefined;
+    let resolvedExecId = execId;
+    for (const event of events) {
+      resolvedExecId = execIdFromMeta(event, resolvedExecId);
+      options.onEvent?.(event);
+      if (event.type === 'exitCode') {
+        exitCode = parseExitCode(event.data);
+      }
+    }
+    return buildExecLogResult(resolvedExecId, exitCode);
+  }
+
+  let resolvedExecId = execId;
+  const stream = followExecEventStream<ExecLogResult>({
+    eventsUrl: eventsUrl.toString(),
+    token: options.token,
+    ...(options.signal && { signal: options.signal }),
+    operation: 'GET exec logs',
+    abortError: () => new Error(`exec log stream for ${execId} was aborted`),
+    onEvent: (event) => {
+      resolvedExecId = execIdFromMeta(event, resolvedExecId);
+      options.onEvent?.(event);
+      if (event.type === 'exitCode') {
+        return buildExecLogResult(resolvedExecId, parseExitCode(event.data));
+      }
+      return undefined;
+    },
+    onDisconnect: () => new Error(`exec log stream for ${execId} ended without a terminal event`),
+  });
+  return stream.result;
+}
+
+function parseSSE(body: string): ExecLogEvent[] {
+  const normalized = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const events: ExecLogEvent[] = [];
+  for (const block of normalized.split('\n\n')) {
+    if (!block.trim()) continue;
+    let id: string | undefined;
+    let type = 'message';
+    const data: string[] = [];
+    for (const line of block.split('\n')) {
+      if (line.startsWith('id:')) {
+        id = line.slice(3).trimStart();
+      } else if (line.startsWith('event:')) {
+        type = line.slice(6).trimStart();
+      } else if (line.startsWith('data:')) {
+        data.push(line.slice(5).replace(/^ /, ''));
+      }
+    }
+    if (data.length > 0 || type !== 'message' || id !== undefined) {
+      events.push({ ...(id !== undefined && { id }), type, data: data.join('\n') });
+    }
+  }
+  return events;
+}
+
+function parseExitCode(data: string): number {
+  const exitCode = Number.parseInt(data, 10);
+  if (Number.isNaN(exitCode)) {
+    throw new Error(`invalid exec exit code: ${data}`);
+  }
+  return exitCode;
+}
+
+function execIdFromMeta(event: ExecLogEvent, fallback: string): string {
+  if (event.type !== 'meta') return fallback;
+  try {
+    const meta = JSON.parse(event.data) as { id?: unknown };
+    return typeof meta.id === 'string' && meta.id ? meta.id : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function buildExecLogResult(execId: string, exitCode: number | undefined): ExecLogResult {
+  if (exitCode === undefined) {
+    return { execId, status: 'RUNNING' };
+  }
+  return {
+    execId,
+    exitCode,
+    status:
+      exitCode === 0 ? 'SUCCEEDED'
+      : exitCode === -1 ? 'CANCELLED'
+      : 'FAILED',
+  };
 }
 
 /**

--- a/src/resources/gradle-instances-helpers.ts
+++ b/src/resources/gradle-instances-helpers.ts
@@ -4,13 +4,17 @@ import { RequestOptions } from '../internal/request-options';
 import { path } from '../internal/utils/path';
 import {
   exec,
+  observeExecLogs,
   type ExecChildProcess,
+  type ExecLogOptions,
+  type ExecLogResult,
   type GradleBuildExecRequest,
   type GradlePlaystoreConfig,
   type GradleReactNativeConfig,
   type GradleSigningConfig,
   type WebhookConfig,
 } from '../exec-client';
+export type { ExecLogOptions, ExecLogResult } from '../exec-client';
 import { syncFolder as syncFolderImpl, type FolderSyncOptions } from '../folder-sync';
 import { createIgnoreFn } from '../folder-sync-ignore';
 import {
@@ -73,6 +77,8 @@ export type GradleBuildOptions = {
 export type GradleClient = {
   sync(localCodePath: string, opts?: GradleSyncOptions): Promise<SyncResult>;
   gradlebuild(options?: GradleBuildOptions): ExecChildProcess;
+  /** Replay an existing build's logs, optionally following it to completion. */
+  observeBuildLogs(execId: string, options?: ExecLogOptions): Promise<ExecLogResult>;
 };
 
 // Machine-local or regenerable files that must never reach the build
@@ -184,6 +190,10 @@ export class GradleInstances extends GeneratedGradleInstances {
         }
 
         return exec(request, { apiUrl, token, log });
+      },
+
+      observeBuildLogs(execId: string, options?: ExecLogOptions): Promise<ExecLogResult> {
+        return observeExecLogs(execId, { apiUrl, token, log, ...options });
       },
     };
   }

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -5,13 +5,16 @@ import { RequestOptions } from '../internal/request-options';
 import { path } from '../internal/utils/path';
 import {
   exec,
+  observeExecLogs,
   type AppStoreUploadConfig,
   type ExecChildProcess,
+  type ExecLogOptions,
+  type ExecLogResult,
   type ExecRequest,
   type WebhookConfig,
 } from '../exec-client';
 
-export type { AppStoreUploadConfig, WebhookConfig } from '../exec-client';
+export type { AppStoreUploadConfig, ExecLogOptions, ExecLogResult, WebhookConfig } from '../exec-client';
 import {
   syncFolder as syncFolderImpl,
   type AdditionalFileSyncEntry,
@@ -341,6 +344,9 @@ export type XcodeClient = {
    * const { exitCode } = await build;
    */
   xcodebuild: (settings?: XcodeProjectConfig, options?: XcodeBuildOptions) => ExecChildProcess;
+
+  /** Replay an existing build's logs, optionally following it to completion. */
+  observeBuildLogs: (execId: string, options?: ExecLogOptions) => Promise<ExecLogResult>;
 
   /**
    * Run a one-shot shell command in the synced workspace.
@@ -737,6 +743,10 @@ export class XcodeInstances extends GeneratedXcodeInstances {
         }
 
         return exec(request, { apiUrl, token, log });
+      },
+
+      observeBuildLogs(execId: string, options?: ExecLogOptions): Promise<ExecLogResult> {
+        return observeExecLogs(execId, { apiUrl, token, log, ...options });
       },
 
       run(commandLine: string, options?: XcodeRunOptions): ExecChildProcess {

--- a/tests/exec-logs.test.ts
+++ b/tests/exec-logs.test.ts
@@ -1,0 +1,125 @@
+jest.mock('eventsource-client', () => ({
+  createEventSource: jest.fn(),
+}));
+
+import { createEventSource, type EventSourceOptions } from 'eventsource-client';
+import { observeExecLogs, type ExecLogEvent } from '../src/exec-client';
+import { nodeProxyTransport } from '../src/internal/proxy-transport';
+import type { RequestInfo } from '../src/internal/builtin-types';
+
+const originalFetch = nodeProxyTransport.fetch;
+
+describe('existing exec logs', () => {
+  afterEach(() => {
+    nodeProxyTransport.fetch = originalFetch;
+    jest.mocked(createEventSource).mockReset();
+  });
+
+  test('fetches a finite snapshot and reports a running build', async () => {
+    const calls: string[] = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) => {
+      calls.push(String(input));
+      return new Response(
+        'id: 1\nevent: meta\ndata: {"id":"build-1","status":"RUNNING"}\n\n' +
+          'id: 2\nevent: command\ndata: xcodebuild\n\n' +
+          'id: 3\nevent: stdout\ndata: compiling\n\n',
+      );
+    });
+    const events: ExecLogEvent[] = [];
+
+    await expect(
+      observeExecLogs('active', {
+        apiUrl: 'https://xcode.example.test',
+        token: 'token',
+        onEvent: (event) => events.push(event),
+      }),
+    ).resolves.toEqual({ execId: 'build-1', status: 'RUNNING' });
+
+    expect(calls).toEqual(['https://xcode.example.test/exec/active/events?follow=false']);
+    expect(events).toEqual([
+      { id: '1', type: 'meta', data: '{"id":"build-1","status":"RUNNING"}' },
+      { id: '2', type: 'command', data: 'xcodebuild' },
+      { id: '3', type: 'stdout', data: 'compiling' },
+    ]);
+  });
+
+  test('recognizes a terminal snapshot', async () => {
+    nodeProxyTransport.fetch = jest.fn(async () => {
+      return new Response('event: stderr\ndata: failed\n\nevent: exitCode\ndata: 7\n\n');
+    });
+
+    await expect(
+      observeExecLogs('build-2', {
+        apiUrl: 'https://gradle.example.test',
+        token: 'token',
+      }),
+    ).resolves.toEqual({ execId: 'build-2', status: 'FAILED', exitCode: 7 });
+  });
+
+  test('surfaces a missing retained build', async () => {
+    nodeProxyTransport.fetch = jest.fn(async () => {
+      return new Response('{"message":"build not found"}', {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    await expect(
+      observeExecLogs('build-missing', {
+        apiUrl: 'https://xcode.example.test',
+        token: 'token',
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  test('replays and follows until the terminal event', async () => {
+    nodeProxyTransport.fetch = jest.fn(async () => new Response(null, { status: 200 }));
+    jest.mocked(createEventSource).mockImplementationOnce((optionsOrUrl) => {
+      const options = optionsOrUrl as EventSourceOptions;
+      setTimeout(() => {
+        options.onMessage?.({ event: 'stdout', data: 'building' });
+        options.onMessage?.({ event: 'exitCode', data: '0' });
+      }, 0);
+      return { close: jest.fn() } as never;
+    });
+    const events: ExecLogEvent[] = [];
+
+    await expect(
+      observeExecLogs('build-3', {
+        apiUrl: 'https://xcode.example.test',
+        token: 'token',
+        follow: true,
+        onEvent: (event) => events.push(event),
+      }),
+    ).resolves.toEqual({ execId: 'build-3', status: 'SUCCEEDED', exitCode: 0 });
+    expect(events).toEqual([
+      { type: 'stdout', data: 'building' },
+      { type: 'exitCode', data: '0' },
+    ]);
+  });
+
+  test('rejects when a follow-mode event callback fails', async () => {
+    jest.mocked(createEventSource).mockImplementationOnce((optionsOrUrl) => {
+      const options = optionsOrUrl as EventSourceOptions;
+      setTimeout(() => {
+        options.onMessage?.({ event: 'stdout', data: 'building' });
+        options.onMessage?.({ event: 'stdout', data: 'must be ignored' });
+      }, 0);
+      return { close: jest.fn() } as never;
+    });
+    const callbackError = new Error('output failed');
+    const onEvent = jest.fn(() => {
+      throw callbackError;
+    });
+
+    await expect(
+      observeExecLogs('build-4', {
+        apiUrl: 'https://xcode.example.test',
+        token: 'token',
+        follow: true,
+        onEvent,
+      }),
+    ).rejects.toBe(callbackError);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- allow Xcode and Gradle builds to detach without requiring a webhook and print an exact follow-up logs command
- add `xcode logs` and `gradle logs` with active snapshots, optional following, and retained/persisted fallback
- share the core SSE transport between newly started executions and existing-build observers, and align webhook examples with persisted logs

## Dependency
- requires matching daemon support for finite `follow=false` snapshots and the retained `latest` alias; those backend changes are not included in this repository PR

## Test plan
- [x] `./scripts/lint`
- [x] `yarn test --runInBand`
- [x] `yarn --cwd packages/cli test --runInBand`
- [x] verify `lim xcode logs --help` and `lim gradle logs --help`

Made with [Cursor](https://cursor.com)