### PR TITLE
cli,example: add Apple cloud signing

### DIFF
--- a/examples/publish-to-stores/README.md
+++ b/examples/publish-to-stores/README.md
@@ -13,20 +13,20 @@ still prepare its signing material (see
 ## Architecture
 
 - `frontend/` uses `@limrun/apple-auth` to sign into Apple through Limrun's
-  registry relay, choose or create a bundle ID, and prepare four publishing
-  resources — an Apple distribution certificate, App Store provisioning
-  profile, App Store Connect app record, and App Store Connect API key —
-  plus, optionally, the device-install credentials: a development
-  certificate and ad-hoc/development provisioning profiles covering the
-  team's registered iPhones.
+  registry relay, choose or create a bundle ID, and choose Apple cloud signing
+  or manual signing. It prepares the App Store Connect app record and Admin API
+  key for either mode; manual mode also creates the distribution certificate
+  and App Store provisioning profile. It can separately prepare
+  device-install credentials covering the team's registered iPhones.
 - The Android tab uses `@limrun/play-auth` for Google Identity Services and
   browser-side upload-keystore generation. It detects the package from the
   project, verifies Play Console access, then calls the backend with a
   short-lived Google access token.
 - `backend/` keeps `LIM_API_KEY` server-side, mints a short-lived
   `applerelay:*:connect` scoped token, stores signing secrets as files under
-  `backend/.secrets/`, runs a detached `lim xcode build` with
-  `--upload-to-appstore`, and tracks the callback. Android follows the same
+  `backend/.secrets/`, runs a detached `lim xcode build` with the selected
+  signing mode and `--upload-to-appstore`, and tracks the callback. Android
+  follows the same
   pattern with detached `lim gradle build`: it signs `bundleRelease`, resolves
   the next Play `versionCode`, publishes the AAB, and reports completion by
   webhook.
@@ -40,9 +40,27 @@ TestFlight automatically; the success link opens the app's distribution page
 where the processed build can be attached to a version and submitted for
 review.
 
+## iOS signing modes
+
+The Connect phase makes the ownership of signing credentials explicit:
+
+- **Apple cloud signing** uses only the App Store Connect API key from the
+  configured secret store. `lim xcode build` exports with
+  `--signing-method app-store-connect`; Apple creates, stores, and reuses the
+  cloud-managed distribution certificate and provisioning profile.
+- **Manual signing** creates and maintains the distribution certificate (p12)
+  and App Store provisioning profile in the configured secret store. The
+  backend materializes them only for the build and passes
+  `--certificate-p12` and `--provisioning-profile`. The App Store Connect API
+  key is still used for the upload.
+
+Switching modes resets the Connect checklist to that mode's required resources.
+The device-install certificate and profile actions remain optional and are
+independent of the publishing mode.
+
 ## Device install credentials
 
-The last three Connect actions create what the
+The certificate and device-profile Connect actions create what the
 [`device-install`](../device-install) example needs: a development
 certificate (WebUSB installs) and ad-hoc/development provisioning profiles
 (QR code and WebUSB installs) bound to the iPhones already registered on the
@@ -91,6 +109,8 @@ an origin other than `http://localhost:5173`.
   entered in the UI (see [Webhook URL](#webhook-url))
 - An Apple Developer Program account with permission to create App Store
   Connect API keys
+- For Apple cloud signing, an Admin API key or one with **Access to
+  cloud-managed distribution certificates**
 - A Google Play Console app and a Google account with release permission
 
 ## Webhook URL

--- a/examples/publish-to-stores/backend/index.ts
+++ b/examples/publish-to-stores/backend/index.ts
@@ -94,14 +94,25 @@ app.delete('/secrets/:type/:name', async (req: Request<{ type: string; name: str
 // must be a public URL that forwards to the webhook receiver's port 3001
 // (e.g. from `ngrok http 3001`).
 app.post('/publish', async (req: Request<{}, {}, Partial<PublishRequest>>, res: Response) => {
-  const { projectPath, teamId, bundleId, scheme, secretsDir, webhookUrl } = req.body;
-  if (!projectPath || !teamId || !bundleId || !webhookUrl) {
+  const { projectPath, teamId, bundleId, signingMode, scheme, secretsDir, webhookUrl } = req.body;
+  if (!projectPath || !teamId || !bundleId || !signingMode || !webhookUrl) {
     return res.status(400).json({
       status: 'error',
-      message: 'projectPath, teamId, bundleId and webhookUrl are required',
+      message: 'projectPath, teamId, bundleId, signingMode and webhookUrl are required',
     });
   }
-  const id = await startPublish({ projectPath, teamId, bundleId, scheme, secretsDir, webhookUrl });
+  if (signingMode !== 'cloud' && signingMode !== 'manual') {
+    return res.status(400).json({ status: 'error', message: 'signingMode must be cloud or manual' });
+  }
+  const id = await startPublish({
+    projectPath,
+    teamId,
+    bundleId,
+    signingMode,
+    scheme,
+    secretsDir,
+    webhookUrl,
+  });
   return res.status(202).json({ publishId: id });
 });
 

--- a/examples/publish-to-stores/backend/package.json
+++ b/examples/publish-to-stores/backend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "tsx watch index.ts",
     "start": "tsc -b && node dist/index.js",
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "test": "tsx --test publish.test.ts"
   },
   "license": "ISC",
   "dependencies": {

--- a/examples/publish-to-stores/backend/package.json
+++ b/examples/publish-to-stores/backend/package.json
@@ -12,7 +12,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@limrun/api": "^0.45.2",
+    "@limrun/api": "^0.46.1",
     "cors": "^2.8.5",
     "express": "^5.1.0"
   },

--- a/examples/publish-to-stores/backend/publish.test.ts
+++ b/examples/publish-to-stores/backend/publish.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { buildSigningArguments, resolvePublishCredentials } from './publish.js';
+import { putSecret } from './secret-store.js';
+
+const teamId = 'TEAM123456';
+const bundleId = 'com.example.app';
+
+async function withSecrets(run: (dir: string) => Promise<void>) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'publish-signing-test-'));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('cloud signing resolves only the App Store Connect API key', async () => {
+  await withSecrets(async (dir) => {
+    await putSecret(
+      'appStoreConnectApiKey',
+      `${teamId}/APP_STORE_CONNECT_API_KEY`,
+      { keyId: 'KEY123', issuerId: 'issuer-id', privateKeyP8Base64: 'a2V5' },
+      dir,
+    );
+
+    const credentials = await resolvePublishCredentials(teamId, bundleId, 'cloud', dir);
+    assert.equal(credentials.signingMode, 'cloud');
+    assert.equal(credentials.apiKey.data.keyId, 'KEY123');
+  });
+});
+
+test('manual signing requires and resolves stored certificate and profile', async () => {
+  await withSecrets(async (dir) => {
+    await putSecret(
+      'appStoreConnectApiKey',
+      `${teamId}/APP_STORE_CONNECT_API_KEY`,
+      { keyId: 'KEY123', privateKeyP8Base64: 'a2V5' },
+      dir,
+    );
+    await assert.rejects(
+      resolvePublishCredentials(teamId, bundleId, 'manual', dir),
+      /No distribution certificate/,
+    );
+
+    await putSecret(
+      'appleCertificate',
+      `${teamId}/DISTRIBUTION`,
+      {
+        certificateP12Base64: 'cDEy',
+        certificatePassword: 'secret',
+        serialNumber: 'CERT123',
+        expirationDate: '2000-01-01T00:00:00Z',
+      },
+      dir,
+    );
+    await putSecret(
+      'appleProvisioningProfile',
+      `${teamId}/PROFILE`,
+      {
+        teamID: teamId,
+        bundleIDs: ` ${bundleId} `,
+        certificateSerialNumbers: 'OTHER',
+        expirationDate: '2100-01-01T00:00:00Z',
+        provisioningProfileBase64: 'cHJvZmlsZQ==',
+      },
+      dir,
+    );
+    await assert.rejects(resolvePublishCredentials(teamId, bundleId, 'manual', dir), /certificate.*expired/i);
+
+    await putSecret(
+      'appleCertificate',
+      `${teamId}/DISTRIBUTION`,
+      {
+        certificateP12Base64: 'cDEy',
+        certificatePassword: 'secret',
+        serialNumber: 'CERT123',
+        expirationDate: '2100-01-01T00:00:00Z',
+      },
+      dir,
+    );
+    await assert.rejects(
+      resolvePublishCredentials(teamId, bundleId, 'manual', dir),
+      /matches the distribution/,
+    );
+
+    await putSecret(
+      'appleProvisioningProfile',
+      `${teamId}/PROFILE`,
+      {
+        teamID: teamId,
+        bundleIDs: ` ${bundleId} `,
+        certificateSerialNumbers: 'CERT123',
+        expirationDate: '2100-01-01T00:00:00Z',
+        provisioningProfileBase64: 'cHJvZmlsZQ==',
+      },
+      dir,
+    );
+
+    const credentials = await resolvePublishCredentials(teamId, bundleId, 'manual', dir);
+    assert.equal(credentials.signingMode, 'manual');
+    assert.equal(credentials.certificate.data.certificatePassword, 'secret');
+    assert.equal(credentials.profile.data.bundleIDs.trim(), bundleId);
+  });
+});
+
+test('build arguments keep cloud and manual signing mutually exclusive', () => {
+  const cloud = buildSigningArguments({
+    signingMode: 'cloud',
+    teamId,
+    apiKeyId: 'KEY123',
+    apiIssuerId: 'issuer-id',
+    apiKeyPath: '/tmp/AuthKey.p8',
+  });
+  assert.ok(cloud.includes('--signing-method'));
+  assert.ok(!cloud.includes('--certificate-p12'));
+
+  const manual = buildSigningArguments({
+    signingMode: 'manual',
+    teamId,
+    apiKeyId: 'KEY123',
+    apiKeyPath: '/tmp/AuthKey.p8',
+    certificatePath: '/tmp/certificate.p12',
+    certificatePassword: 'secret',
+    profilePath: '/tmp/profile.mobileprovision',
+  });
+  assert.ok(manual.includes('--certificate-p12'));
+  assert.ok(manual.includes('--provisioning-profile'));
+  assert.ok(!manual.includes('--signing-method'));
+  assert.ok(cloud.includes('--upload-to-appstore'));
+  assert.ok(manual.includes('--upload-to-appstore'));
+});

--- a/examples/publish-to-stores/backend/publish.ts
+++ b/examples/publish-to-stores/backend/publish.ts
@@ -1,6 +1,7 @@
-// Runs one store publish: materializes stored signing secrets into temp files,
-// starts a detached `lim xcode build` with a build-finish webhook, uploads to
-// App Store Connect, and tracks the build until the callback arrives.
+// Runs one store publish: materializes either the cloud-signing API key or
+// manual signing credentials, starts a detached `lim xcode build` with a
+// build-finish webhook, uploads to App Store Connect, and tracks the build
+// until the callback arrives.
 import { spawn } from 'node:child_process';
 import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
@@ -8,10 +9,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { getSecret, listSecrets, type StoredSecret } from './secret-store.js';
 
+export type SigningMode = 'cloud' | 'manual';
+
 export type PublishRequest = {
   projectPath: string;
   teamId: string;
   bundleId: string;
+  signingMode: SigningMode;
   scheme?: string;
   /** Store directory the signing secrets live in; backend default when absent. */
   secretsDir?: string;
@@ -23,45 +27,88 @@ export type PublishRequest = {
   webhookUrl: string;
 };
 
-type PublishCredentials = {
+type CloudPublishCredentials = {
+  signingMode: 'cloud';
+  apiKey: StoredSecret;
+};
+
+type ManualPublishCredentials = {
+  signingMode: 'manual';
   certificate: StoredSecret;
   profile: StoredSecret;
   apiKey: StoredSecret;
 };
 
+type PublishCredentials = CloudPublishCredentials | ManualPublishCredentials;
+
+function isUnexpired(expirationDate?: string): boolean {
+  if (!expirationDate) return true;
+  const expiresAt = Date.parse(expirationDate);
+  return !Number.isNaN(expiresAt) && expiresAt > Date.now();
+}
+
+function commaSeparatedValues(value?: string): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
 /**
- * Resolves the three secrets a store upload needs. The distribution
- * certificate and App Store Connect API key live under conventional names;
- * the App Store profile is found by its references: same team, binds the
- * bundle ID, and binds no devices (only App Store profiles are device-free).
+ * Resolves the credentials for the selected signing mode. Cloud signing only
+ * needs the team API key; manual signing additionally reads the distribution
+ * certificate and App Store profile maintained by the secret store.
  */
 export async function resolvePublishCredentials(
   teamId: string,
   bundleId: string,
+  signingMode: SigningMode,
   secretsDir?: string,
 ): Promise<PublishCredentials> {
+  const apiKey = await getSecret('appStoreConnectApiKey', `${teamId}/APP_STORE_CONNECT_API_KEY`, secretsDir);
+  if (!apiKey) {
+    throw new Error(`No App Store Connect API key stored for team ${teamId}. Run Connect first.`);
+  }
+  if (signingMode === 'cloud') {
+    if (!apiKey.data.issuerId) {
+      throw new Error(
+        `The App Store Connect API key for team ${teamId} has no issuer ID; cloud signing requires a team key.`,
+      );
+    }
+    return { signingMode, apiKey };
+  }
+
   const certificate = await getSecret('appleCertificate', `${teamId}/DISTRIBUTION`, secretsDir);
   if (!certificate) {
     throw new Error(`No distribution certificate stored for team ${teamId}. Run Connect first.`);
   }
-  const apiKey = await getSecret('appStoreConnectApiKey', `${teamId}/APP_STORE_CONNECT_API_KEY`, secretsDir);
-  if (!apiKey) {
-    throw new Error(`No App Store Connect API key stored for team ${teamId}. Run Connect first.`);
+  if (!isUnexpired(certificate.data.expirationDate)) {
+    throw new Error(`The stored distribution certificate for team ${teamId} has expired. Run Connect again.`);
+  }
+  const certificateSerial = certificate.data.serialNumber;
+  if (!certificateSerial) {
+    throw new Error(
+      `The stored distribution certificate for team ${teamId} has no serial number. Run Connect again.`,
+    );
   }
   const profiles = (await listSecrets(secretsDir))
     .filter(
       (secret) =>
         secret.type === 'appleProvisioningProfile' &&
         secret.data.teamID === teamId &&
-        (secret.data.bundleIDs ?? '').split(',').includes(bundleId) &&
-        !secret.data.deviceIDs,
+        commaSeparatedValues(secret.data.bundleIDs).includes(bundleId) &&
+        !secret.data.deviceIDs &&
+        isUnexpired(secret.data.expirationDate) &&
+        commaSeparatedValues(secret.data.certificateSerialNumbers).includes(certificateSerial),
     )
     .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
   const profile = profiles[0];
   if (!profile) {
-    throw new Error(`No App Store provisioning profile stored for ${bundleId}. Run Connect first.`);
+    throw new Error(
+      `No current App Store provisioning profile stored for ${bundleId} matches the distribution certificate. Run Connect with manual signing first.`,
+    );
   }
-  return { certificate, profile, apiKey };
+  return { signingMode, certificate, profile, apiKey };
 }
 
 // How deep findExpoAppConfigs descends. Monorepos nest their Expo app a few
@@ -294,43 +341,103 @@ export function spawnDetachedLim(options: {
   });
 }
 
+export function buildSigningArguments(options: {
+  signingMode: SigningMode;
+  teamId: string;
+  apiKeyId: string;
+  apiIssuerId?: string;
+  apiKeyPath: string;
+  certificatePath?: string;
+  certificatePassword?: string;
+  profilePath?: string;
+}): string[] {
+  const args: string[] = [];
+  if (options.signingMode === 'cloud') {
+    if (!options.apiIssuerId) throw new Error('Cloud signing requires an App Store Connect issuer ID.');
+    args.push('--signing-method', 'app-store-connect', '--team-id', options.teamId);
+  } else {
+    if (!options.certificatePath || !options.profilePath) {
+      throw new Error('Manual signing requires a certificate and provisioning profile.');
+    }
+    args.push(
+      '--certificate-p12',
+      options.certificatePath,
+      '--certificate-password',
+      options.certificatePassword ?? '',
+      '--provisioning-profile',
+      options.profilePath,
+    );
+  }
+  args.push(
+    '--upload-to-appstore',
+    '--auto-build-number',
+    '--asc-key-id',
+    options.apiKeyId,
+    '--asc-key',
+    options.apiKeyPath,
+  );
+  if (options.apiIssuerId) args.push('--asc-issuer-id', options.apiIssuerId);
+  return args;
+}
+
+function loggedCommand(args: string[]): string {
+  return args
+    .map((arg, index) => (args[index - 1] === '--certificate-password' ? '<redacted>' : arg))
+    .join(' ');
+}
+
 /**
- * Materializes the stored signing secrets into temp files and spawns
- * `lim xcode build` with a build-finish webhook pointing at the URL the
- * request carries. Returns the publish ID the frontend polls; the outcome
+ * Materializes the selected signing credentials into a temp directory and
+ * spawns `lim xcode build` with a build-finish webhook pointing at the URL
+ * the request carries. Returns the publish ID the frontend polls; the outcome
  * arrives via the webhook, not the CLI's output — that output only goes to
  * this process's console for debugging.
  */
 export async function startPublish(request: PublishRequest): Promise<string> {
-  const credentials = await resolvePublishCredentials(request.teamId, request.bundleId, request.secretsDir);
-  const { certificate, profile } = credentials;
+  const credentials = await resolvePublishCredentials(
+    request.teamId,
+    request.bundleId,
+    request.signingMode,
+    request.secretsDir,
+  );
 
   const workDir = await mkdtemp(path.join(os.tmpdir(), 'publish-to-stores-'));
-  const certificatePath = path.join(workDir, 'certificate.p12');
-  const profilePath = path.join(workDir, 'profile.mobileprovision');
-  await writeFile(certificatePath, Buffer.from(certificate.data.certificateP12Base64, 'base64'), {
-    mode: 0o600,
-  });
-  await writeFile(profilePath, Buffer.from(profile.data.provisioningProfileBase64, 'base64'), {
+  const apiKeyPath = path.join(workDir, 'AuthKey.p8');
+  await writeFile(apiKeyPath, Buffer.from(credentials.apiKey.data.privateKeyP8Base64, 'base64'), {
     mode: 0o600,
   });
 
   const { id, token } = beginPublish();
 
-  const args = [
-    'xcode',
-    'build',
-    request.projectPath,
-    '--sdk',
-    'iphoneos',
-    '--configuration',
-    'Release',
-    '--certificate-p12',
-    certificatePath,
-    '--certificate-password',
-    certificate.data.certificatePassword ?? '',
-    '--provisioning-profile',
-    profilePath,
+  const args = ['xcode', 'build', request.projectPath, '--sdk', 'iphoneos', '--configuration', 'Release'];
+  let certificatePath: string | undefined;
+  let profilePath: string | undefined;
+  if (credentials.signingMode === 'manual') {
+    certificatePath = path.join(workDir, 'certificate.p12');
+    profilePath = path.join(workDir, 'profile.mobileprovision');
+    await writeFile(
+      certificatePath,
+      Buffer.from(credentials.certificate.data.certificateP12Base64, 'base64'),
+      {
+        mode: 0o600,
+      },
+    );
+    await writeFile(profilePath, Buffer.from(credentials.profile.data.provisioningProfileBase64, 'base64'), {
+      mode: 0o600,
+    });
+  }
+  args.push(
+    ...buildSigningArguments({
+      signingMode: credentials.signingMode,
+      teamId: request.teamId,
+      apiKeyId: credentials.apiKey.data.keyId,
+      apiIssuerId: credentials.apiKey.data.issuerId,
+      apiKeyPath,
+      certificatePath,
+      certificatePassword:
+        credentials.signingMode === 'manual' ? credentials.certificate.data.certificatePassword : undefined,
+      profilePath,
+    }),
     '--webhook-url',
     request.webhookUrl,
     '--webhook-header',
@@ -341,22 +448,7 @@ export async function startPublish(request: PublishRequest): Promise<string> {
     // The detach summary (instance, console link, webhook) arrives as one
     // JSON object on stdout instead of prose, so it is machine-readable here.
     '--json',
-  ];
-  const apiKeyPath = path.join(workDir, 'AuthKey.p8');
-  await writeFile(apiKeyPath, Buffer.from(credentials.apiKey.data.privateKeyP8Base64, 'base64'), {
-    mode: 0o600,
-  });
-  args.push(
-    '--upload-to-appstore',
-    '--auto-build-number',
-    '--asc-key-id',
-    credentials.apiKey.data.keyId,
-    '--asc-key',
-    apiKeyPath,
   );
-  if (credentials.apiKey.data.issuerId) {
-    args.push('--asc-issuer-id', credentials.apiKey.data.issuerId);
-  }
   if (request.scheme) {
     args.push('--scheme', request.scheme);
   }
@@ -366,7 +458,7 @@ export async function startPublish(request: PublishRequest): Promise<string> {
   for (const line of await ensureExpoBundleIdentifier(request.projectPath, request.bundleId)) {
     log(line);
   }
-  log(`$ lim ${args.join(' ')}`);
+  log(`$ lim ${loggedCommand(args)}`);
   spawnDetachedLim({ id, args, workDir, log });
   return id;
 }

--- a/examples/publish-to-stores/backend/tsconfig.json
+++ b/examples/publish-to-stores/backend/tsconfig.json
@@ -10,6 +10,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["index.ts", "secret-store.ts", "publish.ts"],
+  "include": ["index.ts", "secret-store.ts", "publish.ts", "publish.test.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/publish-to-stores/backend/yarn.lock
+++ b/examples/publish-to-stores/backend/yarn.lock
@@ -132,17 +132,17 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
   integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
 
-"@limrun/api@^0.45.2":
-  version "0.45.2"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.2.tgz#39fc213112594dc29f91350e573d9ce6897814e3"
-  integrity sha512-MObfpKJ8Vg+qnHU+FGNIFOmUI8QAnmKWiTCudy9ap7Wozl/Su3kgwPDBXY7LiD9IjjR95kbOL3Y+LaPGBbKPAQ==
+"@limrun/api@^0.46.1":
+  version "0.46.1"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.1.tgz#afaf28a83931b5f60754f6d1e62769270eba5d42"
+  integrity sha512-6qImY7XFj7xOR0h+evi38Uo2nEWMtxH9sc6pA35b8FlpZqFYPbCAgHblKnnUoZuoqJmIAA4wFHMjvpfTbagIjQ==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"
     ignore "^7.0.5"
     proxy-from-env "^2.1.0"
-    undici "7.24.7"
+    undici "7.28.0"
     ws "^8.18.3"
     yauzl "^3.4.0"
 
@@ -804,10 +804,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.24.7:
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.24.7.tgz#af9535341bbe80625ca403a02418477a5c6a8760"
-  integrity sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==
+undici@7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unpipe@~1.0.0:
   version "1.0.0"

--- a/examples/publish-to-stores/frontend/src/components/ConnectPhase.tsx
+++ b/examples/publish-to-stores/frontend/src/components/ConnectPhase.tsx
@@ -1,12 +1,7 @@
 // The Connect wizard UI: Apple ID login (password + 2FA), team selection,
 // bundle ID / app name inputs, and the action checklist. All behaviour
 // lives in useConnect; this component only renders its state.
-import {
-  CONNECT_ACTIONS,
-  NEW_BUNDLE_ID,
-  type ConnectController,
-  type ActionStatus,
-} from '../hooks/useConnect';
+import { NEW_BUNDLE_ID, type ConnectController, type ActionStatus } from '../hooks/useConnect';
 import { hintText, infoBox, inputStyle, labelStyle, primaryButton, secondaryButton, warnBox } from '../theme';
 import { Section } from './Section';
 
@@ -109,8 +104,8 @@ export function ConnectPhase({ connect }: { connect: ConnectController }) {
     return (
       <Section title="1. Connect">
         <div style={infoBox}>
-          Connected: team {connect.connection.teamId}, bundle ID {connect.connection.bundleId}. Signing
-          material is in the secret store, so this phase is skipped.
+          Connected: team {connect.connection.teamId}, bundle ID {connect.connection.bundleId}, using{' '}
+          {connect.connection.signingMode === 'cloud' ? 'Apple cloud signing' : 'manual signing'}.
         </div>
         <button style={secondaryButton(false)} onClick={connect.disconnect}>
           Disconnect and start over
@@ -179,9 +174,27 @@ export function ConnectPhase({ connect }: { connect: ConnectController }) {
             name on the App Store.
           </p>
 
+          <label style={labelStyle}>Signing mode</label>
+          <select
+            style={inputStyle}
+            value={connect.signingMode}
+            disabled={connect.busy === 'confirm'}
+            onChange={(event) => connect.selectSigningMode(event.target.value as 'cloud' | 'manual')}
+          >
+            <option value="cloud">Apple cloud signing</option>
+            <option value="manual">Manual signing</option>
+          </select>
+          <p style={hintText}>
+            {connect.signingMode === 'cloud' ?
+              'This mode only needs the App Store Connect API key. Apple creates and keeps the signing certificate.'
+            : 'The distribution certificate and provisioning profile are created and maintained in this secret store.'
+            }
+          </p>
+
           <label style={labelStyle}>Actions</label>
-          {CONNECT_ACTIONS.map((action) => {
+          {connect.visibleActions.map((action) => {
             const state = connect.actionStates[action.id];
+            const required = connect.requiredActions.has(action.id);
             return (
               <label
                 key={action.id}
@@ -190,11 +203,14 @@ export function ConnectPhase({ connect }: { connect: ConnectController }) {
                 <input
                   type="checkbox"
                   checked={connect.selectedActions.has(action.id)}
-                  disabled={connect.busy === 'confirm'}
+                  disabled={connect.busy === 'confirm' || required}
                   onChange={() => connect.toggleAction(action.id)}
                 />
                 <span style={{ flex: 1 }}>
-                  <strong>{action.label}</strong>
+                  <strong>
+                    {action.label}
+                    {required ? ' (required)' : ''}
+                  </strong>
                   <br />
                   <span style={hintText}>{action.description}</span>
                   {state && (

--- a/examples/publish-to-stores/frontend/src/components/PublishPhase.tsx
+++ b/examples/publish-to-stores/frontend/src/components/PublishPhase.tsx
@@ -59,6 +59,7 @@ export function PublishPhase({
             projectPath: projectPath.trim(),
             teamId: connection.teamId,
             bundleId: connection.bundleId,
+            signingMode: connection.signingMode,
             webhookUrl: webhookUrl.trim(),
           })
         }

--- a/examples/publish-to-stores/frontend/src/hooks/useConnect.ts
+++ b/examples/publish-to-stores/frontend/src/hooks/useConnect.ts
@@ -1,6 +1,6 @@
 // The Connect phase: a one-time flow that signs into Apple, resolves the
-// team and bundle ID, and materializes everything a publish — and,
-// optionally, the device-install example — later needs: certificates,
+// team and bundle ID, and materializes everything a publish, and
+// optionally the device-install example, later needs: certificates,
 // provisioning profiles, the App Store Connect app record and an App
 // Store Connect API key — into the backend's secret store. Read
 // top-to-bottom it doubles as a reference for the `@limrun/apple-auth`
@@ -37,24 +37,24 @@ import {
 } from '@limrun/apple-auth';
 import { useAppleIDLogin } from '@limrun/apple-auth/react';
 import { naming } from '../config';
-import { errorMessage, fetchRegistrySession, type RegistrySession } from '../lib/backend';
+import { errorMessage, fetchRegistrySession, type RegistrySession, type SigningMode } from '../lib/backend';
 
 /**
  * The deselectable actions of the Connect checklist. The bundle ID itself is
- * always ensured because every profile depends on it. The first four cover
- * publishing; the last three prepare the signing material the
- * device-install example uses for QR code and WebUSB installs.
+ * always ensured because every profile depends on it. The app record and API
+ * key cover publishing; the remaining actions prepare signing material for
+ * the device-install example's QR code and WebUSB installs.
  */
 export const CONNECT_ACTIONS = [
   {
     id: 'distributionCertificate',
     label: 'App distribution certificate',
-    description: 'Signs TestFlight, App Store and ad-hoc builds.',
+    description: 'Required for manual App Store signing; also signs ad-hoc device installs.',
   },
   {
     id: 'appStoreProfile',
     label: 'App Store provisioning profile',
-    description: 'For TestFlight and App Store uploads.',
+    description: 'Required for manual TestFlight and App Store signing.',
   },
   {
     id: 'appRecord',
@@ -64,7 +64,7 @@ export const CONNECT_ACTIONS = [
   {
     id: 'apiKey',
     label: 'App Store Connect API key',
-    description: 'Authenticates the TestFlight/App Store upload.',
+    description: 'Authenticates uploads and, in cloud mode, signing.',
   },
   {
     id: 'developmentCertificate',
@@ -85,6 +85,15 @@ export const CONNECT_ACTIONS = [
 
 export type ConnectActionId = (typeof CONNECT_ACTIONS)[number]['id'];
 
+const REQUIRED_ACTIONS: Record<SigningMode, readonly ConnectActionId[]> = {
+  cloud: ['appRecord', 'apiKey'],
+  manual: ['distributionCertificate', 'appStoreProfile', 'appRecord', 'apiKey'],
+};
+
+function requiredActions(signingMode: SigningMode): Set<ConnectActionId> {
+  return new Set(REQUIRED_ACTIONS[signingMode]);
+}
+
 export type ActionStatus = 'pending' | 'running' | 'done' | 'skipped' | 'error';
 
 export type ActionState = { status: ActionStatus; note?: string };
@@ -93,6 +102,7 @@ export type Connection = {
   teamId: string;
   bundleId: string;
   appName: string;
+  signingMode: SigningMode;
   /**
    * Numeric App Store Connect app record ID, captured when the app record
    * action runs. Used to link to the app's App Store Connect page after a
@@ -113,20 +123,41 @@ function isUnexpired(expirationDate?: string) {
 }
 
 /**
- * Whether a returning user is still connected: the store must hold the
- * team's distribution certificate, its App Store Connect API key, and at
- * least one of the team's provisioning profiles from an earlier session.
+ * Whether a returning user is still connected: both modes need an App Store
+ * Connect API key; manual signing additionally needs the certificate and
+ * provisioning profile maintained in the secret store.
  */
-function storeHoldsConnectionSecrets(secrets: SigningSecretMetadata[], stored: Connection): boolean {
+async function storeHoldsConnectionSecrets(
+  secretStore: SigningSecretStore,
+  secrets: SigningSecretMetadata[],
+  stored: Connection,
+): Promise<boolean> {
   const has = (type: string, name: string) =>
     secrets.some((secret) => secret.type === type && secret.name === name);
-  return (
-    has(APPLE_CERTIFICATE_SECRET_TYPE, appleCertificateSecretName(stored.teamId, 'DISTRIBUTION')) &&
-    has(APP_STORE_CONNECT_API_KEY_SECRET_TYPE, appStoreConnectApiKeySecretName(stored.teamId)) &&
-    secrets.some(
-      (secret) =>
-        secret.type === APPLE_PROVISIONING_PROFILE_SECRET_TYPE && secret.name.startsWith(`${stored.teamId}/`),
-    )
+  const hasApiKey = has(
+    APP_STORE_CONNECT_API_KEY_SECRET_TYPE,
+    appStoreConnectApiKeySecretName(stored.teamId),
+  );
+  if (stored.signingMode === 'cloud') return hasApiKey;
+  if (!hasApiKey) return false;
+  const certificate = await secretStore.get(
+    APPLE_CERTIFICATE_SECRET_TYPE,
+    appleCertificateSecretName(stored.teamId, 'DISTRIBUTION'),
+  );
+  if (!certificate?.data.certificateP12Base64 || !isUnexpired(certificate.data.expirationDate)) return false;
+  const profileMetadata = secrets.filter(
+    (secret) =>
+      secret.type === APPLE_PROVISIONING_PROFILE_SECRET_TYPE && secret.name.startsWith(`${stored.teamId}/`),
+  );
+  const profiles = await Promise.all(
+    profileMetadata.map((secret) => secretStore.get(APPLE_PROVISIONING_PROFILE_SECRET_TYPE, secret.name)),
+  );
+  return profiles.some(
+    (profile) =>
+      profile?.data.teamID === stored.teamId &&
+      profile.data.bundleIDs?.split(',').includes(stored.bundleId) &&
+      !profile.data.deviceIDs &&
+      isUnexpired(profile.data.expirationDate),
   );
 }
 
@@ -175,8 +206,9 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
   const [portalAppIds, setPortalAppIds] = useState<AppleBundleID[]>([]);
   const [bundleIdsLoading, setBundleIdsLoading] = useState(false);
   const [appName, setAppName] = useState('');
-  const [selectedActions, setSelectedActions] = useState<Set<ConnectActionId>>(
-    () => new Set(CONNECT_ACTIONS.map((action) => action.id)),
+  const [signingMode, setSigningMode] = useState<SigningMode>('cloud');
+  const [selectedActions, setSelectedActions] = useState<Set<ConnectActionId>>(() =>
+    requiredActions('cloud'),
   );
   const [actionStates, setActionStates] = useState<Partial<Record<ConnectActionId, ActionState>>>({});
   const [connection, setConnection] = useState<Connection>();
@@ -196,16 +228,19 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
       let stored: Connection;
       try {
         stored = JSON.parse(raw) as Connection;
+        // Connections saved before the selector existed used cloud signing.
+        stored.signingMode ??= 'cloud';
       } catch {
         localStorage.removeItem(CONNECTION_STORAGE_KEY);
         return;
       }
       try {
-        if (storeHoldsConnectionSecrets(await secretStore.list(), stored)) {
+        if (await storeHoldsConnectionSecrets(secretStore, await secretStore.list(), stored)) {
           if (!cancelled) {
             setConnection(stored);
             setBundleId(stored.bundleId);
             setAppName(stored.appName);
+            setSigningMode(stored.signingMode);
           }
         } else {
           localStorage.removeItem(CONNECTION_STORAGE_KEY);
@@ -286,12 +321,21 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
   }
 
   function toggleAction(id: ConnectActionId) {
+    if (requiredActions(signingMode).has(id)) return;
     setSelectedActions((current) => {
       const next = new Set(current);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
     });
+  }
+
+  function selectSigningMode(mode: SigningMode) {
+    setSigningMode(mode);
+    // Start each mode with exactly its publish requirements. Device-install
+    // credentials remain opt-in and can be selected afterwards.
+    setSelectedActions(requiredActions(mode));
+    setActionStates({});
   }
 
   // --- Step 1: Apple ID login -----------------------------------------------
@@ -432,10 +476,8 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
       await run('appStoreProfile', async () => {
         const certificateId = distributionCertificate?.certificateId;
         if (!certificateId) {
-          throw new Error('Select the distribution certificate action too; the profile must reference it.');
+          throw new Error('Manual signing requires the distribution certificate action.');
         }
-        // Reuse a portal profile with our name so repeated Connect runs don't
-        // pile up duplicates (Apple rejects duplicate profile names anyway).
         const name = naming.appStoreProfileName(trimmedBundleId);
         const profiles = await listAppleProfiles({
           relay,
@@ -443,22 +485,38 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
           profileKind: 'appstore',
           bundleId: trimmedBundleId,
         });
-        const existing = profiles.find((profile) => profile.name === name);
-        let profileId = existing?.profileId;
-        if (!profileId) {
-          const created = await createAppleProfile({
-            relay,
-            teamId,
-            profileKind: 'appstore',
-            bundleId: trimmedBundleId,
-            appIdId,
-            certificateIds: [certificateId],
-            name,
-          });
-          profileId = created.profileId;
+        const existingId = profiles.find((profile) => profile.name === name)?.profileId;
+        if (existingId) {
+          const downloaded = await downloadAppleProfile({ relay, teamId, profileId: existingId });
+          const info =
+            downloaded.rawBodyBase64 ? parseProvisioningProfileBase64(downloaded.rawBodyBase64) : undefined;
+          const serial = distributionCertificate?.secret.data.serialNumber;
+          const usable =
+            info !== undefined &&
+            !!serial &&
+            info.certificateSerialNumbers.includes(serial) &&
+            isUnexpired(info.expirationDate);
+          if (usable) {
+            await saveAppleProfileSecret({ relay, teamId, profileId: existingId, secretStore, log });
+            return 'Reused existing';
+          }
+          await deleteAppleProfile({ relay, teamId, profileId: existingId });
+          if (info?.uuid) {
+            await secretStore.delete(APPLE_PROVISIONING_PROFILE_SECRET_TYPE, `${teamId}/${info.uuid}`);
+          }
+          log('Replacing a stale App Store profile', name);
         }
-        await saveAppleProfileSecret({ relay, teamId, profileId, secretStore, log });
-        return existing ? 'Reused existing' : 'Created';
+        const created = await createAppleProfile({
+          relay,
+          teamId,
+          profileKind: 'appstore',
+          bundleId: trimmedBundleId,
+          appIdId,
+          certificateIds: [certificateId],
+          name,
+        });
+        await saveAppleProfileSecret({ relay, teamId, profileId: created.profileId, secretStore, log });
+        return existingId ? 'Recreated' : 'Created';
       });
 
       // App Store Connect rides the same session but carries its own active
@@ -598,6 +656,7 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
         teamId,
         bundleId: trimmedBundleId,
         appName: trimmedAppName,
+        signingMode,
         ascAppId,
       };
       setConnection(established);
@@ -618,6 +677,8 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
     setSelectedTeamId('');
     setPortalAppIds([]);
     setBundleIdChoice(NEW_BUNDLE_ID);
+    setSigningMode('cloud');
+    setSelectedActions(requiredActions('cloud'));
     void appleLogin.close();
   }
 
@@ -654,7 +715,13 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
     bundleIdsLoading,
     appName,
     setAppName,
+    signingMode,
+    selectSigningMode,
     // Checklist
+    requiredActions: requiredActions(signingMode),
+    visibleActions: CONNECT_ACTIONS.filter(
+      (action) => signingMode === 'manual' || action.id !== 'appStoreProfile',
+    ),
     selectedActions,
     toggleAction,
     actionStates,

--- a/examples/publish-to-stores/frontend/src/lib/backend.ts
+++ b/examples/publish-to-stores/frontend/src/lib/backend.ts
@@ -59,10 +59,13 @@ export async function fetchRegistrySession(): Promise<RegistrySession> {
   return (await response.json()) as RegistrySession;
 }
 
+export type SigningMode = 'cloud' | 'manual';
+
 export type PublishInput = {
   projectPath: string;
   teamId: string;
   bundleId: string;
+  signingMode: SigningMode;
   scheme?: string;
   /** Public URL limbuild POSTs the build-finish webhook to, verbatim. */
   webhookUrl: string;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.45.5",
+    "@limrun/api": "0.46.1",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -8,8 +8,11 @@ import { parseAdditionalFileFlags } from '../../lib/additional-files';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
 import { webhookConfigFromFlags } from '../../lib/webhook-options';
 import {
+  cloudSigningFlagsProblem,
+  hasCloudSigningFlags,
   hasSigningFlags,
   signingFlagsProblem,
+  type XcodeCloudSigningFlagValues,
   type XcodeSigningFlagValues,
 } from '../../lib/xcode-signing-options';
 import {
@@ -17,6 +20,8 @@ import {
   type AppStoreUploadConfig,
   type XcodeBuildOptions,
   type XcodeClient,
+  type XcodeCloudSigningConfig,
+  type XcodeCloudSigningMethod,
   type XcodeSigningConfig,
 } from '@limrun/api';
 
@@ -49,6 +54,8 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --xcodegen-spec specs/app.yml --xcodegen-project ios',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
+    '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method release-testing --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload signed-device-build.ipa',
+    '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method app-store-connect --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload-to-appstore',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./app.mobileprovision --provisioning-profile ./widgets.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
@@ -145,19 +152,27 @@ export default class XcodeBuild extends BaseCommand {
       // project path placed after the flag as another profile.
       multipleNonGreedy: true,
     }),
+    'signing-method': Flags.string({
+      description:
+        'Use Apple cloud signing during archive export. Distribution methods require the ASC key to have access to cloud-managed distribution certificates.',
+      options: ['app-store-connect', 'release-testing', 'debugging'],
+    }),
+    'team-id': Flags.string({
+      description: 'Apple Developer team ID for --signing-method, e.g. VMBY3VYW4U.',
+    }),
     'upload-to-appstore': Flags.boolean({
       description:
-        'Upload the signed IPA to App Store Connect after the build, making it available for TestFlight or App Store distribution. Requires the signing flags plus --asc-key-id and --asc-key.',
+        'Upload the signed IPA to App Store Connect after the build, making it available for TestFlight or App Store distribution. Requires manual or cloud signing plus --asc-key-id and --asc-key.',
       default: false,
     }),
     'asc-key-id': Flags.string({
-      description: 'App Store Connect API key ID for --upload-to-appstore, e.g. 2X9R4HXF34.',
+      description: 'App Store Connect API key ID for cloud signing or --upload-to-appstore, e.g. 2X9R4HXF34.',
     }),
     'asc-issuer-id': Flags.string({
       description: 'App Store Connect issuer ID for team API keys. Omit when using an individual API key.',
     }),
     'asc-key': Flags.string({
-      description: 'Path to the App Store Connect API private key (.p8) for --upload-to-appstore.',
+      description: 'Path to the App Store Connect API private key (.p8) for cloud signing or upload.',
     }),
     'asc-wait-timeout': Flags.integer({
       description:
@@ -167,7 +182,7 @@ export default class XcodeBuild extends BaseCommand {
     }),
     'auto-build-number': Flags.boolean({
       description:
-        'Set the build number to one more than the highest already in App Store Connect (1 for a new app), so repeat uploads never collide on CFBundleVersion. Resolved server-side with the ASC key. Requires --upload-to-appstore and a project using Xcode-standard versioning (CFBundleVersion = $(CURRENT_PROJECT_VERSION)).',
+        'Set the build number to one more than the highest already in App Store Connect (1 for a new app), so repeat uploads never collide on CFBundleVersion. Resolved server-side with the ASC key. Requires --upload-to-appstore; manual signing also requires Xcode-standard versioning (CFBundleVersion = $(CURRENT_PROJECT_VERSION)).',
       default: false,
     }),
     'webhook-url': Flags.string({
@@ -223,7 +238,7 @@ export default class XcodeBuild extends BaseCommand {
         '--xcodegen-spec/--xcodegen-project apply to native XcodeGen projects and cannot be combined with Expo / React Native flags.',
       );
     }
-    if (flags.ios && hasSigningFlags(flags)) {
+    if (flags.ios && (hasSigningFlags(flags) || hasCloudSigningFlags(flags))) {
       this.error('--ios builds run on a simulator and cannot use signing flags.');
     }
     const signingProblem = signingFlagsProblem(flags);
@@ -231,6 +246,10 @@ export default class XcodeBuild extends BaseCommand {
       // Rejected before instance resolution: a doomed flag combination must
       // not leave a billed instance behind.
       this.error(signingProblem);
+    }
+    const cloudSigningProblem = cloudSigningFlagsProblem(flags);
+    if (cloudSigningProblem) {
+      this.error(cloudSigningProblem);
     }
     if (flags.ios && (flags['upload-to-appstore'] || hasAppStoreFlags(flags))) {
       this.error('--ios builds run on a simulator and cannot upload to App Store Connect.');
@@ -292,15 +311,27 @@ export default class XcodeBuild extends BaseCommand {
         }
         options.signing = signing;
       }
-      if (!flags['upload-to-appstore'] && hasAppStoreFlags(flags)) {
-        // Reserved: a bare ASC credential may gain other meanings later
-        // (managed signing, entitlement preflight), so it never implies one.
-        this.error('The asc flags and --auto-build-number require --upload-to-appstore.');
+      const cloudSigning = await this.buildCloudSigningOptions(flags);
+      if (cloudSigning) {
+        if (flags.sdk && flags.sdk !== 'iphoneos') {
+          this.error('Cloud signing requires --sdk iphoneos.');
+        }
+        settings.sdk = 'iphoneos';
+        options.cloudSigning = cloudSigning;
+      }
+      if (
+        !flags['upload-to-appstore'] &&
+        (flags['asc-wait-timeout'] !== undefined || flags['auto-build-number'])
+      ) {
+        this.error('--asc-wait-timeout and --auto-build-number require --upload-to-appstore.');
+      }
+      if (!flags['upload-to-appstore'] && !cloudSigning && hasASCCredentialFlags(flags)) {
+        this.error('The asc credential flags require --signing-method or --upload-to-appstore.');
       }
       if (flags['upload-to-appstore']) {
-        if (!signing) {
+        if (!signing && !cloudSigning) {
           this.error(
-            '--upload-to-appstore delivers the signed IPA, so it requires --certificate-p12, --certificate-password, and --provisioning-profile.',
+            '--upload-to-appstore delivers a signed IPA, so it requires manual signing flags or --signing-method.',
           );
         }
         if (settings.sdk !== 'iphoneos') {
@@ -436,6 +467,21 @@ export default class XcodeBuild extends BaseCommand {
     };
   }
 
+  private async buildCloudSigningOptions(
+    flags: XcodeCloudSigningFlagValues,
+  ): Promise<XcodeCloudSigningConfig | undefined> {
+    if (!flags['signing-method']) {
+      return undefined;
+    }
+    return {
+      method: flags['signing-method'] as XcodeCloudSigningMethod,
+      teamId: flags['team-id']!,
+      apiKeyId: flags['asc-key-id']!,
+      apiIssuerId: flags['asc-issuer-id']!,
+      apiPrivateKeyBase64: await this.readFileBase64(flags['asc-key']!, '--asc-key'),
+    };
+  }
+
   private async readFileBase64(path: string, flagName: string): Promise<string> {
     try {
       return (await readFile(path)).toString('base64');
@@ -444,9 +490,7 @@ export default class XcodeBuild extends BaseCommand {
     }
   }
 
-  private async buildAppStoreOptions(
-    flags: AppStoreFlags,
-  ): Promise<AppStoreUploadConfig & { autoIncrementBuildNumber?: boolean }> {
+  private async buildAppStoreOptions(flags: AppStoreFlags): Promise<AppStoreUploadConfig> {
     if (!flags['asc-key-id'] || !flags['asc-key']) {
       this.error('--upload-to-appstore requires both --asc-key-id and --asc-key.');
     }
@@ -505,5 +549,13 @@ function hasAppStoreFlags(flags: AppStoreFlags): boolean {
     flags['asc-key'] !== undefined ||
     flags['asc-wait-timeout'] !== undefined ||
     flags['auto-build-number']
+  );
+}
+
+function hasASCCredentialFlags(flags: AppStoreFlags): boolean {
+  return (
+    flags['asc-key-id'] !== undefined ||
+    flags['asc-issuer-id'] !== undefined ||
+    flags['asc-key'] !== undefined
   );
 }

--- a/packages/cli/src/lib/xcode-signing-options.test.ts
+++ b/packages/cli/src/lib/xcode-signing-options.test.ts
@@ -1,4 +1,9 @@
-import { hasSigningFlags, signingFlagsProblem } from './xcode-signing-options';
+import {
+  cloudSigningFlagsProblem,
+  hasCloudSigningFlags,
+  hasSigningFlags,
+  signingFlagsProblem,
+} from './xcode-signing-options';
 
 describe('signingFlagsProblem', () => {
   it('accepts an absent group and a complete group', () => {
@@ -32,5 +37,44 @@ describe('hasSigningFlags', () => {
     expect(hasSigningFlags({})).toBe(false);
     expect(hasSigningFlags({ 'certificate-password': '' })).toBe(true);
     expect(hasSigningFlags({ 'provisioning-profile': ['app'] })).toBe(true);
+  });
+});
+
+describe('cloudSigningFlagsProblem', () => {
+  const complete = {
+    'signing-method': 'release-testing',
+    'team-id': 'TEAM123456',
+    'asc-key-id': 'KEY123',
+    'asc-issuer-id': 'issuer',
+    'asc-key': 'AuthKey.p8',
+  };
+
+  it('accepts an absent group and a complete group', () => {
+    expect(cloudSigningFlagsProblem({})).toBeUndefined();
+    expect(cloudSigningFlagsProblem(complete)).toBeUndefined();
+  });
+
+  it('requires every cloud signing credential', () => {
+    expect(cloudSigningFlagsProblem({ 'signing-method': 'debugging' })).toMatch(/--team-id.*--asc-key-id/);
+    expect(cloudSigningFlagsProblem({ 'team-id': 'TEAM123456' })).toMatch(/requires --signing-method/);
+  });
+
+  it('rejects manual and cloud signing together', () => {
+    expect(
+      cloudSigningFlagsProblem({
+        ...complete,
+        'certificate-p12': 'dist.p12',
+        'certificate-password': 'pw',
+        'provisioning-profile': ['app.mobileprovision'],
+      }),
+    ).toMatch(/cannot be combined/);
+  });
+});
+
+describe('hasCloudSigningFlags', () => {
+  it('detects either cloud-signing-specific flag', () => {
+    expect(hasCloudSigningFlags({})).toBe(false);
+    expect(hasCloudSigningFlags({ 'signing-method': 'debugging' })).toBe(true);
+    expect(hasCloudSigningFlags({ 'team-id': 'TEAM123456' })).toBe(true);
   });
 });

--- a/packages/cli/src/lib/xcode-signing-options.ts
+++ b/packages/cli/src/lib/xcode-signing-options.ts
@@ -4,6 +4,14 @@ export interface XcodeSigningFlagValues {
   'provisioning-profile'?: string[];
 }
 
+export interface XcodeCloudSigningFlagValues extends XcodeSigningFlagValues {
+  'signing-method'?: string;
+  'team-id'?: string;
+  'asc-key-id'?: string;
+  'asc-issuer-id'?: string;
+  'asc-key'?: string;
+}
+
 export function hasSigningFlags(flags: XcodeSigningFlagValues): boolean {
   return (
     flags['certificate-p12'] !== undefined ||
@@ -28,6 +36,31 @@ export function signingFlagsProblem(flags: XcodeSigningFlagValues): string | und
     flags['provisioning-profile'] === undefined
   ) {
     return 'Signed device builds require --certificate-p12, --certificate-password, and --provisioning-profile.';
+  }
+  return undefined;
+}
+
+export function hasCloudSigningFlags(flags: XcodeCloudSigningFlagValues): boolean {
+  return flags['signing-method'] !== undefined || flags['team-id'] !== undefined;
+}
+
+export function cloudSigningFlagsProblem(flags: XcodeCloudSigningFlagValues): string | undefined {
+  if (!hasCloudSigningFlags(flags)) {
+    return undefined;
+  }
+  if (flags['signing-method'] === undefined) {
+    return '--team-id requires --signing-method.';
+  }
+  if (hasSigningFlags(flags)) {
+    return 'Cloud signing flags cannot be combined with --certificate-p12, --certificate-password, or --provisioning-profile.';
+  }
+  const missing: string[] = [];
+  if (flags['team-id'] === undefined) missing.push('--team-id');
+  if (flags['asc-key-id'] === undefined) missing.push('--asc-key-id');
+  if (flags['asc-issuer-id'] === undefined) missing.push('--asc-issuer-id');
+  if (flags['asc-key'] === undefined) missing.push('--asc-key');
+  if (missing.length > 0) {
+    return `--signing-method requires ${missing.join(', ')}.`;
   }
   return undefined;
 }

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@0.45.5":
-  version "0.45.5"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.45.5.tgz#e009b49b533a20de92e02fc334eacd5a624dedf8"
-  integrity sha512-CDXSsWh5BZWNfF6XWyEn9P2QtUpLg702UqcjBihGdLZBzUfMU7JrjTQx7aT4woE9o1KSgvtX6RInaEi0hFcxng==
+"@limrun/api@0.46.1":
+  version "0.46.1"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.1.tgz#afaf28a83931b5f60754f6d1e62769270eba5d42"
+  integrity sha512-6qImY7XFj7xOR0h+evi38Uo2nEWMtxH9sc6pA35b8FlpZqFYPbCAgHblKnnUoZuoqJmIAA4wFHMjvpfTbagIjQ==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
## Summary
- add `lim xcode build` cloud-signing flags and validation
- let the publish-to-stores example choose Apple cloud or manually managed signing
- keep manual certificates and profiles fresh and reject stale credentials

## Dependency
- [ ] Merge and release the API changes from #275
- [ ] Bump `@limrun/api` here to that release

## Test plan
- [x] CLI signing-option tests (8 passing)
- [x] publish-to-stores backend tests and build
- [x] publish-to-stores frontend build and lint
- [ ] CLI build after the released API version is bumped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signing and App Store publish paths in the CLI and example backend; mistakes could break releases, but scope is mostly example code plus flag validation and tests.
> 
> **Overview**
> Adds **Apple cloud signing** as an alternative to local p12/profile signing for device builds and App Store uploads.
> 
> **CLI:** `lim xcode build` gains `--signing-method` (`app-store-connect`, `release-testing`, `debugging`), `--team-id`, and ASC credential flags wired into `options.cloudSigning`. Validation blocks mixing cloud flags with manual `--certificate-p12` / profile flags, and `--upload-to-appstore` accepts either signing path. `@limrun/api` is bumped to **0.46.1**.
> 
> **publish-to-stores:** Connect lets users pick **cloud vs manual** signing; the checklist shows only required actions per mode (cloud: app record + API key; manual: cert, App Store profile, app record, API key). Publish sends `signingMode` to the backend, which resolves credentials accordingly—cloud uses the ASC key with `--signing-method app-store-connect`; manual materializes cert/profile and enforces expiry and cert–profile serial matching. Connect **recreates stale App Store profiles** when they no longer match the distribution certificate. Backend tests cover credential resolution and CLI arg building; README documents the two modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a20f9fe4eea8f1eca56edccb4c6ee62efab5d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->