### PR TITLE
examples: disable unsupported Appium log capture

### DIFF
--- a/examples/appium-ios/index.ts
+++ b/examples/appium-ios/index.ts
@@ -84,6 +84,7 @@ const driver = await remote({
     'appium:wdaLocalPort': 443,
     'appium:useNewWDA': false,
     'appium:usePreinstalledWDA': true,
+    'appium:skipLogCapture': true,
     // @ts-expect-error -- limInstance* are our custom capabilities not known to webdriverio
     'appium:limInstanceApiUrl': instance.status.apiUrl,
     'appium:limInstanceToken': instance.status.token,


### PR DESCRIPTION
## Summary
- disable XCUITest log capture in the Appium iOS example
- avoid the blocked `simctl spawn ... log stream` command while preserving the rest of the session setup

## Test plan
- [x] Run `npm run build` in `examples/appium-ios`
- [x] Verify the capability against the production Appium flow

Made with [Cursor](https://cursor.com)