### PR TITLE
cli: accept repeated --provisioning-profile for apps with embedded extensions

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -9,7 +9,6 @@ import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance }
 import { webhookConfigFromFlags } from '../../lib/webhook-options';
 import {
   hasSigningFlags,
-  signingConfigFromMaterial,
   signingFlagsProblem,
   type XcodeSigningFlagValues,
 } from '../../lib/xcode-signing-options';
@@ -426,11 +425,15 @@ export default class XcodeBuild extends BaseCommand {
     if (!hasSigningFlags(flags)) {
       return undefined;
     }
-    const [certificate, ...profiles] = await Promise.all([
+    const [certificateP12Base64, ...provisioningProfilesBase64] = await Promise.all([
       this.readFileBase64(flags['certificate-p12']!, '--certificate-p12'),
       ...flags['provisioning-profile']!.map((path) => this.readFileBase64(path, '--provisioning-profile')),
     ]);
-    return signingConfigFromMaterial(certificate, flags['certificate-password']!, profiles);
+    return {
+      certificateP12Base64,
+      certificatePassword: flags['certificate-password']!,
+      provisioningProfilesBase64,
+    };
   }
 
   private async readFileBase64(path: string, flagName: string): Promise<string> {

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -8,19 +8,21 @@ import { parseAdditionalFileFlags } from '../../lib/additional-files';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
 import { webhookConfigFromFlags } from '../../lib/webhook-options';
 import {
+  hasSigningFlags,
+  signingConfigFromMaterial,
+  signingFlagsProblem,
+  type XcodeSigningFlagValues,
+} from '../../lib/xcode-signing-options';
+import {
   parseBuildSettingEntries,
   type AppStoreUploadConfig,
   type XcodeBuildOptions,
   type XcodeClient,
+  type XcodeSigningConfig,
 } from '@limrun/api';
 
 const DEVICE_SDKS = new Set(['iphoneos', 'watchos']);
 const SIMULATOR_SDKS = new Set(['iphonesimulator', 'watchsimulator']);
-type SigningFlags = {
-  'certificate-p12'?: string;
-  'certificate-password'?: string;
-  'provisioning-profile'?: string;
-};
 type AppStoreFlags = {
   'upload-to-appstore': boolean;
   'asc-key-id'?: string;
@@ -49,6 +51,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./MyProject --xcodegen-spec specs/app.yml --xcodegen-project ios',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
+    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./app.mobileprovision --provisioning-profile ./widgets.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
@@ -137,7 +140,8 @@ export default class XcodeBuild extends BaseCommand {
     }),
     'provisioning-profile': Flags.string({
       description:
-        'Path to a .mobileprovision profile. Requires --certificate-p12 and --certificate-password.',
+        'Path to a .mobileprovision profile. Requires --certificate-p12 and --certificate-password. Repeat for an app with embedded extensions (widgets, watch apps): one profile per bundle, all for the same certificate; each is matched to its bundle by the application-identifier inside the profile.',
+      multiple: true,
     }),
     'upload-to-appstore': Flags.boolean({
       description:
@@ -219,6 +223,12 @@ export default class XcodeBuild extends BaseCommand {
     }
     if (flags.ios && hasSigningFlags(flags)) {
       this.error('--ios builds run on a simulator and cannot use signing flags.');
+    }
+    const signingProblem = signingFlagsProblem(flags);
+    if (signingProblem) {
+      // Rejected before instance resolution: a doomed flag combination must
+      // not leave a billed instance behind.
+      this.error(signingProblem);
     }
     if (flags.ios && (flags['upload-to-appstore'] || hasAppStoreFlags(flags))) {
       this.error('--ios builds run on a simulator and cannot upload to App Store Connect.');
@@ -408,34 +418,16 @@ export default class XcodeBuild extends BaseCommand {
     });
   }
 
-  private async buildSigningOptions(flags: SigningFlags): Promise<
-    | {
-        certificateP12Base64: string;
-        certificatePassword: string;
-        provisioningProfileBase64: string;
-      }
-    | undefined
-  > {
-    const hasCertificate = flags['certificate-p12'] !== undefined;
-    const hasPassword = flags['certificate-password'] !== undefined;
-    const hasProfile = flags['provisioning-profile'] !== undefined;
+  private async buildSigningOptions(flags: XcodeSigningFlagValues): Promise<XcodeSigningConfig | undefined> {
+    // Flag completeness was validated before instance resolution.
     if (!hasSigningFlags(flags)) {
       return undefined;
     }
-    if (!hasCertificate || !hasPassword || !hasProfile) {
-      this.error(
-        'Signed device builds require --certificate-p12, --certificate-password, and --provisioning-profile.',
-      );
-    }
-
-    return {
-      certificateP12Base64: await this.readFileBase64(flags['certificate-p12']!, '--certificate-p12'),
-      certificatePassword: flags['certificate-password']!,
-      provisioningProfileBase64: await this.readFileBase64(
-        flags['provisioning-profile']!,
-        '--provisioning-profile',
-      ),
-    };
+    const [certificate, ...profiles] = await Promise.all([
+      this.readFileBase64(flags['certificate-p12']!, '--certificate-p12'),
+      ...flags['provisioning-profile']!.map((path) => this.readFileBase64(path, '--provisioning-profile')),
+    ]);
+    return signingConfigFromMaterial(certificate, flags['certificate-password']!, profiles);
   }
 
   private async readFileBase64(path: string, flagName: string): Promise<string> {
@@ -498,14 +490,6 @@ export default class XcodeBuild extends BaseCommand {
       return undefined;
     }
   }
-}
-
-function hasSigningFlags(flags: SigningFlags): boolean {
-  return (
-    flags['certificate-p12'] !== undefined ||
-    flags['certificate-password'] !== undefined ||
-    flags['provisioning-profile'] !== undefined
-  );
 }
 
 function hasAppStoreFlags(flags: AppStoreFlags): boolean {

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -142,6 +142,9 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Path to a .mobileprovision profile. Requires --certificate-p12 and --certificate-password. Repeat for an app with embedded extensions (widgets, watch apps): one profile per bundle, all for the same certificate; each is matched to its bundle by the application-identifier inside the profile.',
       multiple: true,
+      // One value per occurrence: greedy mode would swallow a positional
+      // project path placed after the flag as another profile.
+      multipleNonGreedy: true,
     }),
     'upload-to-appstore': Flags.boolean({
       description:

--- a/packages/cli/src/lib/xcode-signing-options.test.ts
+++ b/packages/cli/src/lib/xcode-signing-options.test.ts
@@ -1,8 +1,4 @@
-import {
-  hasSigningFlags,
-  signingConfigFromMaterial,
-  signingFlagsProblem,
-} from './xcode-signing-options';
+import { hasSigningFlags, signingConfigFromMaterial, signingFlagsProblem } from './xcode-signing-options';
 
 describe('signingFlagsProblem', () => {
   it('accepts an absent group and a complete group', () => {

--- a/packages/cli/src/lib/xcode-signing-options.test.ts
+++ b/packages/cli/src/lib/xcode-signing-options.test.ts
@@ -1,0 +1,60 @@
+import {
+  hasSigningFlags,
+  signingConfigFromMaterial,
+  signingFlagsProblem,
+} from './xcode-signing-options';
+
+describe('signingFlagsProblem', () => {
+  it('accepts an absent group and a complete group', () => {
+    expect(signingFlagsProblem({})).toBeUndefined();
+    expect(
+      signingFlagsProblem({
+        'certificate-p12': 'dist.p12',
+        'certificate-password': 'pw',
+        'provisioning-profile': ['app', 'widgets'],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('rejects a partial group', () => {
+    expect(signingFlagsProblem({ 'provisioning-profile': ['app'] })).toMatch(/--certificate-p12/);
+  });
+
+  it('treats an empty-string password as provided, not missing', () => {
+    expect(
+      signingFlagsProblem({
+        'certificate-p12': 'dist.p12',
+        'certificate-password': '',
+        'provisioning-profile': ['app'],
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('hasSigningFlags', () => {
+  it('detects any signing flag, so a partial group can be rejected', () => {
+    expect(hasSigningFlags({})).toBe(false);
+    expect(hasSigningFlags({ 'certificate-password': '' })).toBe(true);
+    expect(hasSigningFlags({ 'provisioning-profile': ['app'] })).toBe(true);
+  });
+});
+
+describe('signingConfigFromMaterial', () => {
+  it('uses the single-profile field for one profile so older limbuild servers keep working', () => {
+    expect(signingConfigFromMaterial('cert', 'pw', ['app-profile'])).toEqual({
+      certificateP12Base64: 'cert',
+      certificatePassword: 'pw',
+      provisioningProfileBase64: 'app-profile',
+    });
+  });
+
+  it('uses ONLY the array field for multiple profiles', () => {
+    const config = signingConfigFromMaterial('cert', 'pw', ['app-profile', 'widget-profile']);
+    expect(config).toEqual({
+      certificateP12Base64: 'cert',
+      certificatePassword: 'pw',
+      provisioningProfilesBase64: ['app-profile', 'widget-profile'],
+    });
+    expect(config.provisioningProfileBase64).toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/xcode-signing-options.test.ts
+++ b/packages/cli/src/lib/xcode-signing-options.test.ts
@@ -1,4 +1,4 @@
-import { hasSigningFlags, signingConfigFromMaterial, signingFlagsProblem } from './xcode-signing-options';
+import { hasSigningFlags, signingFlagsProblem } from './xcode-signing-options';
 
 describe('signingFlagsProblem', () => {
   it('accepts an absent group and a complete group', () => {
@@ -32,25 +32,5 @@ describe('hasSigningFlags', () => {
     expect(hasSigningFlags({})).toBe(false);
     expect(hasSigningFlags({ 'certificate-password': '' })).toBe(true);
     expect(hasSigningFlags({ 'provisioning-profile': ['app'] })).toBe(true);
-  });
-});
-
-describe('signingConfigFromMaterial', () => {
-  it('uses the single-profile field for one profile so older limbuild servers keep working', () => {
-    expect(signingConfigFromMaterial('cert', 'pw', ['app-profile'])).toEqual({
-      certificateP12Base64: 'cert',
-      certificatePassword: 'pw',
-      provisioningProfileBase64: 'app-profile',
-    });
-  });
-
-  it('uses ONLY the array field for multiple profiles', () => {
-    const config = signingConfigFromMaterial('cert', 'pw', ['app-profile', 'widget-profile']);
-    expect(config).toEqual({
-      certificateP12Base64: 'cert',
-      certificatePassword: 'pw',
-      provisioningProfilesBase64: ['app-profile', 'widget-profile'],
-    });
-    expect(config.provisioningProfileBase64).toBeUndefined();
   });
 });

--- a/packages/cli/src/lib/xcode-signing-options.ts
+++ b/packages/cli/src/lib/xcode-signing-options.ts
@@ -1,5 +1,3 @@
-import type { XcodeSigningConfig } from '@limrun/api';
-
 export interface XcodeSigningFlagValues {
   'certificate-p12'?: string;
   'certificate-password'?: string;
@@ -32,26 +30,4 @@ export function signingFlagsProblem(flags: XcodeSigningFlagValues): string | und
     return 'Signed device builds require --certificate-p12, --certificate-password, and --provisioning-profile.';
   }
   return undefined;
-}
-
-/**
- * Maps the read signing material to the exec request's signing config.
- * Exactly one profile uses the single-profile field so older limbuild
- * servers keep working. Multiple profiles use ONLY the array field: an old
- * server that does not understand it then fails the build loudly instead of
- * silently signing every bundle with one profile, which is the exact broken
- * archive multi-profile signing exists to prevent.
- */
-export function signingConfigFromMaterial(
-  certificateP12Base64: string,
-  certificatePassword: string,
-  provisioningProfilesBase64: string[],
-): XcodeSigningConfig {
-  return {
-    certificateP12Base64,
-    certificatePassword,
-    ...(provisioningProfilesBase64.length === 1 ?
-      { provisioningProfileBase64: provisioningProfilesBase64[0] }
-    : { provisioningProfilesBase64 }),
-  };
 }

--- a/packages/cli/src/lib/xcode-signing-options.ts
+++ b/packages/cli/src/lib/xcode-signing-options.ts
@@ -1,0 +1,57 @@
+import type { XcodeSigningConfig } from '@limrun/api';
+
+export interface XcodeSigningFlagValues {
+  'certificate-p12'?: string;
+  'certificate-password'?: string;
+  'provisioning-profile'?: string[];
+}
+
+export function hasSigningFlags(flags: XcodeSigningFlagValues): boolean {
+  return (
+    flags['certificate-p12'] !== undefined ||
+    flags['certificate-password'] !== undefined ||
+    flags['provisioning-profile'] !== undefined
+  );
+}
+
+/**
+ * Returns the problem with an incomplete signing flag group, or undefined
+ * when the group is absent or complete. Pure and oclif-free so the command
+ * can reject a doomed combination before resolving (and possibly
+ * auto-creating) a billed instance.
+ */
+export function signingFlagsProblem(flags: XcodeSigningFlagValues): string | undefined {
+  if (!hasSigningFlags(flags)) {
+    return undefined;
+  }
+  if (
+    flags['certificate-p12'] === undefined ||
+    flags['certificate-password'] === undefined ||
+    flags['provisioning-profile'] === undefined
+  ) {
+    return 'Signed device builds require --certificate-p12, --certificate-password, and --provisioning-profile.';
+  }
+  return undefined;
+}
+
+/**
+ * Maps the read signing material to the exec request's signing config.
+ * Exactly one profile uses the single-profile field so older limbuild
+ * servers keep working. Multiple profiles use ONLY the array field: an old
+ * server that does not understand it then fails the build loudly instead of
+ * silently signing every bundle with one profile, which is the exact broken
+ * archive multi-profile signing exists to prevent.
+ */
+export function signingConfigFromMaterial(
+  certificateP12Base64: string,
+  certificatePassword: string,
+  provisioningProfilesBase64: string[],
+): XcodeSigningConfig {
+  return {
+    certificateP12Base64,
+    certificatePassword,
+    ...(provisioningProfilesBase64.length === 1 ?
+      { provisioningProfileBase64: provisioningProfilesBase64[0] }
+    : { provisioningProfilesBase64 }),
+  };
+}

--- a/packages/device-install/README.md
+++ b/packages/device-install/README.md
@@ -219,7 +219,7 @@ const { exitCode } = await xcode.xcodebuild(
     signing: {
       certificateP12Base64: certificateSecret.data.certificateP12Base64,
       certificatePassword: certificateSecret.data.certificatePassword,
-      provisioningProfileBase64: profileSecret.data.provisioningProfileBase64,
+      provisioningProfilesBase64: [profileSecret.data.provisioningProfileBase64],
     },
     upload: { assetName: 'my-app.ipa' },
   },

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -35,8 +35,7 @@ export type XcodeBuildExecRequest = {
   signing?: {
     certificateP12Base64?: string;
     certificatePassword?: string;
-    provisioningProfileBase64?: string;
-    /** One profile per embedded bundle; wins over provisioningProfileBase64. */
+    /** One profile per embedded bundle. */
     provisioningProfilesBase64?: string[];
   };
   /** Wire name retained for compatibility with the limbuild exec API. */

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -36,6 +36,8 @@ export type XcodeBuildExecRequest = {
     certificateP12Base64?: string;
     certificatePassword?: string;
     provisioningProfileBase64?: string;
+    /** One profile per embedded bundle; wins over provisioningProfileBase64. */
+    provisioningProfilesBase64?: string[];
   };
   /** Wire name retained for compatibility with the limbuild exec API. */
   testflight?: AppStoreUploadConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export {
   type XcodeBuildOptions,
   type XcodeRunOptions,
   type XcodeGenConfig,
+  type XcodeSigningConfig,
   type ReactNativeBuildConfig,
   type SimulatorAttachResult,
   type SimulatorStatus,

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -56,6 +56,7 @@ export {
   type XcodeBuildOptions,
   type XcodeRunOptions,
   type XcodeGenConfig,
+  type XcodeSigningConfig,
   type ReactNativeBuildConfig,
   type SimulatorAttachResult,
   type SimulatorStatus,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -120,7 +120,22 @@ export type XcodeGenConfig = {
 export type XcodeSigningConfig = {
   certificateP12Base64?: string;
   certificatePassword?: string;
+  /**
+   * Base64-encoded .mobileprovision profile. Use this single-profile field
+   * for an app with no embedded extensions; it also works on older limbuild
+   * servers.
+   */
   provisioningProfileBase64?: string;
+  /**
+   * Base64-encoded .mobileprovision profiles, one per bundle the app embeds:
+   * the app itself plus each app extension (e.g. WidgetKit) and watch app.
+   * All profiles must share the signing certificate and carry explicit
+   * (non-wildcard) bundle ids; each is matched to its bundle by the
+   * application-identifier inside the profile. Takes precedence over
+   * provisioningProfileBase64. Older limbuild servers do not understand this
+   * field and fail the build instead of signing with a subset.
+   */
+  provisioningProfilesBase64?: string[];
 };
 
 export type ReactNativeBuildConfig = {

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -121,19 +121,11 @@ export type XcodeSigningConfig = {
   certificateP12Base64?: string;
   certificatePassword?: string;
   /**
-   * Base64-encoded .mobileprovision profile. Use this single-profile field
-   * for an app with no embedded extensions; it also works on older limbuild
-   * servers.
-   */
-  provisioningProfileBase64?: string;
-  /**
    * Base64-encoded .mobileprovision profiles, one per bundle the app embeds:
    * the app itself plus each app extension (e.g. WidgetKit) and watch app.
-   * All profiles must share the signing certificate and carry explicit
-   * (non-wildcard) bundle ids; each is matched to its bundle by the
-   * application-identifier inside the profile. Takes precedence over
-   * provisioningProfileBase64. Older limbuild servers do not understand this
-   * field and fail the build instead of signing with a subset.
+   * All profiles must share the signing certificate, and with more than one
+   * profile each must carry an explicit (non-wildcard) bundle id; profiles
+   * are matched to bundles by the application-identifier inside them.
    */
   provisioningProfilesBase64?: string[];
 };

--- a/tests/xcode-client-signing.test.ts
+++ b/tests/xcode-client-signing.test.ts
@@ -1,0 +1,65 @@
+jest.mock('eventsource-client', () => ({
+  createEventSource: jest.fn((options: { onMessage: (message: { event: string; data: string }) => void }) => {
+    setTimeout(() => options.onMessage({ event: 'exitCode', data: '0' }), 0);
+    return { close: jest.fn() };
+  }),
+}));
+
+import Limrun from '@limrun/api';
+import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
+import type { RequestInfo } from '../src/internal/builtin-types';
+
+const originalFetch = nodeProxyTransport.fetch;
+
+describe('xcode client signing', () => {
+  afterEach(() => {
+    nodeProxyTransport.fetch = originalFetch;
+  });
+
+  test('serializes the multi-profile signing config verbatim', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://xcode.example.test/exec') {
+        return jsonResponse({ execId: 'build-1' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const xcode = await client.xcodeInstances.createClient({
+      apiUrl: 'https://xcode.example.test',
+      token: 'xcode-token',
+    });
+
+    const result = await xcode.xcodebuild(
+      { sdk: 'iphoneos' },
+      {
+        signing: {
+          certificateP12Base64: 'cert',
+          certificatePassword: 'pw',
+          provisioningProfilesBase64: ['widget-profile', 'app-profile'],
+        },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls[0]?.init?.method).toBe('POST');
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'xcodebuild',
+      xcodebuild: { sdk: 'iphoneos' },
+      signing: {
+        certificateP12Base64: 'cert',
+        certificatePassword: 'pw',
+        provisioningProfilesBase64: ['widget-profile', 'app-profile'],
+      },
+    });
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking API rename from `provisioningProfileBase64` to `provisioningProfilesBase64` affects all signed-build callers; signing behavior is security-sensitive though scope is limited to client wiring and validation.
> 
> **Overview**
> **Signed device builds** can now supply **multiple provisioning profiles** (app + widgets, watch extensions, etc.) via repeated `--provisioning-profile` on `lim xcode build`, and the same shape on the Xcode client API as `provisioningProfilesBase64` instead of a single `provisioningProfileBase64`.
> 
> The CLI reads every profile path in parallel, uses `multipleNonGreedy` so a trailing positional project path is not swallowed as another profile, and documents bundle matching via `application-identifier` inside each profile. Signing flag validation (`hasSigningFlags`, `signingFlagsProblem`) moves into `xcode-signing-options` and runs **before** instance resolution so incomplete signing flags fail without spinning up a billed sandbox.
> 
> Docs and a client test confirm the exec payload serializes the multi-profile signing config unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e14528b893fb366e8f9a2fbc8ae7f9aa5c0d27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->