### PR TITLE
ios: play a local video file as the simulated camera

### DIFF
--- a/packages/cli/src/commands/ios/camera-video.ts
+++ b/packages/cli/src/commands/ios/camera-video.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import path from 'path';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getIosInstanceClient } from '../../lib/instance-client-factory';
+
+export default class IosCameraVideo extends BaseCommand {
+  static summary = 'Play a video file as the simulated camera';
+  static description =
+    'Upload a local video file and play it as the camera feed of a running iOS instance, replacing the live browser camera. ' +
+    'Apps see the video through their regular AVCaptureSession pipeline. ' +
+    'By default the video loops; with --no-loop it plays once and the feed freezes on the last frame. ' +
+    'Use the `clear` action to restore the default camera source.';
+  static examples = [
+    '<%= config.bin %> ios camera-video play ./fixtures/qr-scan.mp4',
+    '<%= config.bin %> ios camera-video play ./clip.mp4 --no-loop --id <instance-ID>',
+    '<%= config.bin %> ios camera-video clear',
+  ];
+
+  static args = {
+    action: Args.string({
+      description: 'Camera video action: `play` starts playback and `clear` restores the default camera',
+      required: true,
+      options: ['play', 'clear'],
+    }),
+    path: Args.string({
+      description: 'Local video file to play as the camera (required for the `play` action).',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    loop: Flags.boolean({
+      description: 'Restart the video when it ends. Use --no-loop to play once and freeze on the last frame.',
+      default: true,
+      allowNo: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(IosCameraVideo);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      try {
+        if (args.action === 'clear') {
+          await client.clearCameraVideo();
+          if (flags.json) {
+            this.outputJson({ ok: true });
+          } else {
+            this.output('Camera restored to the default source.');
+          }
+          return;
+        }
+
+        if (!args.path) {
+          this.error('The `play` action requires a video file path.');
+        }
+        const localPath = path.resolve(args.path);
+        if (!fs.existsSync(localPath)) {
+          this.error(`File not found: ${localPath}`);
+        }
+
+        await client.setCameraVideo(localPath, { loop: flags.loop });
+        if (flags.json) {
+          this.outputJson({ ok: true, loop: flags.loop });
+        } else {
+          this.output(`Playing ${localPath} as the camera${flags.loop ? ' on loop' : ' once'}.`);
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -231,6 +231,18 @@ export type ContainerTargetOptions = {
 };
 
 /**
+ * Options for playing a video file as the simulated camera feed.
+ */
+export type CameraVideoOptions = {
+  /**
+   * Whether to restart the video when it ends. When false the video
+   * plays once and the camera feed freezes on its last frame.
+   * @default true
+   */
+  loop?: boolean;
+};
+
+/**
  * Result of auto-discovering a StoreKit configuration from the
  * simulator's cached sandbox response.
  */
@@ -863,6 +875,29 @@ export type InstanceClient = {
    * @param opts Optional app container targeting (see `pushFile`).
    */
   deleteFile: (name: string, opts?: ContainerTargetOptions) => Promise<void>;
+
+  /**
+   * Play a local video file as the simulated camera feed.
+   *
+   * Uploads the file to the simulator and switches the camera source to
+   * it, replacing the live WebRTC camera until {@link clearCameraVideo}
+   * is called. Apps see the video through their regular
+   * `AVCaptureSession` pipeline.
+   *
+   * By default the video loops; with `loop: false` it plays once and the
+   * feed freezes on the last frame.
+   *
+   * @param path The path of the local video file to play as the camera.
+   * @param opts Playback options (currently just `loop`).
+   * @throws If the file has no decodable video track.
+   */
+  setCameraVideo: (path: string, opts?: CameraVideoOptions) => Promise<void>;
+
+  /**
+   * Stop video-file camera playback and restore the default WebRTC
+   * camera source. Safe to call when no video is playing.
+   */
+  clearCameraVideo: () => Promise<void>;
 
   /**
    * Run `xcrun` command with the given arguments.
@@ -1682,6 +1717,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       }),
       startVideoRecordingResult: () => undefined,
       stopVideoRecordingResult: () => undefined,
+      cameraControlResult: () => undefined,
       setOrientationResult: () => undefined,
       scrollResult: () => undefined,
       performActionsResult: (msg): PerformActionsResult => ({
@@ -1888,6 +1924,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             pushFile,
             pullFile,
             deleteFile,
+            setCameraVideo,
+            clearCameraVideo,
             lsof,
             deviceInfo: cachedDeviceInfo,
           });
@@ -2380,6 +2418,23 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         const errorBody = await response.text();
         throw new Error(`Deletion of '${name}' failed: ${response.status} ${errorBody}`);
       }
+    };
+
+    const setCameraVideo = async (filePath: string, cameraOptions?: CameraVideoOptions): Promise<void> => {
+      // Fixed prefix so repeat calls with the same file overwrite the
+      // previous upload instead of accumulating staging files.
+      const destination = `limrun-camera-${path.basename(filePath)}`;
+      const remotePath = await pushFile(filePath, destination);
+      await sendRequest<void>('cameraControl', {
+        action: 'setSource',
+        source: 'video',
+        arg: remotePath,
+        loop: cameraOptions?.loop ?? true,
+      });
+    };
+
+    const clearCameraVideo = (): Promise<void> => {
+      return sendRequest<void>('cameraControl', { action: 'reset' });
     };
 
     const setStoreKitConfig = async (bundleId: string, storekit: Buffer | Uint8Array): Promise<void> => {


### PR DESCRIPTION
## Summary
- New iOS client methods: `setCameraVideo(path, { loop })` uploads a local video with the existing `/files` endpoint and switches the camera source to it via `cameraControl` on the signaling socket; `clearCameraVideo()` restores the default WebRTC camera.
- `loop` defaults to true; with `loop: false` the video plays once and the camera feed freezes on the last frame.
- New CLI command: `lim ios camera-video play <path> [--no-loop]` and `lim ios camera-video clear`, following the `ios record start|stop` action convention.

Requires the limulator side from limrun-inc/limrun#561.

## Test plan
- [x] `yarn build` + `yarn lint` clean in the SDK root
- [x] CLI compiles (`tsc`) and `lim ios camera-video --help` renders correctly
- [ ] Manual: `lim ios camera-video play ./clip.mp4 --no-loop` against an instance running the limulator from limrun#561

Made with [Cursor](https://cursor.com)