### PR TITLE
assets: let fetch set Content-Length on buffered signed-URL uploads

### DIFF
--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -2385,11 +2385,12 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
     const setStoreKitConfig = async (bundleId: string, storekit: Buffer | Uint8Array): Promise<void> => {
       const body = Buffer.isBuffer(storekit) ? storekit : Buffer.from(storekit);
       const url = `${options.apiUrl}/payments/storeKitConfigs/${encodeURIComponent(bundleId)}`;
+      // No manual Content-Length: fetch derives it from the buffer, and setting it
+      // as well duplicates the header, which strict undici dispatchers reject.
       const response = await nodeProxyTransport.fetch(url, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/octet-stream',
-          'Content-Length': body.length.toString(),
           Authorization: `Bearer ${options.token}`,
         },
         body: body as any,

--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -53,15 +53,24 @@ export interface AssetGetOrUploadResponse {
 }
 
 /**
- * Body init for the signed-URL PUT. Without a progress callback the buffer is sent
- * directly. With one, the buffer is wrapped in a ReadableStream so the callback can
- * fire as chunks are pulled onto the socket; the explicit Content-Length header set
- * by the caller keeps the request non-chunked, which signed URLs require.
+ * Request init fragment for the signed-URL PUT. Without a progress callback the
+ * buffer is sent directly and fetch derives Content-Length from it; setting the
+ * header manually as well makes fetch append its own computed value next to it
+ * ("n, n"), which strict undici dispatchers — used whenever HTTP(S)_PROXY is set —
+ * reject with UND_ERR_INVALID_ARG "invalid content-length header". With a
+ * callback, the buffer is wrapped in a ReadableStream so the callback can fire as
+ * chunks are pulled onto the socket; fetch cannot know a stream's length, so only
+ * there an explicit Content-Length header keeps the request non-chunked, which
+ * signed URLs require.
  */
-function uploadBodyInit(
+function uploadRequestInit(
   data: Buffer,
   onProgress?: (uploadedBytes: number, totalBytes: number) => void,
-): { body: NonNullable<RequestInit['body']>; duplex?: 'half' } {
+): {
+  body: NonNullable<RequestInit['body']>;
+  duplex?: 'half';
+  headers?: { 'Content-Length': string };
+} {
   if (!onProgress) {
     return { body: data as unknown as NonNullable<RequestInit['body']> };
   }
@@ -79,7 +88,11 @@ function uploadBodyInit(
       onProgress(sent, data.length);
     },
   });
-  return { body: stream as unknown as NonNullable<RequestInit['body']>, duplex: 'half' };
+  return {
+    body: stream as unknown as NonNullable<RequestInit['body']>,
+    duplex: 'half',
+    headers: { 'Content-Length': data.length.toString() },
+  };
 }
 
 export class Assets extends GeneratedAssets {
@@ -109,13 +122,14 @@ export class Assets extends GeneratedAssets {
         ...(creationResponse.expiresAt && { expiresAt: creationResponse.expiresAt }),
       };
     }
+    const { headers: uploadHeaders, ...bodyInit } = uploadRequestInit(data, body.onUploadProgress);
     const uploadResponse = await nodeProxyTransport.fetch(creationResponse.signedUploadUrl, {
       headers: {
-        'Content-Length': data.length.toString(),
         'Content-Type': 'application/octet-stream',
+        ...uploadHeaders,
       },
       method: 'PUT',
-      ...uploadBodyInit(data, body.onUploadProgress),
+      ...bodyInit,
     });
     if (uploadResponse.status !== 200) {
       throw new Error(`Failed to upload asset: ${uploadResponse.status} ${await uploadResponse.text()}`);

--- a/tests/assets-get-or-upload.test.ts
+++ b/tests/assets-get-or-upload.test.ts
@@ -1,0 +1,112 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { createHash, randomBytes } from 'crypto';
+
+import Limrun from '@limrun/api';
+import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
+import type { RequestInfo } from '../src/internal/builtin-types';
+
+const originalFetch = nodeProxyTransport.fetch;
+
+afterEach(() => {
+  nodeProxyTransport.fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+// Larger than one 256 KB stream chunk so the streamed path pulls several times.
+const fileBytes = randomBytes(600 * 1024 + 123);
+
+let filePath: string;
+beforeAll(async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'limrun-assets-'));
+  filePath = path.join(dir, 'app.zip');
+  await fs.writeFile(filePath, fileBytes);
+});
+
+function clientWithAsset(md5?: string) {
+  const client = new Limrun({ apiKey: 'key' });
+  jest.spyOn(client.assets, 'getOrCreate').mockResolvedValue({
+    id: 'asset_1',
+    name: 'app.zip',
+    kind: 'App',
+    signedUploadUrl: 'https://asset-storage.example.test/put?sig=abc',
+    signedDownloadUrl: 'https://asset-storage.example.test/get?sig=def',
+    ...(md5 && { md5 }),
+  } as never);
+  return client;
+}
+
+function headerValue(init: RequestInit | undefined, name: string): string | undefined {
+  const headers = (init?.headers ?? {}) as Record<string, string>;
+  const key = Object.keys(headers).find((k) => k.toLowerCase() === name);
+  return key === undefined ? undefined : headers[key];
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value!);
+  }
+  return Buffer.concat(chunks);
+}
+
+describe('assets.getOrUpload signed-URL PUT', () => {
+  // Regression: a manual Content-Length next to a buffer body makes fetch send
+  // both its own computed value and ours ("n, n"), which strict undici
+  // dispatchers (in use whenever HTTP(S)_PROXY is set) reject with
+  // UND_ERR_INVALID_ARG "invalid content-length header".
+  test('buffered upload leaves Content-Length to fetch', async () => {
+    const fetchMock = jest.fn(async (_input: RequestInfo, _init?: RequestInit) => new Response('{}'));
+    nodeProxyTransport.fetch = fetchMock;
+    const client = clientWithAsset();
+
+    const asset = await client.assets.getOrUpload({ path: filePath });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [input, init] = fetchMock.mock.calls[0]!;
+    expect(String(input)).toBe('https://asset-storage.example.test/put?sig=abc');
+    expect(init?.method).toBe('PUT');
+    expect(headerValue(init, 'content-length')).toBeUndefined();
+    expect(headerValue(init, 'content-type')).toBe('application/octet-stream');
+    expect((init as { duplex?: string }).duplex).toBeUndefined();
+    expect(Buffer.isBuffer(init?.body)).toBe(true);
+    expect(Buffer.compare(init?.body as Buffer, fileBytes)).toBe(0);
+    expect(asset.md5).toBe(createHash('md5').update(fileBytes).digest('hex'));
+  });
+
+  test('streamed upload pins Content-Length, streams all bytes, and reports progress', async () => {
+    const fetchMock = jest.fn(async (_input: RequestInfo, _init?: RequestInit) => new Response('{}'));
+    nodeProxyTransport.fetch = fetchMock;
+    const client = clientWithAsset();
+    const progress: Array<[number, number]> = [];
+
+    await client.assets.getOrUpload({
+      path: filePath,
+      onUploadProgress: (uploaded, total) => progress.push([uploaded, total]),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(headerValue(init, 'content-length')).toBe(fileBytes.length.toString());
+    expect((init as { duplex?: string }).duplex).toBe('half');
+    const sent = await readAll(init?.body as ReadableStream<Uint8Array>);
+    expect(Buffer.compare(sent, fileBytes)).toBe(0);
+    expect(progress.length).toBeGreaterThan(1);
+    expect(progress[progress.length - 1]).toEqual([fileBytes.length, fileBytes.length]);
+  });
+
+  test('matching md5 skips the upload', async () => {
+    const fetchMock = jest.fn(async (_input: RequestInfo, _init?: RequestInit) => new Response('{}'));
+    nodeProxyTransport.fetch = fetchMock;
+    const client = clientWithAsset(createHash('md5').update(fileBytes).digest('hex'));
+
+    const asset = await client.assets.getOrUpload({ path: filePath });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(asset.id).toBe('asset_1');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Customer report: on `lim` 0.25.0, `lim asset push <file>` (with `--json`/`--quiet`) and `lim ios create --install <file>` fail on any local file with:

```
TypeError: fetch failed
  cause: InvalidArgumentError: invalid content-length header (UND_ERR_INVALID_ARG)
```

The metadata call succeeds first, so the failed PUT leaves a byte-less asset row that later errors at install time with `failed to query asset file`.

## Root cause

Three pieces interact; each is harmless alone:

1. `Assets.getOrUpload` sets a manual `Content-Length` on the signed-URL PUT. For the **buffered** path the body is a `Buffer`, whose length fetch already knows — so per the WHATWG fetch spec, fetch *appends* its own computed `Content-Length` next to the manual one. The header list then carries the joined value `"16384, 16384"`.
2. Normally invisible: Node's bundled undici parses that leniently (`parseInt`) and re-emits a clean header, so uploads work when no proxy is configured.
3. But since `node: respect HTTP_PROXY` (96ba9fe), when `HTTP(S)_PROXY` env vars are set — CI runners, corporate machines — `nodeProxyTransport.fetch` passes an `EnvHttpProxyAgent` from the npm-pinned undici 7.x as `dispatcher` into built-in fetch. undici 7.x core validates `content-length` strictly (digits only, `isValidContentLengthHeaderValue`), so the joined value is rejected with `UND_ERR_INVALID_ARG` before any bytes are sent.

Captured from a repro on the customer's exact Node 22.19.0, logging what built-in fetch hands the dispatcher:

```
headers received by dispatcher: {"Content-Length":"16384, 16384","Content-Type":"application/octet-stream",...}
threw: fetch failed | cause: [UND_ERR_INVALID_ARG] invalid content-length header
```

The **streamed** progress path is unaffected: fetch cannot compute a `ReadableStream`'s length, so nothing is appended and the single manual header survives — and it must stay, since it is what keeps that request non-chunked (S3 signed PUTs reject chunked encoding).

## Fix

- `assets-helpers.ts`: drop the manual `Content-Length` on the buffered path (fetch derives it from the buffer); move it into the streamed path's init, where it is required. Exactly as the reporter suggested.
- `ios-client.ts` `setStoreKitConfig`: same defect (Buffer body + manual header through the same transport), same one-line fix. The stream-bodied `pushFile` keeps its manual header, matching the streamed asset path.

## Verification

- End-to-end repro of `getOrUpload` on Node v22.19.0 with `HTTPS_PROXY` set: buffered path fails with the exact customer error before the fix, passes after; the server receives a clean non-chunked PUT with correct `Content-Length` in both paths.
- New regression tests (`tests/assets-get-or-upload.test.ts`): buffered upload sets no manual `Content-Length`, streamed upload pins it and streams all bytes with progress, md5 match skips the upload.
- `./scripts/lint` and the full jest suite pass (581 passed, 28 skipped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd7c1-050f-7820-bf4e-1d831fa71044?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd7c1-050f-7820-bf4e-1d831fa71044&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

