### PR TITLE
Add iOS microphone mocking: playOnMicrophone/stopMicrophonePlayback SDK methods and live-mic streaming

### DIFF
--- a/packages/cli/src/commands/ios/camera.ts
+++ b/packages/cli/src/commands/ios/camera.ts
@@ -19,7 +19,8 @@ export default class IosCamera extends BaseCommand {
 
   static args = {
     action: Args.string({
-      description: 'Camera action: `play` plays a video file as the camera and `clear` restores the default camera',
+      description:
+        'Camera action: `play` plays a video file as the camera and `clear` restores the default camera',
       required: true,
       options: ['play', 'clear'],
     }),

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -233,6 +233,49 @@ interface RemoteControlProps {
    * 16:9 / 1920×1080 — applies).
    */
   cameraAspect?: CameraAspect;
+
+  /**
+   * iOS only: when true, capture the user's microphone via
+   * `getUserMedia({ audio: true })` and stream it live into the
+   * simulator's mock microphone. Unlike the camera (which is
+   * demand-driven by apps inside the sim), the microphone is
+   * user-driven: flip this prop from a button in your UI. The
+   * component handles the browser permission prompt, the WebRTC
+   * track attach (no SDP renegotiation — the audio slot is
+   * pre-allocated) and the `microphoneStart`/`microphoneStop`
+   * signaling to the host. Progress and failures are reported via
+   * `onMicrophoneStateChange`. Ignored on Android instances.
+   */
+  microphoneEnabled?: boolean;
+
+  /**
+   * Fires whenever the live-microphone pipeline changes state:
+   * after an enable attempt resolves (granted or denied), when the
+   * host acknowledges or rejects the stream, when the browser
+   * revokes the track mid-stream, and on disable. Use it to render
+   * the mic button's on/off/error state.
+   */
+  onMicrophoneStateChange?: (state: MicrophoneState) => void;
+}
+
+/**
+ * Snapshot of the live-microphone pipeline, reported through
+ * `onMicrophoneStateChange`.
+ */
+export interface MicrophoneState {
+  /** True while the browser mic is captured and streaming to the sim. */
+  active: boolean;
+  /**
+   * Browser permission outcome of the last enable attempt: `true`
+   * after the user accepted the prompt, `false` after a denial or
+   * device error, `undefined` when not applicable (e.g. plain
+   * disable).
+   */
+  granted?: boolean;
+  /** Human-readable failure from the last attempt, if any. */
+  error?: string;
+  /** Device label of the captured microphone, when available. */
+  label?: string;
 }
 
 /**
@@ -510,6 +553,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       onCameraStats,
       cameraResolutionCap = 'auto',
       cameraAspect,
+      microphoneEnabled = false,
+      onMicrophoneStateChange,
     }: RemoteControlProps,
     ref,
   ) => {
@@ -594,6 +639,25 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       packetsSent?: number;
       packetsLost?: number;
     } | null>(null);
+    // User-driven outbound microphone state (iOS only). Unlike the
+    // camera, the mic is toggled by the `microphoneEnabled` prop; the
+    // track rides a pre-allocated sendonly audio transceiver so
+    // enabling/disabling is just a `replaceTrack`, plus a
+    // `microphoneStart`/`microphoneStop` WS signal so the host's
+    // audio state machine switches its source.
+    const microphoneEnabledRef = useRef(microphoneEnabled);
+    microphoneEnabledRef.current = microphoneEnabled;
+    const onMicrophoneStateChangeRef = useRef(onMicrophoneStateChange);
+    onMicrophoneStateChangeRef.current = onMicrophoneStateChange;
+    const outboundMicSenderRef = useRef<RTCRtpSender | null>(null);
+    const outboundMicStreamRef = useRef<MediaStream | null>(null);
+    // Bumped on every attach/detach so a handler suspended on an await
+    // (the getUserMedia prompt) detects it was superseded and bails.
+    const micGenerationRef = useRef(0);
+    // Correlates the in-flight `microphoneStart` with its result so a
+    // host-side rejection (e.g. no loopback device on the node) can
+    // tear the capture back down and surface the error.
+    const micStartPendingIdRef = useRef<string | null>(null);
     const firstFrameShownRef = useRef(false);
     const pendingScreenshotResolversRef = useRef<
       Map<string, (value: ScreenshotData | PromiseLike<ScreenshotData>) => void>
@@ -1694,6 +1758,135 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       stopMediaStream(stream);
     };
 
+    // Capture the user's microphone and stream it to the simulator's
+    // mock microphone. Safe to call redundantly: bails when already
+    // attached, when the connection isn't up yet (the ICE-connected
+    // handler re-invokes it), or when the prop flipped off mid-prompt.
+    const attachMicrophone = async () => {
+      if (platform !== 'ios') return;
+      const generation = ++micGenerationRef.current;
+      const isCurrent = () => generation === micGenerationRef.current && microphoneEnabledRef.current;
+      const ws = wsRef.current;
+      const sender = outboundMicSenderRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN || !sender) {
+        // Not connected yet — the post-connect hook retries while the
+        // prop is still on.
+        return;
+      }
+      if (outboundMicStreamRef.current) return;
+      if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[RemoteControl] navigator.mediaDevices.getUserMedia unavailable. ' +
+            'getUserMedia requires a secure context (https or http://localhost).',
+        );
+        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+          active: false,
+          granted: false,
+          error: 'Microphone capture requires a secure context (https)',
+        });
+        return;
+      }
+      let stream: MediaStream | null = null;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[RemoteControl] microphone getUserMedia denied/failed:', err);
+      }
+      if (!isCurrent()) {
+        if (stream) stopMediaStream(stream);
+        return;
+      }
+      if (!stream) {
+        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+          active: false,
+          granted: false,
+          error: 'Microphone permission denied or no device available',
+        });
+        return;
+      }
+      const audioTrack = stream.getAudioTracks()[0] ?? null;
+      if (!audioTrack) {
+        stopMediaStream(stream);
+        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+          active: false,
+          granted: false,
+          error: 'Captured stream has no audio track',
+        });
+        return;
+      }
+      try {
+        await sender.replaceTrack(audioTrack);
+      } catch (err) {
+        debugWarn('replaceTrack(audioTrack) failed:', err);
+        stopMediaStream(stream);
+        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+          active: false,
+          granted: true,
+          error: 'Failed to attach the microphone track to the connection',
+        });
+        return;
+      }
+      if (!isCurrent()) {
+        try {
+          await sender.replaceTrack(null);
+        } catch (err) {
+          debugWarn('replaceTrack(null) on stale mic attach failed:', err);
+        }
+        stopMediaStream(stream);
+        return;
+      }
+      outboundMicStreamRef.current = stream;
+      // If the browser revokes the track later (user clicks Stop in
+      // the tab's mic indicator, device unplugged, ...) tear down and
+      // tell the host, so the sim's mic goes back to silence instead
+      // of freezing on the last buffer.
+      audioTrack.onended = () => {
+        if (outboundMicStreamRef.current !== stream) return;
+        void detachMicrophone('microphone capture ended by the browser');
+      };
+      const id = `ui-mic-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+      micStartPendingIdRef.current = id;
+      ws.send(JSON.stringify({ type: 'microphoneStart', id }));
+      safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+        active: true,
+        granted: true,
+        label: audioTrack.label || undefined,
+      });
+    };
+
+    // Stop the live microphone: drop the track from the sender, stop
+    // the capture (turning the browser's mic indicator off) and tell
+    // the host to switch its audio source back to silence. Safe to
+    // call when nothing is attached.
+    const detachMicrophone = async (error?: string) => {
+      ++micGenerationRef.current;
+      micStartPendingIdRef.current = null;
+      const sender = outboundMicSenderRef.current;
+      const stream = outboundMicStreamRef.current;
+      outboundMicStreamRef.current = null;
+      if (sender && stream) {
+        try {
+          await sender.replaceTrack(null);
+        } catch (err) {
+          debugWarn('replaceTrack(null) on mic detach failed:', err);
+        }
+      }
+      if (stream) stopMediaStream(stream);
+      const ws = wsRef.current;
+      if (stream && ws && ws.readyState === WebSocket.OPEN) {
+        const id = `ui-mic-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+        ws.send(JSON.stringify({ type: 'microphoneStop', id }));
+      }
+      if (stream || error) {
+        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+          active: false,
+          ...(error !== undefined && { error }),
+        });
+      }
+    };
+
     // Translate the user-facing resolution cap into a
     // MediaTrackConstraints fragment we can feed `getUserMedia`
     // or `applyConstraints`. Always returns a 30 fps ceiling so
@@ -1845,6 +2038,16 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       stopCameraStatsPoller();
       stopOutboundLocalStream();
       outboundCameraSenderRef.current = null;
+      // Same for the live microphone. No `microphoneStop` signal here —
+      // the WS is going away with the connection; if `microphoneEnabled`
+      // is still on, the post-reconnect hook re-attaches.
+      ++micGenerationRef.current;
+      micStartPendingIdRef.current = null;
+      if (outboundMicStreamRef.current) {
+        stopMediaStream(outboundMicStreamRef.current);
+        outboundMicStreamRef.current = null;
+      }
+      outboundMicSenderRef.current = null;
       // A scheduled cursor flush would otherwise call setState on a
       // teardown component once the next frame runs.
       if (cursorRafIdRef.current !== undefined) {
@@ -2162,6 +2365,18 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           : null;
         outboundCameraSenderRef.current = outboundCameraTransceiver?.sender ?? null;
 
+        // Same pre-allocation for the live microphone: a sendonly audio
+        // slot negotiated once at connection setup, so toggling the mic
+        // later is just `replaceTrack` — no SDP renegotiation. iOS only,
+        // like the camera.
+        const outboundMicTransceiver =
+          platform === 'ios' ?
+            peerConnection.addTransceiver('audio', {
+              direction: 'sendonly',
+            })
+          : null;
+        outboundMicSenderRef.current = outboundMicTransceiver?.sender ?? null;
+
         // As hardware encoder, we use H265 for iOS and VP9 for Android.
         // We make sure these two are the first ones in the list.
         // If not, the fallback is H264 which is also hardware accelerated, although not as good,
@@ -2383,6 +2598,11 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           updateStatus('ICE state: ' + iceState);
           if (iceState === 'connected' || iceState === 'completed') {
             clearIceDisconnectedGrace();
+            // Re-attach the live microphone across reconnects (or apply a
+            // prop that was flipped on before the connection was up).
+            if (microphoneEnabledRef.current && !outboundMicStreamRef.current) {
+              void attachMicrophone();
+            }
             return;
           }
           if (iceState === 'failed') {
@@ -2780,6 +3000,22 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               startCameraStatsPoller();
               break;
             }
+            case 'microphoneStartResult': {
+              if (micStartPendingIdRef.current === null || message.id !== micStartPendingIdRef.current) {
+                break;
+              }
+              micStartPendingIdRef.current = null;
+              if (typeof message.error === 'string') {
+                // Host rejected the stream (e.g. no loopback device
+                // assigned on the node). Tear the capture back down so
+                // the browser's mic indicator doesn't stay lit for a
+                // stream nobody hears.
+                // eslint-disable-next-line no-console
+                console.warn('[RemoteControl] microphoneStart rejected by host:', message.error);
+                void detachMicrophone(message.error);
+              }
+              break;
+            }
             case 'terminateAppResult':
               if (typeof message.id !== 'string') {
                 debugWarn('Received invalid terminateApp result message:', message);
@@ -2905,6 +3141,18 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         debugWarn('cameraAspect send failed:', err);
       }
     }, [cameraAspect]);
+
+    // Drive the live microphone from the `microphoneEnabled` prop.
+    // When flipped on before the connection is up, attachMicrophone
+    // bails and the ICE-connected handler picks it up instead.
+    useEffect(() => {
+      if (microphoneEnabled) {
+        void attachMicrophone();
+      } else {
+        void detachMicrophone();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [microphoneEnabled]);
 
     useEffect(() => {
       // Reset video loaded state when connection params change

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -266,13 +266,9 @@ export interface MicrophoneState {
   /** True while the browser mic is captured and streaming to the sim. */
   active: boolean;
   /**
-   * Browser permission outcome of the last enable attempt: `true`
-   * after the user accepted the prompt, `false` after a denial or
-   * device error, `undefined` when not applicable (e.g. plain
-   * disable).
+   * Human-readable failure from the last attempt, if any (permission
+   * denied, no device, host rejection, ...).
    */
-  granted?: boolean;
-  /** Human-readable failure from the last attempt, if any. */
   error?: string;
   /** Device label of the captured microphone, when available. */
   label?: string;
@@ -1788,6 +1784,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     const attachMicrophoneOp = async () => {
       const generation = micGenerationRef.current;
       const isCurrent = () => generation === micGenerationRef.current && microphoneEnabledRef.current;
+      const reportMicError = (error: string) => {
+        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+          active: false,
+          error,
+        });
+      };
       if (!isCurrent()) return;
       const ws = wsRef.current;
       const sender = outboundMicSenderRef.current;
@@ -1803,11 +1805,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           '[RemoteControl] navigator.mediaDevices.getUserMedia unavailable. ' +
             'getUserMedia requires a secure context (https or http://localhost).',
         );
-        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
-          active: false,
-          granted: false,
-          error: 'Microphone capture requires a secure context (https)',
-        });
+        reportMicError('Microphone capture requires a secure context (https)');
         return;
       }
       let stream: MediaStream | null = null;
@@ -1822,21 +1820,13 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         return;
       }
       if (!stream) {
-        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
-          active: false,
-          granted: false,
-          error: 'Microphone permission denied or no device available',
-        });
+        reportMicError('Microphone permission denied or no device available');
         return;
       }
       const audioTrack = stream.getAudioTracks()[0] ?? null;
       if (!audioTrack) {
         stopMediaStream(stream);
-        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
-          active: false,
-          granted: false,
-          error: 'Captured stream has no audio track',
-        });
+        reportMicError('Captured stream has no audio track');
         return;
       }
       try {
@@ -1844,11 +1834,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       } catch (err) {
         debugWarn('replaceTrack(audioTrack) failed:', err);
         stopMediaStream(stream);
-        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
-          active: false,
-          granted: true,
-          error: 'Failed to attach the microphone track to the connection',
-        });
+        reportMicError('Failed to attach the microphone track to the connection');
         return;
       }
       if (!isCurrent()) {
@@ -1874,7 +1860,6 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       ws.send(JSON.stringify({ type: 'microphoneStart', id }));
       safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
         active: true,
-        granted: true,
         label: audioTrack.label || undefined,
       });
     };

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -651,9 +651,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     onMicrophoneStateChangeRef.current = onMicrophoneStateChange;
     const outboundMicSenderRef = useRef<RTCRtpSender | null>(null);
     const outboundMicStreamRef = useRef<MediaStream | null>(null);
-    // Bumped on every attach/detach so a handler suspended on an await
+    // Bumped by detach and teardown so an attach suspended on an await
     // (the getUserMedia prompt) detects it was superseded and bails.
     const micGenerationRef = useRef(0);
+    // Serializes attach/detach work so their awaits (replaceTrack on the
+    // shared sender) can never interleave and undo each other's effects.
+    const micOpQueueRef = useRef<Promise<void>>(Promise.resolve());
     // Correlates the in-flight `microphoneStart` with its result so a
     // host-side rejection (e.g. no loopback device on the node) can
     // tear the capture back down and surface the error.
@@ -1758,14 +1761,34 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       stopMediaStream(stream);
     };
 
+    // Runs one attach/detach operation after all previously queued ones,
+    // so two operations' awaits never interleave on the shared sender (a
+    // stale detach could otherwise clear a fresh attach's track, or send
+    // `microphoneStop` after its `microphoneStart`).
+    const runMicOp = (op: () => Promise<void>): Promise<void> => {
+      const next = micOpQueueRef.current.then(op).catch((err) => {
+        debugWarn('microphone operation failed:', err);
+      });
+      micOpQueueRef.current = next;
+      return next;
+    };
+
     // Capture the user's microphone and stream it to the simulator's
     // mock microphone. Safe to call redundantly: bails when already
     // attached, when the connection isn't up yet (the ICE-connected
     // handler re-invokes it), or when the prop flipped off mid-prompt.
-    const attachMicrophone = async () => {
-      if (platform !== 'ios') return;
-      const generation = ++micGenerationRef.current;
+    // Does NOT bump the generation: a redundant call (e.g. the ICE
+    // handler firing on both `connected` and `completed`) must not
+    // cancel an attach already in flight; only detach/teardown cancel.
+    const attachMicrophone = (): Promise<void> => {
+      if (platform !== 'ios') return Promise.resolve();
+      return runMicOp(() => attachMicrophoneOp());
+    };
+
+    const attachMicrophoneOp = async () => {
+      const generation = micGenerationRef.current;
       const isCurrent = () => generation === micGenerationRef.current && microphoneEnabledRef.current;
+      if (!isCurrent()) return;
       const ws = wsRef.current;
       const sender = outboundMicSenderRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN || !sender) {
@@ -1860,31 +1883,36 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // the capture (turning the browser's mic indicator off) and tell
     // the host to switch its audio source back to silence. Safe to
     // call when nothing is attached.
-    const detachMicrophone = async (error?: string) => {
+    const detachMicrophone = (error?: string): Promise<void> => {
+      // Bump synchronously (not on the queue) so an attach that is
+      // suspended on an await bails at its next checkpoint even while
+      // it still owns the queue.
       ++micGenerationRef.current;
       micStartPendingIdRef.current = null;
-      const sender = outboundMicSenderRef.current;
-      const stream = outboundMicStreamRef.current;
-      outboundMicStreamRef.current = null;
-      if (sender && stream) {
-        try {
-          await sender.replaceTrack(null);
-        } catch (err) {
-          debugWarn('replaceTrack(null) on mic detach failed:', err);
+      return runMicOp(async () => {
+        const sender = outboundMicSenderRef.current;
+        const stream = outboundMicStreamRef.current;
+        outboundMicStreamRef.current = null;
+        if (sender && stream) {
+          try {
+            await sender.replaceTrack(null);
+          } catch (err) {
+            debugWarn('replaceTrack(null) on mic detach failed:', err);
+          }
         }
-      }
-      if (stream) stopMediaStream(stream);
-      const ws = wsRef.current;
-      if (stream && ws && ws.readyState === WebSocket.OPEN) {
-        const id = `ui-mic-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-        ws.send(JSON.stringify({ type: 'microphoneStop', id }));
-      }
-      if (stream || error) {
-        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
-          active: false,
-          ...(error !== undefined && { error }),
-        });
-      }
+        if (stream) stopMediaStream(stream);
+        const ws = wsRef.current;
+        if (stream && ws && ws.readyState === WebSocket.OPEN) {
+          const id = `ui-mic-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+          ws.send(JSON.stringify({ type: 'microphoneStop', id }));
+        }
+        if (stream || error) {
+          safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+            active: false,
+            ...(error !== undefined && { error }),
+          });
+        }
+      });
     };
 
     // Translate the user-facing resolution cap into a
@@ -2046,6 +2074,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       if (outboundMicStreamRef.current) {
         stopMediaStream(outboundMicStreamRef.current);
         outboundMicStreamRef.current = null;
+        // The capture is gone; report it so consumers don't keep a stale
+        // `active: true` across drops (a re-attach after reconnect
+        // reports again).
+        safeInvoke('onMicrophoneStateChange', onMicrophoneStateChangeRef.current, {
+          active: false,
+        });
       }
       outboundMicSenderRef.current = null;
       // A scheduled cursor flush would otherwise call setState on a

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,5 @@
 export { RemoteControl } from './components/remote-control';
-export type { RemoteControlHandle } from './components/remote-control';
+export type { RemoteControlHandle, MicrophoneState } from './components/remote-control';
 
 // Accessibility / inspect-mode types and helpers. Exported so customers can
 // build their own side panels, search UIs, or agent-driven inspectors on top

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -1759,8 +1759,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         once: msg.once ?? false,
       }),
       stopMicrophonePlaybackResult: () => undefined,
-      microphoneStatusResult: (msg): IosMicrophoneStatus =>
-        msg.status ?? { source: 'silence' },
+      microphoneStatusResult: (msg): IosMicrophoneStatus => msg.status ?? { source: 'silence' },
       setOrientationResult: () => undefined,
       scrollResult: () => undefined,
       performActionsResult: (msg): PerformActionsResult => ({

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -2226,9 +2226,11 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       if (!audioPath) {
         throw new Error('path must be a non-empty string');
       }
+      // JSON.stringify drops undefined values, so an unset `once` is
+      // simply omitted from the wire message (host defaults to looping).
       return sendRequest<IosPlayOnMicrophoneResult>('playOnMicrophone', {
         path: audioPath,
-        ...(microphoneOptions?.once === undefined ? {} : { once: microphoneOptions.once }),
+        once: microphoneOptions?.once,
       });
     };
 

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -448,6 +448,22 @@ export type PerformActionsResult = {
   results: PerformActionResult[];
 };
 
+/** Result of a successful {@link InstanceClient.playOnMicrophone} call. */
+export type IosPlayOnMicrophoneResult = {
+  /** Duration of the decoded audio in microseconds. */
+  duration: number;
+  /** Whether playback stops after one pass (true) or loops until stopped (false). */
+  once: boolean;
+};
+
+/** Mock-microphone state returned by {@link InstanceClient.microphoneStatus}. */
+export type IosMicrophoneStatus = {
+  /** Active audio source. */
+  source: 'silence' | 'file' | 'webrtcMic';
+  /** Path of the currently playing file, when source is `file`. */
+  filePath?: string;
+};
+
 /**
  * A client for interacting with a Limrun iOS instance
  */
@@ -674,6 +690,22 @@ export type InstanceClient = {
    * Note that the download URL is only valid while the instance is running.
    */
   stopRecording: (saveTo: { presignedUrl?: string; localPath?: string }) => Promise<string>;
+
+  /**
+   * Play an audio file as the simulator's microphone input. Stage the file on
+   * the instance first with `pushFile` (no bundle ID); `path` is the same
+   * name used there. Loops until stopped by default; pass `once: true` to
+   * play a single pass. Playing a new file replaces the current one.
+   * Apps launched via `launchApp` get the microphone permission pre-granted.
+   */
+  playOnMicrophone: (path: string, options?: { once?: boolean }) => Promise<IosPlayOnMicrophoneResult>;
+
+  /** Stop mock-microphone file playback, if any. */
+  stopMicrophonePlayback: () => Promise<void>;
+
+  /** Get the current mock-microphone state. */
+  microphoneStatus: () => Promise<IosMicrophoneStatus>;
+
   /** Send an application-level keepAlive message on the control websocket. */
   keepAlive: () => void;
 
@@ -1079,6 +1111,10 @@ type ServerResponse = {
   results?: PerformActionResult[];
   // Keychain transfer result fields
   durationMs?: number;
+  // Mock-microphone result fields
+  duration?: number;
+  once?: boolean;
+  status?: IosMicrophoneStatus;
 };
 
 /**
@@ -1718,6 +1754,13 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       startVideoRecordingResult: () => undefined,
       stopVideoRecordingResult: () => undefined,
       cameraControlResult: () => undefined,
+      playOnMicrophoneResult: (msg): IosPlayOnMicrophoneResult => ({
+        duration: msg.duration ?? 0,
+        once: msg.once ?? false,
+      }),
+      stopMicrophonePlaybackResult: () => undefined,
+      microphoneStatusResult: (msg): IosMicrophoneStatus =>
+        msg.status ?? { source: 'silence' },
       setOrientationResult: () => undefined,
       scrollResult: () => undefined,
       performActionsResult: (msg): PerformActionsResult => ({
@@ -1905,6 +1948,9 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             performActions,
             startRecording,
             stopRecording,
+            playOnMicrophone,
+            stopMicrophonePlayback,
+            microphoneStatus,
             keepAlive,
             syncApp,
             setStoreKitConfig,
@@ -2171,6 +2217,27 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         await downloadFileToLocalPath(downloadUrl, options.token, saveTo.localPath);
       }
       return downloadUrl;
+    };
+
+    const playOnMicrophone = async (
+      audioPath: string,
+      microphoneOptions?: { once?: boolean },
+    ): Promise<IosPlayOnMicrophoneResult> => {
+      if (!audioPath) {
+        throw new Error('path must be a non-empty string');
+      }
+      return sendRequest<IosPlayOnMicrophoneResult>('playOnMicrophone', {
+        path: audioPath,
+        ...(microphoneOptions?.once === undefined ? {} : { once: microphoneOptions.once }),
+      });
+    };
+
+    const stopMicrophonePlayback = async (): Promise<void> => {
+      await sendRequest<void>('stopMicrophonePlayback');
+    };
+
+    const microphoneStatus = async (): Promise<IosMicrophoneStatus> => {
+      return sendRequest<IosMicrophoneStatus>('microphoneStatus');
     };
 
     const keepAlive = (): void => {


### PR DESCRIPTION
## Summary

- SDK: `playOnMicrophone` (once or looped, file staged via the files API) and `stopMicrophonePlayback` on the iOS instance client, with microphone status exposed through the signaling stream.
- UI (`@limrun/ui`): live microphone button on the remote control that streams the browser microphone over WebRTC into the instance.

Companion to limrun-inc/limrun#565, which adds the LimAudio loopback driver and the limulator/macnode side.

## Test plan

- [x] Exercised against a local limulator: file playback recorded inside the guest at the expected frequency
- [ ] e2e once limrun#565 is rolled out to staging

Made with [Cursor](https://cursor.com)
