### PR TITLE
ios: drop manual Content-Length on setStoreKitConfig upload

### DIFF
--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -2385,11 +2385,13 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
     const setStoreKitConfig = async (bundleId: string, storekit: Buffer | Uint8Array): Promise<void> => {
       const body = Buffer.isBuffer(storekit) ? storekit : Buffer.from(storekit);
       const url = `${options.apiUrl}/payments/storeKitConfigs/${encodeURIComponent(bundleId)}`;
+      // No manual Content-Length: fetch computes it from the Buffer, and setting
+      // it too makes Node 22's built-in fetch send a duplicate that the npm undici
+      // proxy dispatcher rejects whenever HTTP(S)_PROXY is set.
       const response = await nodeProxyTransport.fetch(url, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/octet-stream',
-          'Content-Length': body.length.toString(),
           Authorization: `Bearer ${options.token}`,
         },
         body: body as any,


### PR DESCRIPTION
## Summary

- Follow-up to #280: `IosClient.setStoreKitConfig` had the same latent bug as the asset upload — a Buffer body PUT through `nodeProxyTransport.fetch` with a manually set `Content-Length`.
- On Node 22 with `HTTP(S)_PROXY` set, the built-in fetch (undici 6.x) appends its own `content-length` for a Buffer body next to the manual one, and the npm `undici@7` proxy dispatcher rejects the combined value with `InvalidArgumentError: invalid content-length header` before any bytes are sent.
- Fix: drop the manual header and let fetch compute it from the Buffer. `pushFile` keeps its manual header because its body is a stream, where fetch cannot derive a length and the header keeps the request non-chunked.

This completes the audit from #280: no other buffered-body fetch call in the SDK sets `Content-Length` manually.

## Test plan

- [x] `./scripts/lint` (prettier, eslint, build, tsc, attw, publint) passes
- [ ] `setStoreKitConfig` under Node 22 with `HTTPS_PROXY` set succeeds

Made with [Cursor](https://cursor.com)