### PR TITLE
assets: drop manual Content-Length on buffered signed-URL uploads

### DIFF
--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -54,9 +54,10 @@ export interface AssetGetOrUploadResponse {
 
 /**
  * Body init for the signed-URL PUT. Without a progress callback the buffer is sent
- * directly. With one, the buffer is wrapped in a ReadableStream so the callback can
- * fire as chunks are pulled onto the socket; the explicit Content-Length header set
- * by the caller keeps the request non-chunked, which signed URLs require.
+ * directly and fetch derives Content-Length from it. With one, the buffer is wrapped
+ * in a ReadableStream so the callback can fire as chunks are pulled onto the socket;
+ * the explicit Content-Length header set by the caller keeps the request non-chunked,
+ * which signed URLs require.
  */
 function uploadBodyInit(
   data: Buffer,
@@ -109,9 +110,13 @@ export class Assets extends GeneratedAssets {
         ...(creationResponse.expiresAt && { expiresAt: creationResponse.expiresAt }),
       };
     }
+    // Content-Length is set manually only for the streamed body; for the buffered
+    // body fetch computes it itself, and setting it too makes Node 22's built-in
+    // fetch send a duplicate that the npm undici proxy dispatcher rejects with
+    // "invalid content-length header" whenever HTTP(S)_PROXY is set.
     const uploadResponse = await nodeProxyTransport.fetch(creationResponse.signedUploadUrl, {
       headers: {
-        'Content-Length': data.length.toString(),
+        ...(body.onUploadProgress && { 'Content-Length': data.length.toString() }),
         'Content-Type': 'application/octet-stream',
       },
       method: 'PUT',


### PR DESCRIPTION
## Summary

- Fixes the customer-reported `TypeError: fetch failed` → `InvalidArgumentError: invalid content-length header (UND_ERR_INVALID_ARG)` on `lim asset push` / `lim ios create --install`.
- The failure needs two conditions at once, which is why it didn't reproduce locally: `HTTP(S)_PROXY` set in the environment (so `nodeProxyTransport` passes the npm `undici@7` `EnvHttpProxyAgent` dispatcher into the built-in fetch) **and** Node 22 (bundled undici 6.x). Node 22's fetch appends its own `content-length` for a Buffer body next to the manual one, and undici 7's stricter request validation (`isValidContentLengthHeaderValue`) rejects the combined value client-side, before any bytes are sent — which is also why the failed run leaves a byte-less asset row.
- Fix: only set `Content-Length` manually on the streamed progress path, where fetch cannot derive a length from the `ReadableStream` and the header is required to keep the signed-URL PUT non-chunked. For the buffered path, fetch computes it from the Buffer.

The same pattern in `IosClient.setStoreKitConfig` is fixed separately in #281.

Verified with an integration test (mock API + mock S3 behind a real forward proxy, `HTTP_PROXY` set): published `@limrun/api@0.46.2` fails the buffered upload on Node 22 exactly as reported; this branch passes both buffered and streamed paths on Node 22 and 26, with the full payload and a single correct `Content-Length` arriving at the server.

## Test plan

- [x] `./scripts/lint` (prettier, eslint, build, tsc, attw, publint) passes
- [x] Integration test: buffered + streamed `getOrUpload` behind a real proxy on Node 22 and Node 26
- [ ] `lim ios create --install <file>` under Node 22 with `HTTPS_PROXY` set succeeds