### PR TITLE
Add iOS microphone CLI commands: play-on-microphone and stop-microphone-playback

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"

--- a/packages/cli/src/commands/ios/play-on-microphone.ts
+++ b/packages/cli/src/commands/ios/play-on-microphone.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import path from 'path';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getIosInstanceClient } from '../../lib/instance-client-factory';
+
+export default class IosPlayOnMicrophone extends BaseCommand {
+  static summary = 'Play a local audio file as microphone input on a running iOS instance';
+  static description =
+    'Upload a local audio file (WAV/MP3/M4A/AAC) to the simulator, then play it as mocked microphone input. ' +
+    'Loops until stopped by default; use --once to play a single pass. Use `ios stop-microphone-playback` to stop.';
+
+  static examples = [
+    '<%= config.bin %> ios play-on-microphone ./sample.wav',
+    '<%= config.bin %> ios play-on-microphone ./sample.mp3 --once',
+    '<%= config.bin %> ios play-on-microphone ./sample.wav --id <instance-ID>',
+  ];
+
+  static args = {
+    path: Args.string({
+      description: 'Local audio file path to upload and play as microphone input',
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    once: Flags.boolean({
+      description: 'Play the audio file once instead of looping it',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(IosPlayOnMicrophone);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const localPath = path.resolve(args.path);
+      if (!fs.existsSync(localPath)) {
+        this.error(`File not found: ${localPath}`);
+      }
+      const stat = fs.statSync(localPath);
+      if (!stat.isFile()) {
+        this.error(`Path is not a file: ${localPath}`);
+      }
+
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      try {
+        const remoteName = path.basename(localPath);
+        this.info(`Uploading ${remoteName}...`);
+        await client.pushFile(localPath, remoteName);
+        const result = await client.playOnMicrophone(remoteName, { once: flags.once });
+
+        if (flags.json) {
+          this.outputJson(result);
+        } else {
+          this.output(
+            `Playing ${remoteName} on microphone (duration=${result.duration}us, once=${result.once})`,
+          );
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/ios/stop-microphone-playback.ts
+++ b/packages/cli/src/commands/ios/stop-microphone-playback.ts
@@ -1,0 +1,41 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getIosInstanceClient } from '../../lib/instance-client-factory';
+
+export default class IosStopMicrophonePlayback extends BaseCommand {
+  static summary = 'Stop mocked microphone playback on a running iOS instance';
+  static description =
+    'Stops audio started with `ios play-on-microphone`; the microphone goes back to silence.';
+
+  static examples = [
+    '<%= config.bin %> ios stop-microphone-playback',
+    '<%= config.bin %> ios stop-microphone-playback --id <instance-ID>',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosStopMicrophonePlayback);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      try {
+        await client.stopMicrophonePlayback();
+        if (flags.json) {
+          this.outputJson({ stopped: true });
+        } else {
+          this.output('Stopped microphone playback');
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@0.46.5":
-  version "0.46.5"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.5.tgz#169fb6e9362fba3de62c7cb351d13a0efe3af2b0"
-  integrity sha512-KbP1wUUv/XT0BdOun9w3yPJqNZaoYE6N31JU9Wzz0tPThNjNhZh7TtikEBWGgTlXC61gnED+w9FjWmSbii9TXQ==
+"@limrun/api@0.46.6":
+  version "0.46.6"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.6.tgz#02cfd817563e8d947b27bf5be7512be658a4c215"
+  integrity sha512-3xG/iaLaMyy/B4aabiRR4X7v7eH04c4l/ZbGGTx5KpgxmJgPCbRRGugBVT51JFvx65XuVQfSR8lujJBvUERtqg==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
## Summary

- Adds the `ios play-on-microphone` (once or looped) and `ios stop-microphone-playback` CLI commands, wrapping the SDK's `playOnMicrophone` / `stopMicrophonePlayback` on the iOS instance client.

## Merge order (important)

This PR is intentionally split from the SDK+UI PR (#291) and must merge **last**:

1. Merge #291 (adds the SDK methods).
2. Let release-please cut a new `@limrun/api` release containing them.
3. Bump `@limrun/api` in `packages/cli/package.json` to that released version on this branch.
4. Merge this PR.

Until step 3, the current `@limrun/api` pin predates the methods, so typecheck here fails by design.

Companion to limrun-inc/limrun#565.

## Test plan

- [ ] After the api bump, `ios play-on-microphone <instance> <file>` plays into a live instance's mic and `ios stop-microphone-playback` stops it

Made with [Cursor](https://cursor.com)