### PR TITLE
deps(cli): bump @limrun/api to 0.45.4 and drop undici resolution

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.45.3",
+    "@limrun/api": "0.45.4",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",
@@ -86,9 +86,5 @@
     "dist",
     "bin",
     "README.md"
-  ],
-  "//": "resolutions.undici overrides @limrun/api's exact pin; remove once the SDK ships undici >=7.28.0 and our @limrun/api dep is bumped",
-  "resolutions": {
-    "undici": "7.28.0"
-  }
+  ]
 }

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,17 +578,17 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@0.45.3":
-  version "0.45.3"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.3.tgz#406b1f6af636a7ef413243861aeb267115d0845c"
-  integrity sha512-gSBiNUcuKjSjoP7WCQqto8+xz4VMfdPcO+Msb3lBPloyMhqxMHtleNXvV8LinmDZ0KFTzBYvPxBz8LF5ljTzvQ==
+"@limrun/api@0.45.4":
+  version "0.45.4"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.4.tgz#cf6fd0bca9627c7feb4d1230f1bc91cadf3b50fa"
+  integrity sha512-4yZE88aWQZJs3ynsG87AinK/X7n6qtFbi5/JHVb2nPXmk6QR1mPpLD58LF8cga9OPkW5+W2B5PeqqUbsPxNPNQ==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"
     ignore "^7.0.5"
     proxy-from-env "^2.1.0"
-    undici "7.24.7"
+    undici "7.28.0"
     ws "^8.18.3"
     yauzl "^3.4.0"
 
@@ -2632,7 +2632,7 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.24.7, undici@7.28.0:
+undici@7.28.0:
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
   integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency version bump and lockfile cleanup only; no application logic changes.
> 
> **Overview**
> Updates the CLI’s **`@limrun/api`** dependency from **0.45.3** to **0.45.4** and refreshes **`yarn.lock`**.
> 
> Removes the package-level **`resolutions.undici`** override that forced **7.28.0** on top of the SDK’s older pin; **0.45.4** already depends on **`undici` 7.28.0**, so the workaround is no longer needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ce55454a5dcc4765bbd23ef55fb94663bdcc1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->