### PR TITLE
deps(cli): bump @limrun/api to 0.45.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.45.4",
+    "@limrun/api": "0.45.5",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@0.45.4":
-  version "0.45.4"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.4.tgz#cf6fd0bca9627c7feb4d1230f1bc91cadf3b50fa"
-  integrity sha512-4yZE88aWQZJs3ynsG87AinK/X7n6qtFbi5/JHVb2nPXmk6QR1mPpLD58LF8cga9OPkW5+W2B5PeqqUbsPxNPNQ==
+"@limrun/api@0.45.5":
+  version "0.45.5"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.5.tgz#e009b49b533a20de92e02fc334eacd5a624dedf8"
+  integrity sha512-CDXSsWh5BZWNfF6XWyEn9P2QtUpLg702UqcjBihGdLZBzUfMU7JrjTQx7aT4woE9o1KSgvtX6RInaEi0hFcxng==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only dependency bump with no application code changes; risk is limited to whatever changed in the published SDK between patch releases.
> 
> **Overview**
> Updates the **`lim`** CLI to depend on **`@limrun/api` `0.45.5`** (from `0.45.4`) in `packages/cli/package.json`, with the matching **`yarn.lock`** resolution and integrity hash.
> 
> No CLI source changes—only the pinned SDK version used at install/build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64a363f2d7f82ef7698de81bf493a10858192a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->