### PR TITLE
cli: release 0.25.0 with the Xcode build cache flags

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "0.46.1",
+    "@limrun/api": "0.46.2",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@0.46.1":
-  version "0.46.1"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.1.tgz#afaf28a83931b5f60754f6d1e62769270eba5d42"
-  integrity sha512-6qImY7XFj7xOR0h+evi38Uo2nEWMtxH9sc6pA35b8FlpZqFYPbCAgHblKnnUoZuoqJmIAA4wFHMjvpfTbagIjQ==
+"@limrun/api@0.46.2":
+  version "0.46.2"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.2.tgz#bc13e2213c56953b59b917ee647ec2544c719d9d"
+  integrity sha512-xPM63pRScsRNVfMa9kv2ui79nmEzIitDUvO5oe6PuPLS+RZn6UqK7YJpzSHQVN2WssCEGh0ZDJRM4Qgb954Odg==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
## Summary
- Bump the `lim` CLI to 0.25.0 and move its exact `@limrun/api` pin to 0.46.2, the release that carries the build cache client surface.

Verified against the published package rather than a local build: `followCache`, `getCache` and `bindCacheKey` all resolve as functions on a client constructed from `@limrun/api@0.46.2`, and the built CLI exposes `--cache-key`, `--cache-restore-keys`, `--cache-paths` and `--wait-cache`.

## Test plan
- [x] `yarn install` resolves `@limrun/api@0.46.2`
- [x] `yarn build` in `packages/cli`
- [x] `yarn test` in `packages/cli` (57 tests)
- [x] Cache flags present in `lim xcode create --help` and `lim xcode delete --help`
- [ ] After merge, dispatch `publish-cli.yaml` on `main`

Made with [Cursor](https://cursor.com)