### PR TITLE
cli: release 0.23.0 with multi-provisioning-profile signing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no runtime or logic modifications in the diff.
> 
> **Overview**
> **Bumps the `lim` CLI package version from `0.22.0` to `0.23.0`** in `packages/cli/package.json` so the next npm publish is tagged as release **0.23.0** (aligned with the release noted in the PR title, including multi-provisioning-profile signing shipped in this version outside this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75e12ef3881d6b7a5ef5a3bfb33bb0b5e16669a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->