### PR TITLE
feat(ui): render the device as an interactive 3D object in RemoteControl

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -6,6 +6,22 @@ types and helpers for building inspect, search, and agent interfaces.
 
 See [examples](../../examples/) to see how it can be used.
 
+## 3D device stage
+
+`RemoteControl` renders the device as an interactive 3D object by default:
+
+- Move your cursor around and the device subtly turns to face it, catching
+  the light from a new angle.
+- Grab the device — its corner bezels or the space around it — and drag to
+  rotate it in 3D. Give it a flick and it spins before settling back to face
+  you.
+
+Screen input stays pixel-accurate while the device is tilted: pointer
+positions are unprojected back onto the device surface before touch
+injection. Precision modes (Alt-pinch, the inspect overlay) flatten the
+device while active, and the effect is disabled automatically for users who
+prefer reduced motion. Pass `interactive3d={false}` to opt out entirely.
+
 Related browser workflow packages are published separately:
 
 - `@limrun/apple-auth` handles Apple ID login, signing credentials, and App

--- a/packages/ui/src/components/remote-control.css
+++ b/packages/ui/src/components/remote-control.css
@@ -11,6 +11,91 @@
   height: 100%;
 }
 
+/* The 3D-transformed plane holding the device (back panel, frame, video,
+   glare). It fills the container so its center — the transform origin —
+   coincides with the device center, and so child coordinates match
+   container coordinates. */
+.rc-stage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.rc-3d .rc-stage {
+  transform-style: preserve-3d;
+  will-change: transform;
+}
+
+/* Depth layering inside the 3D stage. Sub-pixel translateZ offsets give the
+   3D depth sorter a deterministic order matching the 2D z-index stack while
+   staying visually imperceptible: back panel (0) < iOS frame (0.5px) <
+   video (0.75px) < Android frame (1px) < glare (1.25px). backface-visibility
+   hides the front layers while a spinning device shows its back. */
+.rc-3d .rc-phone-frame {
+  transform: translateZ(1px);
+  backface-visibility: hidden;
+}
+
+.rc-3d .rc-phone-frame-ios {
+  transform: translateZ(0.5px);
+}
+
+.rc-3d .rc-video {
+  transform: translate(-50%, -50%) translateZ(0.75px);
+  backface-visibility: hidden;
+}
+
+.rc-3d .rc-video-frameless {
+  transform: translateZ(0.75px);
+}
+
+/* Photorealistic-ish device back shown while the device spins past 90°.
+   Geometry (position, size, border radius) is synced to the frame by the
+   stage's animation loop. */
+.rc-stage-back {
+  position: absolute;
+  z-index: 5;
+  pointer-events: none;
+  transform: rotateY(180deg);
+  backface-visibility: hidden;
+  background: radial-gradient(120% 90% at 30% 8%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0) 55%),
+    linear-gradient(135deg, #3d4046 0%, #1a1b1e 55%, #26282c 100%);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 255, 255, 0.07),
+    inset 0 0 24px rgba(0, 0, 0, 0.55);
+}
+
+/* Camera cluster hint on the device back. */
+.rc-stage-back::after {
+  content: '';
+  position: absolute;
+  top: 3.5%;
+  left: 7%;
+  width: 32%;
+  aspect-ratio: 1;
+  border-radius: 24%;
+  background: radial-gradient(circle at 30% 30%, rgba(30, 32, 36, 1) 12%, rgba(0, 0, 0, 0) 13%),
+    radial-gradient(circle at 70% 30%, rgba(30, 32, 36, 1) 12%, rgba(0, 0, 0, 0) 13%),
+    radial-gradient(circle at 30% 70%, rgba(30, 32, 36, 1) 12%, rgba(0, 0, 0, 0) 13%),
+    linear-gradient(150deg, #131417 0%, #202227 100%);
+  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.08);
+}
+
+/* Glass glare that sweeps across the device as it tilts, as if lit from a
+   fixed light source. Fully transparent at rest; driven by the stage's
+   animation loop. */
+.rc-stage-glare {
+  position: absolute;
+  z-index: 35;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateZ(1.25px);
+  backface-visibility: hidden;
+}
+
 .rc-phone-frame {
   position: relative;
   z-index: 30;

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -21,6 +21,7 @@ import {
 import { AxFetcher, AxStatus } from '../core/ax-fetcher';
 import { AxElement, AxSnapshot, axElementAtPoint, axSnapshotsEqual } from '../core/ax-tree';
 import { InspectOverlay, InspectOverlayGeometry, InspectMode } from './inspect-overlay';
+import { useStage3D } from './use-stage-3d';
 
 declare global {
   interface Window {
@@ -54,6 +55,25 @@ interface RemoteControlProps {
   // showFrame controls whether to display the device frame
   // around the video. Defaults to true.
   showFrame?: boolean;
+
+  /**
+   * Render the device as an interactive 3D object. Defaults to true.
+   *
+   * - Moving the cursor around makes the device subtly turn to face it,
+   *   catching the light from a new angle.
+   * - Grabbing the device — its corner bezels or the space around it — and
+   *   dragging rotates it in 3D. A flick sends it spinning before it
+   *   settles back to face you.
+   *
+   * Screen input stays pixel-accurate while tilted: pointer positions are
+   * unprojected back onto the device surface before touch injection. The
+   * bezel bands directly above/below/beside the screen keep their existing
+   * edge-clamped touch behavior (e.g. the iOS home-indicator swipe-up from
+   * below the screen), and precision modes (Alt-pinch, inspect overlay)
+   * flatten the device while active. Automatically disabled when the user
+   * prefers reduced motion.
+   */
+  interactive3d?: boolean;
 
   // When true, drops after a working session auto-reconnect instead of
   // surfacing the manual "Retry" button. Defaults to false.
@@ -498,6 +518,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       sessionId: propSessionId,
       openUrl,
       showFrame = true,
+      interactive3d = true,
       autoReconnect = false,
       onTerminated,
       inspectMode,
@@ -516,6 +537,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     const containerRef = useRef<HTMLDivElement>(null);
     const videoRef = useRef<HTMLVideoElement>(null);
     const frameRef = useRef<HTMLImageElement>(null);
+    // Interactive 3D stage: tilt-to-face-cursor, grab/flick rotation, and
+    // the exact pointer unprojection that keeps touch input accurate while
+    // the device is tilted.
+    const stage3d = useStage3D({ enabled: interactive3d, containerRef, videoRef, frameRef, showFrame });
     const [videoLoaded, setVideoLoaded] = useState(false);
     const [retryExhausted, setRetryExhausted] = useState(false);
     // Set once we've concluded the instance is permanently gone (its
@@ -927,6 +952,14 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       }
     };
 
+    // Precision modes flatten the 3D stage: the Alt-pinch indicators and the
+    // inspect overlay are drawn outside the tilted plane, so the device must
+    // face the viewer for them to line up exactly with the video.
+    const syncStage3dFlatten = () => {
+      const inspecting = inspectModeRef.current === true || inspectModeRef.current === 'hover-only';
+      stage3d.setFlattened(isAltHeldRef.current || inspecting);
+    };
+
     // Update Alt modifier state. Only iOS Simulator uses Indigo modifier injection.
     const updateAltHeld = (nextHeld: boolean) => {
       if (isAltHeldRef.current === nextHeld) {
@@ -934,6 +967,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       }
       isAltHeldRef.current = nextHeld;
       setIsAltHeld(nextHeld);
+      syncStage3dFlatten();
 
       // Clear hover point when Alt is released to hide indicators immediately.
       if (!nextHeld) {
@@ -989,7 +1023,11 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       const videoHeight = video.videoHeight;
       if (!videoWidth || !videoHeight) return null;
 
-      const videoRect = video.getBoundingClientRect();
+      // While the 3D stage is active the video's bounding rect is its
+      // projected (transformed) box, which is useless for input math. Use
+      // the untransformed layout rect instead; pointer positions are mapped
+      // into the same space by stage3d.unprojectClient before use.
+      const videoRect = stage3d.getVideoLayoutRect() ?? video.getBoundingClientRect();
       const containerRect = container.getBoundingClientRect();
 
       const displayWidth = videoRect.width;
@@ -1027,8 +1065,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       clientX: number,
       clientY: number,
     ): PointerGeometry | null => {
-      const relativeX = clientX - ctx.videoRect.left - ctx.offsetX;
-      const relativeY = clientY - ctx.videoRect.top - ctx.offsetY;
+      // Undo the 3D tilt (identity when the stage is flat or 3D is off).
+      const point = stage3d.unprojectClient(clientX, clientY);
+      const relativeX = point.x - ctx.videoRect.left - ctx.offsetX;
+      const relativeY = point.y - ctx.videoRect.top - ctx.offsetY;
 
       const clampedRelativeX = Math.max(0, Math.min(ctx.actualWidth, relativeX));
       const clampedRelativeY = Math.max(0, Math.min(ctx.actualHeight, relativeY));
@@ -1056,8 +1096,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       clientX: number,
       clientY: number,
     ): HoverPoint | null => {
-      const relativeX = clientX - ctx.videoRect.left - ctx.offsetX;
-      const relativeY = clientY - ctx.videoRect.top - ctx.offsetY;
+      // Undo the 3D tilt (identity when the stage is flat or 3D is off).
+      const point = stage3d.unprojectClient(clientX, clientY);
+      const relativeX = point.x - ctx.videoRect.left - ctx.offsetX;
+      const relativeY = point.y - ctx.videoRect.top - ctx.offsetY;
 
       const clampedRelativeX = Math.max(0, Math.min(ctx.actualWidth, relativeX));
       const clampedRelativeY = Math.max(0, Math.min(ctx.actualHeight, relativeY));
@@ -1184,8 +1226,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     ): AxElement | null => {
       const snapshot = axSnapshotRef.current;
       if (!snapshot || snapshot.screen.width <= 0 || snapshot.screen.height <= 0) return null;
-      const relX = clientX - ctx.videoRect.left - ctx.offsetX;
-      const relY = clientY - ctx.videoRect.top - ctx.offsetY;
+      // Undo the 3D tilt (identity when the stage is flat or 3D is off).
+      const point = stage3d.unprojectClient(clientX, clientY);
+      const relX = point.x - ctx.videoRect.left - ctx.offsetX;
+      const relY = point.y - ctx.videoRect.top - ctx.offsetY;
       if (relX < 0 || relY < 0 || relX > ctx.actualWidth || relY > ctx.actualHeight) return null;
       const axX = (relX / ctx.actualWidth) * snapshot.screen.width;
       const axY = (relY / ctx.actualHeight) * snapshot.screen.height;
@@ -1196,6 +1240,13 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     const handleInteraction = (event: React.MouseEvent | React.TouchEvent) => {
       event.preventDefault();
       event.stopPropagation();
+
+      // 3D stage interactions first: cursor-follow tilt (never consumes) and
+      // grab/flick rotation. A consumed event is a rotation gesture and must
+      // not reach the device as touch input.
+      if (stage3d.handleInteraction(event)) {
+        return;
+      }
 
       // Compute mapping context once per event (reused for all pointers)
       const ctx = computeVideoMappingContext();
@@ -3053,6 +3104,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // toggles. Connection state is independent: the fetcher gets created on
     // dataChannel.onopen and destroyed on teardown.
     useEffect(() => {
+      syncStage3dFlatten();
       const fetcher = axFetcherRef.current;
       if (inspectActive) {
         fetcher?.start();
@@ -3301,7 +3353,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     return (
       <div
         ref={containerRef}
-        className={clsx('rc-container', className)}
+        className={clsx('rc-container', stage3d.active && 'rc-3d', className)}
         style={{ touchAction: 'none' }} // Keep touchAction none for the container
         // Attach unified handler to all interaction events on the container
         // This helps capture mouseleave correctly even if the video element itself isn't hovered
@@ -3332,48 +3384,60 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
             />
           </>
         )}
-        {showFrame && (
-          <img
-            ref={frameRef}
-            src={frameImageSrc}
-            alt=""
-            className={platform === 'ios' ? clsx('rc-phone-frame', 'rc-phone-frame-ios') : 'rc-phone-frame'}
-            draggable={false}
-          />
-        )}
-        <video
-          ref={videoRef}
-          className={clsx('rc-video', !showFrame && 'rc-video-frameless', !videoLoaded && 'rc-video-loading')}
-          style={{
-            ...videoStyle,
-            ...(config.loadingLogo ?
-              {
-                backgroundImage: `url("${config.loadingLogo}")`,
-                backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'center',
-                backgroundSize: config.loadingLogoSize,
+        {/* The stage is the 3D-transformed plane holding the device: back
+            panel, frame, video, and glass glare. Everything that must stay
+            screen-aligned (indicators, inspect overlay, retry/terminated)
+            lives outside it. */}
+        <div ref={stage3d.stageRef} className="rc-stage">
+          {stage3d.active && showFrame && <div ref={stage3d.backRef} className="rc-stage-back" />}
+          {showFrame && (
+            <img
+              ref={frameRef}
+              src={frameImageSrc}
+              alt=""
+              className={platform === 'ios' ? clsx('rc-phone-frame', 'rc-phone-frame-ios') : 'rc-phone-frame'}
+              draggable={false}
+            />
+          )}
+          <video
+            ref={videoRef}
+            className={clsx(
+              'rc-video',
+              !showFrame && 'rc-video-frameless',
+              !videoLoaded && 'rc-video-loading',
+            )}
+            style={{
+              ...videoStyle,
+              ...(config.loadingLogo ?
+                {
+                  backgroundImage: `url("${config.loadingLogo}")`,
+                  backgroundRepeat: 'no-repeat',
+                  backgroundPosition: 'center',
+                  backgroundSize: config.loadingLogoSize,
+                }
+              : {}),
+            }}
+            autoPlay
+            playsInline
+            muted
+            tabIndex={0}
+            onKeyDown={handleKeyboard}
+            onKeyUp={handleKeyboard}
+            onClick={handleVideoClick}
+            onLoadedData={markFirstFrameShown}
+            onFocus={() => {
+              if (videoRef.current) {
+                videoRef.current.style.outline = 'none';
               }
-            : {}),
-          }}
-          autoPlay
-          playsInline
-          muted
-          tabIndex={0}
-          onKeyDown={handleKeyboard}
-          onKeyUp={handleKeyboard}
-          onClick={handleVideoClick}
-          onLoadedData={markFirstFrameShown}
-          onFocus={() => {
-            if (videoRef.current) {
-              videoRef.current.style.outline = 'none';
-            }
-          }}
-          onBlur={() => {
-            if (videoRef.current) {
-              videoRef.current.style.outline = 'none';
-            }
-          }}
-        />
+            }}
+            onBlur={() => {
+              if (videoRef.current) {
+                videoRef.current.style.outline = 'none';
+              }
+            }}
+          />
+          {stage3d.active && <div ref={stage3d.glareRef} className="rc-stage-glare" />}
+        </div>
         {inspectActive && (
           <InspectOverlay
             snapshot={axSnapshot}

--- a/packages/ui/src/components/use-stage-3d.ts
+++ b/packages/ui/src/components/use-stage-3d.ts
@@ -1,0 +1,570 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { facing, unprojectPoint } from '../core/stage-3d-math';
+
+// Perspective distance used for the stage transform. Also used by the
+// inverse projection, so keep the CSS and the math in sync through this
+// constant.
+const PERSPECTIVE_PX = 1200;
+// Maximum cursor-follow tilt. Deliberately subtle.
+const MAX_TILT_DEG = 6;
+// Degrees of rotation per pixel of pointer travel while grabbing.
+const GRAB_SENSITIVITY = 0.35;
+// Critically damped spring used to settle back toward the resting pose.
+const SPRING_STIFFNESS = 170;
+const SPRING_DAMPING = 2 * Math.sqrt(SPRING_STIFFNESS);
+// Exponential decay rate of a flick's angular velocity (1/s).
+const SPIN_FRICTION = 2.2;
+// Below this speed (deg/s) a spin hands off to the settle spring.
+const SPIN_END_SPEED = 100;
+// Release speed (deg/s) required for a flick to keep spinning.
+const FLICK_MIN_SPEED = 260;
+const FLICK_MAX_SPEED = 2200;
+// The X axis never tumbles: clamp while grabbing.
+const MAX_ROT_X_DEG = 65;
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+type ElementRect = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+type StageMetrics = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  centerX: number;
+  centerY: number;
+};
+
+type GrabState = {
+  // Touch identifier, or -1 for the mouse pointer.
+  pointerId: number;
+  lastX: number;
+  lastY: number;
+  lastT: number;
+};
+
+export type Stage3D = {
+  // Resolved activation: the prop is on and the user does not prefer
+  // reduced motion. Drives the `rc-3d` class.
+  active: boolean;
+  stageRef: React.RefObject<HTMLDivElement | null>;
+  glareRef: React.RefObject<HTMLDivElement | null>;
+  backRef: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Feed every container pointer event through here before the normal
+   * touch-injection path. Returns true when the event was consumed by the
+   * 3D stage (a grab/rotation gesture) and must not reach the device.
+   */
+  handleInteraction: (event: React.MouseEvent | React.TouchEvent) => boolean;
+  /**
+   * Map a client-space point to the position it occupies on the
+   * untransformed device surface. Identity when the stage is flat or 3D is
+   * inactive, so it is always safe to apply.
+   */
+  unprojectClient: (clientX: number, clientY: number) => { x: number; y: number };
+  /**
+   * Layout-space (untransformed) client rect of the video element. Returns
+   * null when 3D is inactive so callers can fall back to
+   * getBoundingClientRect, which is only correct without a 3D transform.
+   */
+  getVideoLayoutRect: () => DOMRect | null;
+  /**
+   * Precision modes (Alt-pinch, inspect overlay) flatten the device and
+   * suspend tilt/grab so on-screen indicators drawn outside the stage line
+   * up exactly with the video.
+   */
+  setFlattened: (flattened: boolean) => void;
+};
+
+export const useStage3D = ({
+  enabled,
+  containerRef,
+  videoRef,
+  frameRef,
+  showFrame,
+}: {
+  enabled: boolean;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  frameRef: React.RefObject<HTMLImageElement | null>;
+  showFrame: boolean;
+}): Stage3D => {
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const glareRef = useRef<HTMLDivElement | null>(null);
+  const backRef = useRef<HTMLDivElement | null>(null);
+
+  const [reducedMotion, setReducedMotion] = useState(false);
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReducedMotion(query.matches);
+    const onChange = (event: MediaQueryListEvent) => setReducedMotion(event.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
+
+  const active = enabled && !reducedMotion;
+  const activeRef = useRef(active);
+  activeRef.current = active;
+  const showFrameRef = useRef(showFrame);
+  showFrameRef.current = showFrame;
+
+  // All animation state lives in refs: the loop writes styles directly and
+  // never re-renders React.
+  const rotRef = useRef({ x: 0, y: 0 });
+  const velRef = useRef({ x: 0, y: 0 });
+  const tiltTargetRef = useRef({ x: 0, y: 0 });
+  const modeRef = useRef<'rest' | 'settle' | 'grab' | 'spin'>('rest');
+  const grabRef = useRef<GrabState | null>(null);
+  const flattenedRef = useRef(false);
+  const rafRef = useRef<number | undefined>(undefined);
+  const lastTickRef = useRef(0);
+
+  // The ref objects themselves are stable (they come from useRef in the
+  // component), so the memoized callbacks below can close over them safely.
+  const api = useMemo<Omit<Stage3D, 'active'>>(() => {
+    const getStageMetrics = (): StageMetrics | null => {
+      const container = containerRef.current;
+      const stage = stageRef.current;
+      if (!container || !stage) return null;
+      // The container never carries a transform, so its bounding rect is
+      // layout-accurate; offsets locate the stage inside it independently of
+      // the stage's own (3D-transformed) bounding rect. The transform origin
+      // is the stage center, which the transform leaves fixed.
+      const containerRect = container.getBoundingClientRect();
+      const left = containerRect.left + container.clientLeft + stage.offsetLeft;
+      const top = containerRect.top + container.clientTop + stage.offsetTop;
+      const width = stage.offsetWidth;
+      const height = stage.offsetHeight;
+      return { left, top, width, height, centerX: left + width / 2, centerY: top + height / 2 };
+    };
+
+    // Layout-space rect of an element that is a positioned/in-flow child of
+    // the stage, expressed in client coordinates as if no transform applied.
+    const getChildLayoutRect = (element: HTMLElement, centeredByTranslate: boolean): ElementRect | null => {
+      const metrics = getStageMetrics();
+      if (!metrics) return null;
+      const width = element.offsetWidth;
+      const height = element.offsetHeight;
+      let left = metrics.left + element.offsetLeft;
+      let top = metrics.top + element.offsetTop;
+      if (centeredByTranslate) {
+        // .rc-video (framed) positions itself at 50%/50% with a
+        // translate(-50%, -50%) that offsetLeft/offsetTop don't include.
+        left -= width / 2;
+        top -= height / 2;
+      }
+      return { left, top, right: left + width, bottom: top + height, width, height };
+    };
+
+    const getVideoRect = (): ElementRect | null => {
+      const video = videoRef.current;
+      if (!video) return null;
+      return getChildLayoutRect(video, showFrameRef.current);
+    };
+
+    const getFrameRect = (): ElementRect | null => {
+      const frame = frameRef.current;
+      if (!showFrameRef.current || !frame) return null;
+      return getChildLayoutRect(frame, false);
+    };
+
+    const getDeviceRect = (): ElementRect | null => getFrameRect() ?? getVideoRect();
+
+    const isIdle = () => {
+      const rot = rotRef.current;
+      const vel = velRef.current;
+      return (
+        Math.abs(rot.x) < 0.01 && Math.abs(rot.y) < 0.01 && Math.abs(vel.x) < 0.05 && Math.abs(vel.y) < 0.05
+      );
+    };
+
+    // Normalize an angle to (-180, 180] for glare intensity math.
+    const normalizeAngle = (deg: number) => {
+      const wrapped = ((deg % 360) + 540) % 360;
+      return wrapped - 180;
+    };
+
+    const syncOverlayGeometry = (overlay: HTMLElement, rect: ElementRect, metrics: StageMetrics) => {
+      const left = `${rect.left - metrics.left}px`;
+      const top = `${rect.top - metrics.top}px`;
+      const width = `${rect.width}px`;
+      const height = `${rect.height}px`;
+      if (overlay.style.left !== left) overlay.style.left = left;
+      if (overlay.style.top !== top) overlay.style.top = top;
+      if (overlay.style.width !== width) overlay.style.width = width;
+      if (overlay.style.height !== height) overlay.style.height = height;
+      const radius = `${Math.min(rect.width, rect.height) * 0.16}px`;
+      if (overlay.style.borderRadius !== radius) overlay.style.borderRadius = radius;
+    };
+
+    const render = () => {
+      const stage = stageRef.current;
+      if (!stage) return;
+      const { x, y } = rotRef.current;
+      const flat = Math.abs(x) < 0.01 && Math.abs(y) < 0.01;
+      stage.style.transform =
+        flat ? '' : `perspective(${PERSPECTIVE_PX}px) rotateX(${x}deg) rotateY(${y}deg)`;
+
+      const metrics = getStageMetrics();
+      const deviceRect = metrics ? getDeviceRect() : null;
+
+      const glare = glareRef.current;
+      if (glare) {
+        if (flat || !deviceRect || !metrics) {
+          glare.style.opacity = '0';
+        } else {
+          syncOverlayGeometry(glare, deviceRect, metrics);
+          const yn = normalizeAngle(y);
+          // A fixed light up and to the left of the viewer: the highlight
+          // sweeps across the glass opposite to the rotation.
+          const gx = clamp(50 - yn * 1.6, -60, 160);
+          const gy = clamp(50 + x * 1.6, -60, 160);
+          const intensity = clamp((Math.abs(x) + Math.abs(yn)) / 24, 0, 1) * 0.22;
+          glare.style.opacity = '1';
+          glare.style.background = `radial-gradient(circle at ${gx}% ${gy}%, rgba(255,255,255,${intensity.toFixed(
+            3,
+          )}), rgba(255,255,255,0) 62%)`;
+        }
+      }
+
+      const back = backRef.current;
+      if (back && deviceRect && metrics) {
+        syncOverlayGeometry(back, deviceRect, metrics);
+      }
+    };
+
+    const tick = (now: number) => {
+      rafRef.current = undefined;
+      const dt = clamp((now - lastTickRef.current) / 1000, 0.001, 0.04);
+      lastTickRef.current = now;
+
+      const rot = rotRef.current;
+      const vel = velRef.current;
+      let keepRunning = true;
+
+      if (modeRef.current === 'grab') {
+        // Rotation is driven directly by the pointer handlers; the loop only
+        // paints. Bleed sampled velocity slowly so a held-still release
+        // doesn't inherit an old flick.
+        const decay = Math.exp(-6 * dt);
+        vel.x *= decay;
+        vel.y *= decay;
+      } else if (modeRef.current === 'spin') {
+        const decay = Math.exp(-SPIN_FRICTION * dt);
+        vel.x *= decay;
+        vel.y *= decay;
+        rot.x += vel.x * dt;
+        rot.y += vel.y * dt;
+        // Keep the spin from tumbling end-over-end.
+        rot.x += (0 - rot.x) * Math.min(1, 2.5 * dt);
+        if (Math.hypot(vel.x, vel.y) < SPIN_END_SPEED) {
+          modeRef.current = 'settle';
+        }
+      } else {
+        // Settle: critically damped spring toward the resting pose — the
+        // cursor tilt target plus the nearest full Y turn, so a spun device
+        // always comes back around to face the viewer.
+        const flatten = flattenedRef.current;
+        const baseY = Math.round(rot.y / 360) * 360;
+        const targetX = flatten ? 0 : tiltTargetRef.current.x;
+        const targetY = baseY + (flatten ? 0 : tiltTargetRef.current.y);
+        vel.x += (SPRING_STIFFNESS * (targetX - rot.x) - SPRING_DAMPING * vel.x) * dt;
+        vel.y += (SPRING_STIFFNESS * (targetY - rot.y) - SPRING_DAMPING * vel.y) * dt;
+        rot.x += vel.x * dt;
+        rot.y += vel.y * dt;
+        if (
+          Math.abs(targetX - rot.x) < 0.02 &&
+          Math.abs(targetY - rot.y) < 0.02 &&
+          Math.abs(vel.x) < 0.05 &&
+          Math.abs(vel.y) < 0.05
+        ) {
+          rot.x = targetX;
+          // Land exactly on the target, modulo full turns.
+          rot.y = targetY - baseY;
+          vel.x = 0;
+          vel.y = 0;
+          modeRef.current = 'rest';
+          keepRunning = false;
+        }
+      }
+
+      render();
+      if (keepRunning) {
+        rafRef.current = window.requestAnimationFrame(tick);
+      }
+    };
+
+    const ensureLoop = () => {
+      if (rafRef.current !== undefined) return;
+      lastTickRef.current = performance.now();
+      rafRef.current = window.requestAnimationFrame(tick);
+    };
+
+    const unprojectClient = (clientX: number, clientY: number) => {
+      if (!activeRef.current) return { x: clientX, y: clientY };
+      const rot = rotRef.current;
+      if (Math.abs(rot.x) < 0.01 && Math.abs(rot.y) < 0.01) return { x: clientX, y: clientY };
+      const metrics = getStageMetrics();
+      if (!metrics) return { x: clientX, y: clientY };
+      const local = unprojectPoint(
+        rot.x,
+        rot.y,
+        PERSPECTIVE_PX,
+        clientX - metrics.centerX,
+        clientY - metrics.centerY,
+      );
+      if (!local) return { x: clientX, y: clientY };
+      return { x: metrics.centerX + local.x, y: metrics.centerY + local.y };
+    };
+
+    const updateTiltTarget = (clientX: number, clientY: number) => {
+      if (flattenedRef.current) return;
+      // Let a flick play out instead of fighting the cursor.
+      if (modeRef.current === 'spin' || modeRef.current === 'grab') return;
+      const metrics = getStageMetrics();
+      if (!metrics) return;
+      const deviceRect = getDeviceRect();
+      // Normalize by the device size (not the container, which can be much
+      // wider): one device-width from center reaches the full tilt.
+      const halfX = deviceRect ? Math.max(deviceRect.width, 1) : metrics.width / 2;
+      const halfY = deviceRect ? Math.max(deviceRect.height, 1) : metrics.height / 2;
+      const nx = clamp((clientX - metrics.centerX) / halfX, -1, 1);
+      const ny = clamp((clientY - metrics.centerY) / halfY, -1, 1);
+      // Turn to face the cursor: cursor right → positive rotateY (right edge
+      // recedes), cursor below → negative rotateX (bottom edge recedes).
+      tiltTargetRef.current = { x: -ny * MAX_TILT_DEG, y: nx * MAX_TILT_DEG };
+      if (modeRef.current === 'rest') modeRef.current = 'settle';
+      ensureLoop();
+    };
+
+    const clearTiltTarget = () => {
+      tiltTargetRef.current = { x: 0, y: 0 };
+      if (modeRef.current === 'rest' && isIdle()) return;
+      if (modeRef.current === 'rest') modeRef.current = 'settle';
+      ensureLoop();
+    };
+
+    const beginGrab = (clientX: number, clientY: number, pointerId: number) => {
+      grabRef.current = { pointerId, lastX: clientX, lastY: clientY, lastT: performance.now() };
+      modeRef.current = 'grab';
+      ensureLoop();
+    };
+
+    // Decide whether a press should grab the device instead of touching the
+    // screen. Grabbing happens:
+    //   - anywhere, to catch a device that is spinning or facing away;
+    //   - outside the device entirely (empty container space);
+    //   - on the frame's corner bezels — the areas beyond the screen on both
+    //     axes. Bezel bands directly above/below/left/right of the screen
+    //     keep their existing behavior (edge-clamped touches power gestures
+    //     like the home-indicator swipe from below the screen).
+    const tryBeginGrab = (clientX: number, clientY: number, pointerId: number): boolean => {
+      if (flattenedRef.current) return false;
+      if (modeRef.current === 'spin') {
+        beginGrab(clientX, clientY, pointerId);
+        return true;
+      }
+      const rot = rotRef.current;
+      if (facing(rot.x, rot.y) < 0.2) {
+        beginGrab(clientX, clientY, pointerId);
+        return true;
+      }
+      const point = unprojectClient(clientX, clientY);
+      const deviceRect = getDeviceRect();
+      if (!deviceRect) return false;
+      const insideDevice =
+        point.x >= deviceRect.left &&
+        point.x <= deviceRect.right &&
+        point.y >= deviceRect.top &&
+        point.y <= deviceRect.bottom;
+      if (!insideDevice) {
+        beginGrab(clientX, clientY, pointerId);
+        return true;
+      }
+      // Corner bezels only exist when the frame is shown.
+      if (!getFrameRect()) return false;
+      const videoRect = getVideoRect();
+      if (!videoRect) return false;
+      const beyondX = point.x < videoRect.left || point.x > videoRect.right;
+      const beyondY = point.y < videoRect.top || point.y > videoRect.bottom;
+      if (beyondX && beyondY) {
+        beginGrab(clientX, clientY, pointerId);
+        return true;
+      }
+      return false;
+    };
+
+    const moveGrab = (clientX: number, clientY: number) => {
+      const grab = grabRef.current;
+      if (!grab) return;
+      const now = performance.now();
+      const dt = Math.max((now - grab.lastT) / 1000, 1e-3);
+      const dx = clientX - grab.lastX;
+      const dy = clientY - grab.lastY;
+      const rot = rotRef.current;
+      rot.y += dx * GRAB_SENSITIVITY;
+      rot.x = clamp(rot.x - dy * GRAB_SENSITIVITY, -MAX_ROT_X_DEG, MAX_ROT_X_DEG);
+      const vel = velRef.current;
+      vel.y = clamp(0.5 * vel.y + 0.5 * ((dx * GRAB_SENSITIVITY) / dt), -FLICK_MAX_SPEED, FLICK_MAX_SPEED);
+      vel.x = clamp(0.5 * vel.x + 0.5 * ((-dy * GRAB_SENSITIVITY) / dt), -FLICK_MAX_SPEED, FLICK_MAX_SPEED);
+      grab.lastX = clientX;
+      grab.lastY = clientY;
+      grab.lastT = now;
+      ensureLoop();
+    };
+
+    const endGrab = () => {
+      const grab = grabRef.current;
+      grabRef.current = null;
+      if (!grab) return;
+      const vel = velRef.current;
+      // A pause before release means "place it down", not "flick it".
+      if (performance.now() - grab.lastT > 120) {
+        vel.x = 0;
+        vel.y = 0;
+      }
+      modeRef.current = Math.hypot(vel.x, vel.y) >= FLICK_MIN_SPEED ? 'spin' : 'settle';
+      ensureLoop();
+    };
+
+    const findTouch = (touches: React.TouchList, identifier: number): React.Touch | null => {
+      for (let i = 0; i < touches.length; i++) {
+        const touch = touches.item(i);
+        if (touch && touch.identifier === identifier) return touch;
+      }
+      return null;
+    };
+
+    const handleInteraction = (event: React.MouseEvent | React.TouchEvent): boolean => {
+      if (!activeRef.current) return false;
+
+      if (!('touches' in event)) {
+        switch (event.type) {
+          case 'mousemove':
+            if (grabRef.current) {
+              moveGrab(event.clientX, event.clientY);
+              return true;
+            }
+            // Don't shift the surface underneath an active screen drag.
+            if ((event.buttons & 1) === 0) {
+              updateTiltTarget(event.clientX, event.clientY);
+            }
+            return false;
+          case 'mousedown':
+            if (event.button !== 0) return false;
+            return tryBeginGrab(event.clientX, event.clientY, -1);
+          case 'mouseup':
+            if (grabRef.current) {
+              endGrab();
+              return true;
+            }
+            return false;
+          case 'mouseleave':
+            clearTiltTarget();
+            if (grabRef.current) {
+              endGrab();
+              return true;
+            }
+            return false;
+        }
+        return false;
+      }
+
+      const grab = grabRef.current;
+      switch (event.type) {
+        case 'touchstart': {
+          // Extra fingers landing mid-grab stay with the grab; they must not
+          // leak into the touch-injection path.
+          if (grab) return true;
+          if (event.touches.length !== 1) return false;
+          const touch = event.changedTouches[0];
+          if (!touch) return false;
+          return tryBeginGrab(touch.clientX, touch.clientY, touch.identifier);
+        }
+        case 'touchmove': {
+          if (!grab) return false;
+          const touch = findTouch(event.touches, grab.pointerId);
+          if (touch) moveGrab(touch.clientX, touch.clientY);
+          return true;
+        }
+        case 'touchend':
+        case 'touchcancel': {
+          if (!grab) return false;
+          if (!findTouch(event.touches, grab.pointerId)) endGrab();
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const setFlattened = (flattened: boolean) => {
+      if (flattenedRef.current === flattened) return;
+      flattenedRef.current = flattened;
+      if (flattened) {
+        grabRef.current = null;
+        tiltTargetRef.current = { x: 0, y: 0 };
+        if (modeRef.current === 'grab' || modeRef.current === 'spin') modeRef.current = 'settle';
+      }
+      if (!isIdle() || modeRef.current !== 'rest') {
+        if (modeRef.current === 'rest') modeRef.current = 'settle';
+        ensureLoop();
+      }
+    };
+
+    const getVideoLayoutRect = (): DOMRect | null => {
+      if (!activeRef.current) return null;
+      const rect = getVideoRect();
+      if (!rect) return null;
+      return new DOMRect(rect.left, rect.top, rect.width, rect.height);
+    };
+
+    return {
+      stageRef,
+      glareRef,
+      backRef,
+      handleInteraction,
+      unprojectClient,
+      getVideoLayoutRect,
+      setFlattened,
+    };
+  }, []);
+
+  // When 3D turns off (prop change or reduced-motion), stop the loop and
+  // snap everything back to flat.
+  useEffect(() => {
+    if (active) return;
+    if (rafRef.current !== undefined) {
+      window.cancelAnimationFrame(rafRef.current);
+      rafRef.current = undefined;
+    }
+    grabRef.current = null;
+    modeRef.current = 'rest';
+    rotRef.current = { x: 0, y: 0 };
+    velRef.current = { x: 0, y: 0 };
+    tiltTargetRef.current = { x: 0, y: 0 };
+    const stage = stageRef.current;
+    if (stage) stage.style.transform = '';
+    const glare = glareRef.current;
+    if (glare) glare.style.opacity = '0';
+  }, [active]);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current !== undefined) {
+        window.cancelAnimationFrame(rafRef.current);
+        rafRef.current = undefined;
+      }
+    },
+    [],
+  );
+
+  return { ...api, active };
+};

--- a/packages/ui/src/core/stage-3d-math.test.ts
+++ b/packages/ui/src/core/stage-3d-math.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { facing, projectPoint, rotationBasis, unprojectPoint } from './stage-3d-math';
+
+const PERSPECTIVE = 1200;
+
+describe('stage-3d-math', () => {
+  it('is the identity when the stage is flat', () => {
+    const projected = projectPoint(0, 0, PERSPECTIVE, 123.4, -56.7);
+    expect(projected).not.toBeNull();
+    expect(projected!.x).toBeCloseTo(123.4, 6);
+    expect(projected!.y).toBeCloseTo(-56.7, 6);
+
+    const unprojected = unprojectPoint(0, 0, PERSPECTIVE, 123.4, -56.7);
+    expect(unprojected).not.toBeNull();
+    expect(unprojected!.x).toBeCloseTo(123.4, 6);
+    expect(unprojected!.y).toBeCloseTo(-56.7, 6);
+  });
+
+  it('round-trips project → unproject across the interaction range', () => {
+    const angles = [-45, -20, -8, -1, 0, 3, 12, 30, 60];
+    const points = [
+      { u: 0, v: 0 },
+      { u: 180, v: 390 },
+      { u: -180, v: -390 },
+      { u: 175.25, v: -12.5 },
+      { u: -30, v: 400 },
+    ];
+    for (const rx of angles) {
+      for (const ry of angles) {
+        for (const { u, v } of points) {
+          const screen = projectPoint(rx, ry, PERSPECTIVE, u, v);
+          expect(screen).not.toBeNull();
+          const local = unprojectPoint(rx, ry, PERSPECTIVE, screen!.x, screen!.y);
+          expect(local).not.toBeNull();
+          expect(local!.x).toBeCloseTo(u, 4);
+          expect(local!.y).toBeCloseTo(v, 4);
+        }
+      }
+    }
+  });
+
+  it('moves the right edge away from the viewer for positive rotateY', () => {
+    // "Turn to face the cursor": cursor on the right → positive rotateY →
+    // the right edge (u > 0) recedes, so its projection shrinks toward the
+    // center rather than growing.
+    const projected = projectPoint(0, 20, PERSPECTIVE, 200, 0);
+    expect(projected).not.toBeNull();
+    expect(projected!.x).toBeLessThan(200);
+  });
+
+  it('reports facing correctly', () => {
+    expect(facing(0, 0)).toBeCloseTo(1, 6);
+    expect(facing(0, 90)).toBeCloseTo(0, 6);
+    expect(facing(0, 180)).toBeCloseTo(-1, 6);
+    expect(facing(45, 45)).toBeGreaterThan(0);
+  });
+
+  it('rejects unprojection when looking at the back of the device', () => {
+    // At 180° the ray through the origin still intersects the plane, but any
+    // other screen point maps behind the eye or via a negative ray parameter.
+    expect(unprojectPoint(0, 170, PERSPECTIVE, 50, 10)).toBeNull();
+  });
+
+  it('keeps the rotation basis orthonormal', () => {
+    const { xAxis, yAxis, normal } = rotationBasis(33, -58);
+    const dot = (a: { x: number; y: number; z: number }, b: { x: number; y: number; z: number }) =>
+      a.x * b.x + a.y * b.y + a.z * b.z;
+    expect(dot(xAxis, yAxis)).toBeCloseTo(0, 9);
+    expect(dot(xAxis, normal)).toBeCloseTo(0, 9);
+    expect(dot(yAxis, normal)).toBeCloseTo(0, 9);
+    expect(dot(xAxis, xAxis)).toBeCloseTo(1, 9);
+    expect(dot(yAxis, yAxis)).toBeCloseTo(1, 9);
+    expect(dot(normal, normal)).toBeCloseTo(1, 9);
+  });
+});

--- a/packages/ui/src/core/stage-3d-math.ts
+++ b/packages/ui/src/core/stage-3d-math.ts
@@ -1,0 +1,104 @@
+// Math for the 3D device stage.
+//
+// The stage element is rendered with the CSS transform
+//
+//   perspective(P) rotateX(a) rotateY(b)
+//
+// around its center (default `transform-origin`). CSS applies the functions
+// left-to-right to a point, i.e. a stage-local point q = (u, v, 0) ends up at
+//
+//   p = Rx(a) · Ry(b) · q            (rotation)
+//   screen = (p.x, p.y) · P / (P - p.z)   (perspective divide, eye at (0,0,P))
+//
+// with x pointing right, y pointing down, and z toward the viewer.
+//
+// Pointer events arrive in screen space, but touch injection needs the
+// position on the (untransformed) device surface. `unprojectPoint` inverts
+// the mapping exactly by casting a ray from the eye through the screen point
+// and intersecting it with the rotated stage plane, so taps stay
+// pixel-accurate even while the device is tilted.
+
+export type Vec2 = { x: number; y: number };
+export type Vec3 = { x: number; y: number; z: number };
+
+const DEG2RAD = Math.PI / 180;
+
+type RotationBasis = {
+  // Columns of R = Rx(a)·Ry(b): images of the local x/y/z axes.
+  xAxis: Vec3;
+  yAxis: Vec3;
+  normal: Vec3;
+};
+
+export const rotationBasis = (rotateXDeg: number, rotateYDeg: number): RotationBasis => {
+  const a = rotateXDeg * DEG2RAD;
+  const b = rotateYDeg * DEG2RAD;
+  const ca = Math.cos(a);
+  const sa = Math.sin(a);
+  const cb = Math.cos(b);
+  const sb = Math.sin(b);
+  return {
+    xAxis: { x: cb, y: sa * sb, z: -ca * sb },
+    yAxis: { x: 0, y: ca, z: sa },
+    normal: { x: sb, y: -sa * cb, z: ca * cb },
+  };
+};
+
+// z-component of the rotated surface normal. Positive means the screen face
+// points toward the viewer; negative means we're looking at the back.
+export const facing = (rotateXDeg: number, rotateYDeg: number): number =>
+  Math.cos(rotateXDeg * DEG2RAD) * Math.cos(rotateYDeg * DEG2RAD);
+
+// Forward projection of a stage-local point (relative to the transform
+// origin) into screen space (also relative to the origin). Returns null for
+// points behind the eye. Used by tests to validate the inverse.
+export const projectPoint = (
+  rotateXDeg: number,
+  rotateYDeg: number,
+  perspective: number,
+  u: number,
+  v: number,
+): Vec2 | null => {
+  const { xAxis, yAxis } = rotationBasis(rotateXDeg, rotateYDeg);
+  const p: Vec3 = {
+    x: xAxis.x * u + yAxis.x * v,
+    y: xAxis.y * u + yAxis.y * v,
+    z: xAxis.z * u + yAxis.z * v,
+  };
+  const w = perspective - p.z;
+  if (w <= 0) return null;
+  const scale = perspective / w;
+  return { x: p.x * scale, y: p.y * scale };
+};
+
+// Inverse projection: given a screen point (relative to the transform
+// origin), returns the stage-local point that renders there, or null when
+// the ray misses the front of the surface (grazing angles / backside).
+export const unprojectPoint = (
+  rotateXDeg: number,
+  rotateYDeg: number,
+  perspective: number,
+  screenX: number,
+  screenY: number,
+): Vec2 | null => {
+  const { xAxis, yAxis, normal } = rotationBasis(rotateXDeg, rotateYDeg);
+
+  // The viewer sees the back of the surface: there is no meaningful screen
+  // position to map to.
+  if (normal.z <= 1e-6) return null;
+
+  // Ray from the eye E = (0, 0, P) through S = (screenX, screenY, 0),
+  // intersected with the plane { X : normal · X = 0 }.
+  const denominator = normal.z * perspective - normal.x * screenX - normal.y * screenY;
+  if (Math.abs(denominator) < 1e-9) return null;
+  const t = (normal.z * perspective) / denominator;
+  // t <= 0 means the intersection is behind the eye; t is unbounded near
+  // grazing angles where input mapping is meaningless anyway.
+  if (t <= 0 || !Number.isFinite(t)) return null;
+
+  const X: Vec3 = { x: screenX * t, y: screenY * t, z: perspective * (1 - t) };
+  return {
+    x: xAxis.x * X.x + xAxis.y * X.y + xAxis.z * X.z,
+    y: yAxis.x * X.x + yAxis.y * X.y + yAxis.z * X.z,
+  };
+};

--- a/packages/ui/src/demo.tsx
+++ b/packages/ui/src/demo.tsx
@@ -23,6 +23,7 @@ function Demo() {
   const [isConnected, setIsConnected] = useState(initialAutoconnect);
   const [key, setKey] = useState(0);
   const [showDebugInfo, setShowDebugInfo] = useState(false);
+  const [interactive3d, setInteractive3d] = useState(initialParams.get('3d') !== '0');
   const [inspectChoice, setInspectChoice] = useState<InspectChoice>(initialInspect);
   const [latestSnapshot, setLatestSnapshot] = useState<AxSnapshot | null>(null);
   const [latestSelection, setLatestSelection] = useState<string | null>(null);
@@ -135,6 +136,18 @@ function Demo() {
           </div>
 
           <div className="control-group">
+            <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={interactive3d}
+                onChange={(e) => setInteractive3d(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              3D device (tilt to face cursor, grab corners/space around it to spin)
+            </label>
+          </div>
+
+          <div className="control-group">
             <label htmlFor="inspect-mode">Inspect Mode</label>
             <select
               id="inspect-mode"
@@ -198,6 +211,7 @@ function Demo() {
                     ref={remoteControlRef}
                     url={url}
                     token={token}
+                    interactive3d={interactive3d}
                     inspectMode={inspectModeProp}
                     onAxSnapshotChange={setLatestSnapshot}
                     onInspectSelectionChange={(sel) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Brings the "3D simulator" experience (as described in [Bitrig's blog post](https://bitrig.com/blog/take-bitrigs-3d-simulators-for-a-spin)) to `RemoteControl`:

- **Turns to face the cursor** — moving the mouse around the component subtly tilts the device toward it (max 6°), with a glass glare that sweeps across the device as it catches the light.
- **Grab and spin** — pressing on the frame's corner bezels or on the empty space around the device and dragging rotates it in 3D. A flick sends it spinning (with inertia) before a critically damped spring settles it back to the nearest full turn, facing the viewer. While it spins past 90° a stylized device back (gradient + camera cluster) is shown via `preserve-3d` + `backface-visibility`.
- Enabled by default via a new `interactive3d` prop (`interactive3d={false}` opts out). Automatically disabled for users with `prefers-reduced-motion`.

## How

- **`src/core/stage-3d-math.ts`** — exact forward/inverse projection for the `perspective(P) rotateX(a) rotateY(b)` stage transform. The inverse casts a ray from the CSS eye point through the pointer and intersects the rotated plane, so **screen taps/drags stay pixel-accurate while the device is tilted**. Unit-tested (round-trips, orientation conventions, backface rejection).
- **`src/components/use-stage-3d.ts`** — a hook holding all interaction state in refs and writing `style.transform` from a self-stopping rAF loop (no React re-renders, zero work at rest). Modes: `rest → settle (spring) → grab → spin (friction) → settle`. Also drives the glare gradient and back-panel geometry.
- **`RemoteControl`** integration:
  - The frame + video are wrapped in a `.rc-stage` plane that fills the container (so its transform origin is the device center and child coordinates keep matching container coordinates). Indicators, inspect overlay, and retry/terminated UI stay outside, screen-aligned.
  - Pointer events pass through the stage first; consumed events (rotation gestures) never reach touch injection.
  - Input mapping uses layout-space rects (offset geometry) instead of `getBoundingClientRect`, which returns projected boxes under a 3D transform, and unprojects pointer coordinates in the three mapping helpers.
  - Sub-pixel `translateZ` offsets reproduce the existing z-index order (iOS frame under video, Android frame over it) for the 3D depth sorter.

## Compatibility

- The bezel bands directly above/below/beside the screen keep their existing edge-clamped touch behavior — notably the documented iOS home-indicator swipe-up from below the screen. Only corner bezels and the space around the device become grab handles.
- Precision modes (Alt-pinch mirror indicators, inspect overlay) flatten the device while active so overlays drawn outside the stage line up exactly.
- With `interactive3d={false}` (or reduced motion) the original `getBoundingClientRect` code path is used unchanged.

## Testing

- `yarn test` in `packages/ui` — 57 tests pass (6 new for the projection math).
- `./scripts/lint` (prettier, eslint, build, tsc, attw, publint) passes.
- `packages/ui` `yarn build` (tsc + vite lib build) passes.
- Demo page gets a "3D device" toggle (`?3d=0` to disable) for manual testing against a live instance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf41-1684-7b6b-8089-fceb049622be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf41-1684-7b6b-8089-fceb049622be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

