### PR TITLE
api: expose Xcode cloud signing options

### DIFF
--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -38,6 +38,13 @@ export type XcodeBuildExecRequest = {
     /** One profile per embedded bundle. */
     provisioningProfilesBase64?: string[];
   };
+  cloudSigning?: {
+    method: 'app-store-connect' | 'release-testing' | 'debugging';
+    teamId: string;
+    apiKeyId: string;
+    apiIssuerId: string;
+    apiPrivateKeyBase64: string;
+  };
   /** Wire name retained for compatibility with the limbuild exec API. */
   testflight?: AppStoreUploadConfig;
   buildSettings?: Record<string, string>;
@@ -239,6 +246,11 @@ export type AppStoreUploadConfig = {
    * minutes).
    */
   waitTimeoutSeconds?: number;
+  /**
+   * Set CFBundleVersion to one more than the highest build already known to
+   * App Store Connect before upload.
+   */
+  autoIncrementBuildNumber?: boolean;
 };
 
 type DataListener = (chunk: string) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,8 @@ export {
   type XcodeRunOptions,
   type XcodeGenConfig,
   type XcodeSigningConfig,
+  type XcodeCloudSigningConfig,
+  type XcodeCloudSigningMethod,
   type ReactNativeBuildConfig,
   type SimulatorAttachResult,
   type SimulatorStatus,

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -57,6 +57,8 @@ export {
   type XcodeRunOptions,
   type XcodeGenConfig,
   type XcodeSigningConfig,
+  type XcodeCloudSigningConfig,
+  type XcodeCloudSigningMethod,
   type ReactNativeBuildConfig,
   type SimulatorAttachResult,
   type SimulatorStatus,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -130,6 +130,16 @@ export type XcodeSigningConfig = {
   provisioningProfilesBase64?: string[];
 };
 
+export type XcodeCloudSigningMethod = 'app-store-connect' | 'release-testing' | 'debugging';
+
+export type XcodeCloudSigningConfig = {
+  method: XcodeCloudSigningMethod;
+  teamId: string;
+  apiKeyId: string;
+  apiIssuerId: string;
+  apiPrivateKeyBase64: string;
+};
+
 export type ReactNativeBuildConfig = {
   /**
    * Relative path from the synced workspace root to the Expo app directory.
@@ -151,9 +161,10 @@ export type ReactNativeBuildConfig = {
 export type XcodeBuildOptions = {
   upload?: { assetName: string } | { signedUploadUrl: string };
   signing?: XcodeSigningConfig;
+  cloudSigning?: XcodeCloudSigningConfig;
   /**
    * Upload the signed device IPA to App Store Connect after the build.
-   * Requires signing and sdk=iphoneos. Check ExecResult.appstore on
+   * Requires manual or cloud signing and sdk=iphoneos. Check ExecResult.appstore on
    * completion; it is absent when the instance's limbuild predates the
    * feature (old servers silently ignore this option).
    */
@@ -720,6 +731,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ...(options?.xcodegen && { xcodegen: options.xcodegen }),
           ...(options?.reactNative && { reactNative: options.reactNative }),
           ...(options?.signing && { signing: options.signing }),
+          ...(options?.cloudSigning && { cloudSigning: options.cloudSigning }),
           // The SDK calls this App Store; limbuild's existing wire field remains
           // testflight until the exec API is revised separately.
           ...(options?.appstore && { testflight: options.appstore }),

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -132,6 +132,11 @@ export type XcodeSigningConfig = {
 
 export type XcodeCloudSigningMethod = 'app-store-connect' | 'release-testing' | 'debugging';
 
+/**
+ * Apple-managed signing credentials used while exporting an unsigned device
+ * archive. Apple retains the signing certificate; callers provide only the
+ * App Store Connect team key.
+ */
 export type XcodeCloudSigningConfig = {
   method: XcodeCloudSigningMethod;
   teamId: string;

--- a/tests/xcode-client-signing.test.ts
+++ b/tests/xcode-client-signing.test.ts
@@ -55,6 +55,60 @@ describe('xcode client signing', () => {
       },
     });
   });
+
+  test('serializes cloud signing with automatic App Store build numbering', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://xcode.example.test/exec') {
+        return jsonResponse({ execId: 'build-2' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const xcode = await client.xcodeInstances.createClient({
+      apiUrl: 'https://xcode.example.test',
+      token: 'xcode-token',
+    });
+    const result = await xcode.xcodebuild(
+      { sdk: 'iphoneos', configuration: 'Release' },
+      {
+        cloudSigning: {
+          method: 'app-store-connect',
+          teamId: 'TEAM123456',
+          apiKeyId: 'KEY123',
+          apiIssuerId: 'issuer-uuid',
+          apiPrivateKeyBase64: 'private-key',
+        },
+        appstore: {
+          apiKeyId: 'KEY123',
+          apiIssuerId: 'issuer-uuid',
+          apiPrivateKeyBase64: 'private-key',
+          autoIncrementBuildNumber: true,
+        },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'xcodebuild',
+      xcodebuild: { sdk: 'iphoneos', configuration: 'Release' },
+      cloudSigning: {
+        method: 'app-store-connect',
+        teamId: 'TEAM123456',
+        apiKeyId: 'KEY123',
+        apiIssuerId: 'issuer-uuid',
+        apiPrivateKeyBase64: 'private-key',
+      },
+      testflight: {
+        apiKeyId: 'KEY123',
+        apiIssuerId: 'issuer-uuid',
+        apiPrivateKeyBase64: 'private-key',
+        autoIncrementBuildNumber: true,
+      },
+    });
+  });
 });
 
 function jsonResponse(body: unknown): Response {


### PR DESCRIPTION
## Summary
- expose modern Xcode cloud-signing request types
- serialize cloud signing through the Xcode client
- expose automatic App Store build-number selection

## Test plan
- [x] `yarn test --runInBand tests/xcode-client-signing.test.ts`
- [x] `yarn build`
- [x] `yarn lint`

This API release is a prerequisite for the CLI and example changes in #271.


Made with [Cursor](https://cursor.com)