### PR TITLE
examples: launch Expo Go on Android with an exit callback, mirroring iOS

### DIFF
--- a/examples/fullstack/backend/index.ts
+++ b/examples/fullstack/backend/index.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import cors from 'cors';
-import { Ios, Limrun } from '@limrun/api';
+import { createInstanceClient, Ios, Limrun } from '@limrun/api';
 import { AndroidInstanceCreateParams, IosInstanceCreateParams } from '@limrun/api/resources';
 
 const apiKey = process.env['LIM_API_KEY'];
@@ -120,6 +120,27 @@ app.post(
           spec,
           metadata: { labels: { webSessionId } },
         });
+
+        if (withExpoGo54 && result.status.apiUrl && result.status.token) {
+          const android = await createInstanceClient({
+            apiUrl: result.status.apiUrl,
+            token: result.status.token,
+          });
+          await android.launchApp('host.exp.exponent', {
+            mode: 'RelaunchIfRunning',
+            onExit: async (logs, info) => {
+              // Fires once when the app crashes, ANRs, exits, or is terminated.
+              console.log(`START - Expo Go exited (reason: ${info.reason})`);
+              if (info.crash) {
+                console.log(info.crash.stackTrace);
+              }
+              for (const line of logs) {
+                console.log(line);
+              }
+              console.log(`END - Expo Go exited`);
+            },
+          });
+        }
 
         return res.status(200).json({
           id: result.metadata.id,

--- a/examples/fullstack/backend/package.json
+++ b/examples/fullstack/backend/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@limrun/api": "0.39.4",
+    "@limrun/api": "0.46.4",
     "cors": "^2.8.5",
     "express": "^5.1.0"
   },

--- a/examples/fullstack/backend/yarn.lock
+++ b/examples/fullstack/backend/yarn.lock
@@ -132,17 +132,17 @@
   resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@limrun/api@0.39.4":
-  version "0.39.4"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.39.4.tgz#882aa575943cb025c4bb5b62db6f78112832e093"
-  integrity sha512-KarcBiyNYp+w8is/t7L5x7XuQZQSjOXrsv9cFR9au98ZPhjHEAKkuaJ9BGIl5R+4AONL9Wt+jX4sXL9tJyN/Pw==
+"@limrun/api@0.46.4":
+  version "0.46.4"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.4.tgz#01b2f8f1f45522df24b1ddd1e21d310c23067cf1"
+  integrity sha512-Le4b2aBpol1CMyvrQ93wrnmX/VTy9Z7WFxzGC5JFp3liARzw0uZPV+0c+v0Sm82+9ySBhJfJn/isL2r62h65Yg==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"
     https-proxy-agent "7.0.6"
     ignore "^7.0.5"
     proxy-from-env "^2.1.0"
-    undici "7.24.7"
+    undici "7.28.0"
     ws "^8.18.3"
     yauzl "^3.4.0"
 
@@ -843,10 +843,10 @@ undici-types@~7.10.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz"
   integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
-undici@7.24.7:
-  version "7.24.7"
-  resolved "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz#af9535341bbe80625ca403a02418477a5c6a8760"
-  integrity sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==
+undici@7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unpipe@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The fullstack backend now attaches onExit to the Android Expo Go launch just like the iOS path, logging the exit reason, the crash stack trace when present, and the app's recent logcat lines. Bumps the example's @limrun/api pin to 0.46.4, the first release shipping the Android app lifecycle API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only backend changes with no production auth or data paths; dependency pin update is scoped to the demo app.
> 
> **Overview**
> The fullstack example backend now **launches Expo Go on Android** after instance creation when `withExpoGo54` is enabled, using `createInstanceClient` and `launchApp` with **`RelaunchIfRunning`**—the same pattern as the existing iOS path.
> 
> The Android **`onExit`** handler logs exit **reason**, **crash stack trace** when available, and recent **logcat** lines, giving parity with iOS lifecycle visibility for demo/debugging.
> 
> **`@limrun/api`** is bumped from **0.39.4** to **0.46.4** so the example can use the Android app lifecycle APIs shipped in that release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15865fc78dcbb26eb05513e567cfca9acf22e3ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->