### PR TITLE
ios: typing strategy, tap activation, swipe command, wheel scrolling

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -211,14 +211,17 @@ lim ios tap-element --ax-unique-id btn_ok
 
 # Text input
 lim ios type "Hello World"
+lim ios type "Hello World" --hid          # real key events, text delegates fire
 lim ios type "search query" --enter
 lim ios press-key enter
-lim ios press-key a --modifier shift
+lim ios press-key "@"
 lim ios toggle-keyboard
 
-# Scrolling
+# Scrolling and swiping
 lim ios scroll down --amount 500
 lim ios scroll down --amount 500 --momentum 0.4
+lim ios scroll down --amount 500 --coordinate 200,400
+lim ios swipe --from 200,300 --to 200,600
 
 # Batch multiple actions in one call
 lim ios perform --action type=tap,x=100,y=200 --action 'type=typeText,text=Hello World'

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -210,9 +210,10 @@ lim ios tap-element --ax-label "Submit"
 lim ios tap-element --ax-unique-id btn_ok
 
 # Text input
-lim ios type "Hello World"
-lim ios type "Hello World" --hid          # real key events, text delegates fire
+lim ios type "Hello World"                # real key events, text delegates fire
 lim ios type "search query" --enter
+lim ios set-text "long text" --focused    # instant, no key events
+lim ios set-text "user@example.com" --ax-unique-id email_field
 lim ios press-key enter
 lim ios press-key "@"
 lim ios toggle-keyboard

--- a/packages/cli/src/commands/ios/scroll.ts
+++ b/packages/cli/src/commands/ios/scroll.ts
@@ -56,7 +56,7 @@ export default class IosScroll extends BaseCommand {
       }
 
       const momentum = parseMomentum(flags.momentum);
-      const coordinate = parseCoordinate(flags.coordinate);
+      const coordinate = flags.coordinate ? parsePointFlag(flags.coordinate, '--coordinate') : undefined;
       const scrollOptions =
         momentum === undefined && coordinate === undefined ? undefined : { momentum, coordinate };
 
@@ -74,13 +74,6 @@ export default class IosScroll extends BaseCommand {
       this.log(`Scrolled ${args.direction}`);
     });
   }
-}
-
-function parseCoordinate(value: string | undefined): [number, number] | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  return parsePointFlag(value, '--coordinate');
 }
 
 function parseMomentum(value: string | undefined): number | undefined {

--- a/packages/cli/src/commands/ios/scroll.ts
+++ b/packages/cli/src/commands/ios/scroll.ts
@@ -5,6 +5,7 @@ import {
   hasActiveSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
+import { parsePointFlag } from '../../lib/parse-point';
 
 export default class IosScroll extends BaseCommand {
   static summary = 'Scroll on a running iOS instance';
@@ -37,6 +38,10 @@ export default class IosScroll extends BaseCommand {
       description:
         'Scroll momentum from 0.0 to 1.0. 0 disables inertia; 1 uses the fastest scroll with maximum inertia.',
     }),
+    coordinate: Flags.string({
+      description:
+        'Starting point of the scroll gesture as "x,y" in screen points. Defaults to the screen center; pass this when the scrollable view is not under the center (modals, split views).',
+    }),
   };
 
   async run(): Promise<void> {
@@ -51,16 +56,12 @@ export default class IosScroll extends BaseCommand {
       }
 
       const momentum = parseMomentum(flags.momentum);
-      const scrollOptions = momentum === undefined ? undefined : { momentum };
+      const coordinate = parseCoordinate(flags.coordinate);
+      const scrollOptions =
+        momentum === undefined && coordinate === undefined ? undefined : { momentum, coordinate };
 
       if (hasActiveSession(id)) {
-        if (scrollOptions) {
-          await sendSessionCommand(id, 'perform-actions', [
-            [{ type: 'scroll', direction: args.direction, pixels: flags.amount, momentum }],
-          ]);
-        } else {
-          await sendSessionCommand(id, 'scroll', [args.direction, flags.amount]);
-        }
+        await sendSessionCommand(id, 'scroll', [args.direction, flags.amount, scrollOptions]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
         try {
@@ -73,6 +74,13 @@ export default class IosScroll extends BaseCommand {
       this.log(`Scrolled ${args.direction}`);
     });
   }
+}
+
+function parseCoordinate(value: string | undefined): [number, number] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return parsePointFlag(value, '--coordinate');
 }
 
 function parseMomentum(value: string | undefined): number | undefined {

--- a/packages/cli/src/commands/ios/set-text.ts
+++ b/packages/cli/src/commands/ios/set-text.ts
@@ -1,0 +1,108 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import {
+  getIosInstanceClient,
+  hasActiveSession,
+  sendSessionCommand,
+} from '../../lib/instance-client-factory';
+
+export default class IosSetText extends BaseCommand {
+  static summary = 'Set text on an iOS element directly via accessibility';
+  static description =
+    'Set the value of a text field instantly through the accessibility API, without typing key events. ' +
+    'Much faster than `ios type` for long strings, but key-event-driven text delegates do not fire; ' +
+    'use `ios type` to simulate real typing. Target an element with selector flags, or `--focused` for ' +
+    'whatever field currently has focus.';
+  static examples = [
+    '<%= config.bin %> ios set-text "user@example.com" --ax-unique-id email_field',
+    '<%= config.bin %> ios set-text "long text to paste" --focused',
+    '<%= config.bin %> ios set-text "Hello" --ax-label "Message" --id <instance-ID>',
+  ];
+
+  static args = {
+    text: Args.string({ description: 'The text value to set', required: true }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    focused: Flags.boolean({
+      description: 'Target the currently focused element instead of matching a selector.',
+      default: false,
+      exclusive: [
+        'ax-unique-id',
+        'ax-label',
+        'ax-label-contains',
+        'type',
+        'title',
+        'title-contains',
+        'ax-value',
+      ],
+    }),
+    'ax-unique-id': Flags.string({
+      description: 'Match by `AXUniqueId` (accessibilityIdentifier) using an exact match.',
+    }),
+    'ax-label': Flags.string({
+      description: 'Match by `AXLabel` using an exact match.',
+    }),
+    'ax-label-contains': Flags.string({
+      description: 'Match by `AXLabelContains` using a case-insensitive contains query.',
+    }),
+    type: Flags.string({
+      description: 'Match by element type/role, such as `TextField`.',
+    }),
+    title: Flags.string({
+      description: 'Match by title using an exact match.',
+    }),
+    'title-contains': Flags.string({
+      description: 'Match by `titleContains` using a case-insensitive contains query.',
+    }),
+    'ax-value': Flags.string({
+      description: 'Match by `AXValue` using an exact match.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(IosSetText);
+    this.setParsedFlags(flags);
+
+    const selector: Record<string, string> = {};
+    if (flags['ax-unique-id']) selector.AXUniqueId = flags['ax-unique-id'];
+    if (flags['ax-label']) selector.AXLabel = flags['ax-label'];
+    if (flags['ax-label-contains']) selector.AXLabelContains = flags['ax-label-contains'];
+    if (flags.type) selector.type = flags.type;
+    if (flags.title) selector.title = flags.title;
+    if (flags['title-contains']) selector.titleContains = flags['title-contains'];
+    if (flags['ax-value']) selector.AXValue = flags['ax-value'];
+
+    if (!flags.focused && Object.keys(selector).length === 0) {
+      this.error(
+        'Provide a selector flag such as --ax-unique-id or --ax-label, or pass --focused to target the focused field.',
+      );
+    }
+    const target = flags.focused ? undefined : selector;
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const id = resolvedInstance.id;
+
+      if (hasActiveSession(id)) {
+        const result = await sendSessionCommand(id, 'set-text', [args.text, target]);
+        if (flags.json) this.outputJson(result);
+        else this.log('Text set');
+        return;
+      }
+
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      try {
+        const result = await client.setElementValue(args.text, target);
+        if (flags.json) this.outputJson(result);
+        else this.log('Text set');
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/ios/swipe.ts
+++ b/packages/cli/src/commands/ios/swipe.ts
@@ -50,8 +50,11 @@ export default class IosSwipe extends BaseCommand {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const id = resolvedInstance.id;
 
+      // The batch runs for ~duration; size the IPC timeout accordingly so
+      // long swipes don't hit the daemon's 30s default.
+      const ipcTimeoutMs = flags.duration + 15_000;
       if (hasActiveSession(id)) {
-        await sendSessionCommand(id, 'perform-actions', [actions]);
+        await sendSessionCommand(id, 'perform-actions', [actions], ipcTimeoutMs);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
         try {

--- a/packages/cli/src/commands/ios/swipe.ts
+++ b/packages/cli/src/commands/ios/swipe.ts
@@ -1,0 +1,91 @@
+import { Flags } from '@oclif/core';
+import type { Ios } from '@limrun/api';
+import { BaseCommand } from '../../base-command';
+import { parsePointFlag } from '../../lib/parse-point';
+import {
+  getIosInstanceClient,
+  hasActiveSession,
+  sendSessionCommand,
+} from '../../lib/instance-client-factory';
+
+export default class IosSwipe extends BaseCommand {
+  static summary = 'Swipe between two points on a running iOS instance';
+  static description =
+    'Perform a touch swipe gesture from one screen point to another, expressed in screen points. ' +
+    'Useful for gestures scroll cannot express, like pull-to-refresh (swipe down from the upper third of the screen).';
+  static examples = [
+    '<%= config.bin %> ios swipe --from 200,300 --to 200,600',
+    '<%= config.bin %> ios swipe --from 200,300 --to 200,600 --duration 800',
+    '<%= config.bin %> ios swipe --from 350,400 --to 50,400 --id <instance-ID>',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    from: Flags.string({
+      description: 'Start point as "x,y" in screen points.',
+      required: true,
+    }),
+    to: Flags.string({
+      description: 'End point as "x,y" in screen points.',
+      required: true,
+    }),
+    duration: Flags.integer({
+      description: 'Gesture duration in milliseconds. Longer swipes drag more precisely; shorter ones fling.',
+      default: 300,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosSwipe);
+    this.setParsedFlags(flags);
+
+    const from = parsePointFlag(flags.from, '--from');
+    const to = parsePointFlag(flags.to, '--to');
+    const actions = swipeActions(from, to, flags.duration);
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const id = resolvedInstance.id;
+
+      if (hasActiveSession(id)) {
+        await sendSessionCommand(id, 'perform-actions', [actions]);
+      } else {
+        const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+        try {
+          await client.performActions(actions);
+        } finally {
+          disconnect();
+        }
+      }
+      this.log(`Swiped from (${from[0]}, ${from[1]}) to (${to[0]}, ${to[1]})`);
+    });
+  }
+}
+
+/**
+ * Builds a touchDown -> interpolated touchMoves -> touchUp batch. Steps are
+ * spaced ~10ms apart so the server-side gesture matches the requested
+ * duration; ~3pt movement per step keeps the drag smooth.
+ */
+function swipeActions(from: [number, number], to: [number, number], durationMs: number): Ios.PerformAction[] {
+  const distance = Math.hypot(to[0] - from[0], to[1] - from[1]);
+  const steps = Math.max(2, Math.min(100, Math.round(distance / 3)));
+  const stepDelayMs = Math.max(1, Math.round(durationMs / steps));
+
+  const actions: Ios.PerformAction[] = [{ type: 'touchDown', x: from[0], y: from[1] }];
+  for (let i = 1; i <= steps; i++) {
+    actions.push(
+      { type: 'wait', durationMs: stepDelayMs },
+      {
+        type: 'touchMove',
+        x: from[0] + ((to[0] - from[0]) * i) / steps,
+        y: from[1] + ((to[1] - from[1]) * i) / steps,
+      },
+    );
+  }
+  actions.push({ type: 'touchUp', x: to[0], y: to[1] });
+  return actions;
+}

--- a/packages/cli/src/commands/ios/swipe.ts
+++ b/packages/cli/src/commands/ios/swipe.ts
@@ -52,9 +52,9 @@ export default class IosSwipe extends BaseCommand {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const id = resolvedInstance.id;
 
-      // One timeout governs the batch on both transports; the IPC socket gets
-      // a buffer on top so the daemon-held request fails first with the real
-      // error instead of a generic socket timeout.
+      // One timeout governs the batch on both transports. The IPC socket
+      // gets a buffer on top, so the real error surfaces before the socket
+      // times out.
       const timeoutMs = flags.duration + IPC_TIMEOUT_BUFFER_MS;
       if (hasActiveSession(id)) {
         try {
@@ -85,9 +85,9 @@ export default class IosSwipe extends BaseCommand {
 }
 
 /**
- * Best-effort touch-up after a failed batch: performActions stops at the
- * first error, so the trailing touchUp may never run and the simulator would
- * keep the finger pressed, corrupting every subsequent gesture.
+ * Lifts the finger after a failed batch, best-effort. A failed batch stops
+ * before its trailing touchUp, and a finger left pressed corrupts every
+ * later gesture.
  */
 async function liftFinger(
   send: (batch: Ios.PerformAction[]) => Promise<unknown>,
@@ -101,9 +101,9 @@ async function liftFinger(
 }
 
 /**
- * Builds a touchDown -> interpolated touchMoves -> touchUp batch. Step count
- * follows the requested duration at ~8ms per step (the touch sample rate),
- * capped by distance so short swipes stay coarse enough to register.
+ * Builds the swipe as touchDown, interpolated touchMoves, touchUp. Steps
+ * are ~8ms apart (the touch sample rate); short swipes get fewer steps so
+ * each one still moves.
  */
 function swipeActions(from: [number, number], to: [number, number], durationMs: number): Ios.PerformAction[] {
   const [x0, y0] = from;

--- a/packages/cli/src/commands/ios/swipe.ts
+++ b/packages/cli/src/commands/ios/swipe.ts
@@ -8,6 +8,8 @@ import {
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
+const IPC_TIMEOUT_BUFFER_MS = 15_000;
+
 export default class IosSwipe extends BaseCommand {
   static summary = 'Swipe between two points on a running iOS instance';
   static description =
@@ -42,23 +44,36 @@ export default class IosSwipe extends BaseCommand {
     const { flags } = await this.parse(IosSwipe);
     this.setParsedFlags(flags);
 
-    const from = parsePointFlag(flags.from, '--from');
-    const to = parsePointFlag(flags.to, '--to');
-    const actions = swipeActions(from, to, flags.duration);
-
     await this.withAuth(async () => {
+      const from = parsePointFlag(flags.from, '--from');
+      const to = parsePointFlag(flags.to, '--to');
+      const actions = swipeActions(from, to, flags.duration);
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const id = resolvedInstance.id;
 
-      // The batch runs for ~duration; size the IPC timeout accordingly so
-      // long swipes don't hit the daemon's 30s default.
-      const ipcTimeoutMs = flags.duration + 15_000;
+      // One timeout governs the batch on both transports; the IPC socket gets
+      // a buffer on top so the daemon-held request fails first with the real
+      // error instead of a generic socket timeout.
+      const timeoutMs = flags.duration + IPC_TIMEOUT_BUFFER_MS;
       if (hasActiveSession(id)) {
-        await sendSessionCommand(id, 'perform-actions', [actions], ipcTimeoutMs);
+        try {
+          await sendSessionCommand(
+            id,
+            'perform-actions',
+            [actions, timeoutMs],
+            timeoutMs + IPC_TIMEOUT_BUFFER_MS,
+          );
+        } catch (error) {
+          await liftFinger((batch) => sendSessionCommand(id, 'perform-actions', [batch]), to);
+          throw error;
+        }
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
         try {
-          await client.performActions(actions);
+          await client.performActions(actions, { timeoutMs });
+        } catch (error) {
+          await liftFinger((batch) => client.performActions(batch), to);
+          throw error;
         } finally {
           disconnect();
         }
@@ -69,26 +84,44 @@ export default class IosSwipe extends BaseCommand {
 }
 
 /**
- * Builds a touchDown -> interpolated touchMoves -> touchUp batch. Steps are
- * spaced ~10ms apart so the server-side gesture matches the requested
- * duration; ~3pt movement per step keeps the drag smooth.
+ * Best-effort touch-up after a failed batch: performActions stops at the
+ * first error, so the trailing touchUp may never run and the simulator would
+ * keep the finger pressed, corrupting every subsequent gesture.
+ */
+async function liftFinger(
+  send: (batch: Ios.PerformAction[]) => Promise<unknown>,
+  to: [number, number],
+): Promise<void> {
+  try {
+    await send([{ type: 'touchUp', x: to[0], y: to[1] }]);
+  } catch {
+    // The original error is the one worth surfacing.
+  }
+}
+
+/**
+ * Builds a touchDown -> interpolated touchMoves -> touchUp batch. Step count
+ * follows the requested duration at ~8ms per step (the touch sample rate),
+ * capped by distance so short swipes stay coarse enough to register.
  */
 function swipeActions(from: [number, number], to: [number, number], durationMs: number): Ios.PerformAction[] {
-  const distance = Math.hypot(to[0] - from[0], to[1] - from[1]);
-  const steps = Math.max(2, Math.min(100, Math.round(distance / 3)));
+  const [x0, y0] = from;
+  const [x1, y1] = to;
+  const distance = Math.hypot(x1 - x0, y1 - y0);
+  const steps = Math.max(2, Math.min(60, Math.round(durationMs / 8), Math.round(distance / 3)));
   const stepDelayMs = Math.max(1, Math.round(durationMs / steps));
 
-  const actions: Ios.PerformAction[] = [{ type: 'touchDown', x: from[0], y: from[1] }];
+  const actions: Ios.PerformAction[] = [{ type: 'touchDown', x: x0, y: y0 }];
   for (let i = 1; i <= steps; i++) {
     actions.push(
       { type: 'wait', durationMs: stepDelayMs },
       {
         type: 'touchMove',
-        x: from[0] + ((to[0] - from[0]) * i) / steps,
-        y: from[1] + ((to[1] - from[1]) * i) / steps,
+        x: Math.round(x0 + ((x1 - x0) * i) / steps),
+        y: Math.round(y0 + ((y1 - y0) * i) / steps),
       },
     );
   }
-  actions.push({ type: 'touchUp', x: to[0], y: to[1] });
+  actions.push({ type: 'touchUp', x: x1, y: y1 });
   return actions;
 }

--- a/packages/cli/src/commands/ios/swipe.ts
+++ b/packages/cli/src/commands/ios/swipe.ts
@@ -13,8 +13,9 @@ const IPC_TIMEOUT_BUFFER_MS = 15_000;
 export default class IosSwipe extends BaseCommand {
   static summary = 'Swipe between two points on a running iOS instance';
   static description =
-    'Perform a touch swipe gesture from one screen point to another, expressed in screen points. ' +
-    'Useful for gestures scroll cannot express, like pull-to-refresh (swipe down from the upper third of the screen).';
+    'Perform a touch drag gesture from one screen point to another, expressed in screen points. ' +
+    'Use `ios scroll` for plain content scrolling; swipe gives explicit start/end points and duration ' +
+    'for gestures that need them: pull-to-refresh from a specific area, carousel paging, sliders, and diagonal drags.';
   static examples = [
     '<%= config.bin %> ios swipe --from 200,300 --to 200,600',
     '<%= config.bin %> ios swipe --from 200,300 --to 200,600 --duration 800',

--- a/packages/cli/src/commands/ios/tap-element.ts
+++ b/packages/cli/src/commands/ios/tap-element.ts
@@ -81,8 +81,8 @@ export default class IosTapElement extends BaseCommand {
       const options: Ios.TapElementOptions | undefined =
         flags.activate ? { activate: flags.activate as Ios.TapElementActivation } : undefined;
       if (hasActiveSession(id)) {
-        // The daemon-held request uses the SDK's 90s tapElement budget
-        // (off-screen scroll scans); the IPC socket must not give up first.
+        // tapElement can scroll-scan for up to 90s; the IPC socket must not
+        // give up first.
         const result = await sendSessionCommand(
           id,
           'tap-element',

--- a/packages/cli/src/commands/ios/tap-element.ts
+++ b/packages/cli/src/commands/ios/tap-element.ts
@@ -1,4 +1,5 @@
 import { Flags } from '@oclif/core';
+import { Ios } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
@@ -77,9 +78,17 @@ export default class IosTapElement extends BaseCommand {
         );
       }
 
-      const options = flags.activate ? { activate: flags.activate as 'touch' | 'ax' } : undefined;
+      const options: Ios.TapElementOptions | undefined =
+        flags.activate ? { activate: flags.activate as Ios.TapElementActivation } : undefined;
       if (hasActiveSession(id)) {
-        const result = await sendSessionCommand(id, 'tap-element', [selector, options]);
+        // The daemon-held request uses the SDK's 90s tapElement budget
+        // (off-screen scroll scans); the IPC socket must not give up first.
+        const result = await sendSessionCommand(
+          id,
+          'tap-element',
+          [selector, options],
+          Ios.TAP_ELEMENT_TIMEOUT_MS + 15_000,
+        );
         if (flags.json) this.outputJson(result);
         else this.log('Element tapped');
         return;

--- a/packages/cli/src/commands/ios/tap-element.ts
+++ b/packages/cli/src/commands/ios/tap-element.ts
@@ -44,6 +44,11 @@ export default class IosTapElement extends BaseCommand {
     'ax-value': Flags.string({
       description: 'Match by `AXValue` using an exact match.',
     }),
+    activate: Flags.string({
+      description:
+        'How to activate the element: `touch` (default) scrolls it into view and taps with a real touch; `ax` performs an accessibility press without touch events.',
+      options: ['touch', 'ax'],
+    }),
   };
 
   async run(): Promise<void> {
@@ -72,8 +77,9 @@ export default class IosTapElement extends BaseCommand {
         );
       }
 
+      const options = flags.activate ? { activate: flags.activate as 'touch' | 'ax' } : undefined;
       if (hasActiveSession(id)) {
-        const result = await sendSessionCommand(id, 'tap-element', [selector]);
+        const result = await sendSessionCommand(id, 'tap-element', [selector, options]);
         if (flags.json) this.outputJson(result);
         else this.log('Element tapped');
         return;
@@ -81,7 +87,7 @@ export default class IosTapElement extends BaseCommand {
 
       const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
       try {
-        const result = await client.tapElement(selector);
+        const result = await client.tapElement(selector, options);
         if (flags.json) this.outputJson(result);
         else this.log('Element tapped');
       } finally {

--- a/packages/cli/src/commands/ios/type.ts
+++ b/packages/cli/src/commands/ios/type.ts
@@ -29,6 +29,15 @@ export default class IosType extends BaseCommand {
       description: 'Press Enter after typing.',
       default: false,
     }),
+    hid: Flags.boolean({
+      description:
+        'Type real key events instead of setting the accessibility value, so the app receives genuine keystrokes and text delegates fire. Slower; fails when no field is focused.',
+      default: false,
+    }),
+    'require-focus': Flags.boolean({
+      description: 'Fail instead of typing blind when no input field is focused.',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -42,15 +51,25 @@ export default class IosType extends BaseCommand {
         this.error('ios type only supports iOS instances');
       }
 
+      const options = {
+        strategy: flags.hid ? ('hid' as const) : undefined,
+        requireFocus: flags['require-focus'] || undefined,
+      };
+      let outcome: { warning?: string } | undefined;
       if (hasActiveSession(id)) {
-        await sendSessionCommand(id, 'type', [args.text, flags.enter]);
+        outcome = (await sendSessionCommand(id, 'type', [args.text, flags.enter, options])) as {
+          warning?: string;
+        };
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
         try {
-          await client.typeText(args.text, flags.enter);
+          outcome = await client.typeText(args.text, flags.enter, options);
         } finally {
           disconnect();
         }
+      }
+      if (outcome?.warning) {
+        this.warn(outcome.warning);
       }
       this.log('Text typed');
     });

--- a/packages/cli/src/commands/ios/type.ts
+++ b/packages/cli/src/commands/ios/type.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import type { Ios } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
@@ -10,7 +9,9 @@ import {
 export default class IosType extends BaseCommand {
   static summary = 'Type text into the focused iOS input field';
   static description =
-    'Type text into the currently focused input field on a running iOS instance. Use `--enter` to submit the field after typing.';
+    'Type text into the currently focused input field as real key events, so the app sees genuine keystrokes ' +
+    'and text delegates fire. Fails when no field is focused. For fast text entry without key events, use ' +
+    '`ios set-text`. Use `--enter` to submit the field after typing.';
   static examples = [
     '<%= config.bin %> ios type "Hello World"',
     '<%= config.bin %> ios type "Hello World" --id <instance-ID>',
@@ -30,15 +31,6 @@ export default class IosType extends BaseCommand {
       description: 'Press Enter after typing.',
       default: false,
     }),
-    hid: Flags.boolean({
-      description:
-        'Type real key events instead of setting the accessibility value, so the app receives genuine keystrokes and text delegates fire. Slower; fails when no field is focused.',
-      default: false,
-    }),
-    'require-focus': Flags.boolean({
-      description: 'Fail instead of typing blind when no input field is focused.',
-      default: false,
-    }),
   };
 
   async run(): Promise<void> {
@@ -52,27 +44,15 @@ export default class IosType extends BaseCommand {
         this.error('ios type only supports iOS instances');
       }
 
-      const options: Ios.TypeTextOptions = {
-        strategy: flags.hid ? 'hid' : undefined,
-        requireFocus: flags['require-focus'] || undefined,
-      };
-      let outcome: Ios.TypeTextResult | undefined;
       if (hasActiveSession(id)) {
-        outcome = (await sendSessionCommand(id, 'type', [
-          args.text,
-          flags.enter,
-          options,
-        ])) as Ios.TypeTextResult;
+        await sendSessionCommand(id, 'type', [args.text, flags.enter]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
         try {
-          outcome = await client.typeText(args.text, flags.enter, options);
+          await client.typeText(args.text, flags.enter);
         } finally {
           disconnect();
         }
-      }
-      if (outcome?.warning) {
-        this.warn(outcome.warning);
       }
       this.log('Text typed');
     });

--- a/packages/cli/src/commands/ios/type.ts
+++ b/packages/cli/src/commands/ios/type.ts
@@ -1,4 +1,5 @@
 import { Args, Flags } from '@oclif/core';
+import type { Ios } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
@@ -51,15 +52,17 @@ export default class IosType extends BaseCommand {
         this.error('ios type only supports iOS instances');
       }
 
-      const options = {
-        strategy: flags.hid ? ('hid' as const) : undefined,
+      const options: Ios.TypeTextOptions = {
+        strategy: flags.hid ? 'hid' : undefined,
         requireFocus: flags['require-focus'] || undefined,
       };
-      let outcome: { warning?: string } | undefined;
+      let outcome: Ios.TypeTextResult | undefined;
       if (hasActiveSession(id)) {
-        outcome = (await sendSessionCommand(id, 'type', [args.text, flags.enter, options])) as {
-          warning?: string;
-        };
+        outcome = (await sendSessionCommand(id, 'type', [
+          args.text,
+          flags.enter,
+          options,
+        ])) as Ios.TypeTextResult;
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
         try {

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -335,12 +335,22 @@ export function startDaemonServer(): void {
 
         case 'type':
           if (type === 'ios') {
-            result = { ...(await (client as any).typeText(args[0], args[1], args[2])), typed: true };
+            await (client as any).typeText(args[0], args[1]);
+            result = { typed: true };
           } else {
             const target = typeof args[0] === 'string' || args[0] === undefined ? undefined : args[0];
             const text = typeof args[0] === 'string' ? args[0] : args[1];
             await (client as any).setText(target, text);
             result = { typed: true };
+          }
+          break;
+
+        case 'set-text':
+          if (type === 'ios') {
+            result = await (client as any).setElementValue(args[0], args[1]);
+          } else {
+            const target = typeof args[1] === 'object' && args[1] !== null ? args[1] : undefined;
+            result = await (client as any).setText(target, args[0]);
           }
           break;
 

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -335,7 +335,7 @@ export function startDaemonServer(): void {
 
         case 'type':
           if (type === 'ios') {
-            result = { typed: true, ...(await (client as any).typeText(args[0], args[1], args[2])) };
+            result = { ...(await (client as any).typeText(args[0], args[1], args[2])), typed: true };
           } else {
             const target = typeof args[0] === 'string' || args[0] === undefined ? undefined : args[0];
             const text = typeof args[0] === 'string' ? args[0] : args[1];

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -327,7 +327,7 @@ export function startDaemonServer(): void {
 
         case 'tap-element':
           if (type === 'ios') {
-            result = await (client as any).tapElement(args[0]);
+            result = await (client as any).tapElement(args[0], args[1]);
           } else {
             result = await (client as any).tap({ selector: args[0] });
           }
@@ -335,13 +335,13 @@ export function startDaemonServer(): void {
 
         case 'type':
           if (type === 'ios') {
-            await (client as any).typeText(args[0], args[1]);
+            result = { typed: true, ...(await (client as any).typeText(args[0], args[1], args[2])) };
           } else {
             const target = typeof args[0] === 'string' || args[0] === undefined ? undefined : args[0];
             const text = typeof args[0] === 'string' ? args[0] : args[1];
             await (client as any).setText(target, text);
+            result = { typed: true };
           }
-          result = { typed: true };
           break;
 
         case 'press-key':

--- a/packages/cli/src/lib/parse-point.ts
+++ b/packages/cli/src/lib/parse-point.ts
@@ -1,0 +1,13 @@
+/**
+ * Parses an "x,y" point flag into non-negative coordinates. Empty components
+ * are rejected explicitly because Number('') is 0, which would silently turn
+ * "200," into [200, 0].
+ */
+export function parsePointFlag(value: string, flagName: string): [number, number] {
+  const parts = value.split(',').map((part) => part.trim());
+  const numbers = parts.map((part) => (part === '' ? NaN : Number(part)));
+  if (parts.length !== 2 || numbers.some((n) => !Number.isFinite(n) || n < 0)) {
+    throw new Error(`${flagName} must be "x,y" with non-negative numbers, e.g. ${flagName} 200,400`);
+  }
+  return [numbers[0], numbers[1]];
+}

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -1575,11 +1575,11 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       }
     };
 
-    // Wheel scrolling synthesizes a touch drag: finger down near the cursor
-    // on the first tick, moves opposite the wheel delta, and lifts after a
-    // quiet period. The press point is pulled into the middle band of the
-    // screen along the dominant scroll axis so the drag has travel room; when
-    // the finger runs out of room mid-scroll it lifts and re-presses there.
+    // Mouse wheel / trackpad scrolling over the stream scrolls inside the
+    // simulator. iOS has no scroll wheel, so we fake a finger: press down
+    // where the cursor is, drag it as wheel events come in, lift when they
+    // stop. If the fake finger reaches the screen edge before the user stops
+    // scrolling, lift and press again to keep going.
     const WHEEL_END_QUIET_MS = 150;
     const endWheelGesture = () => {
       const state = wheelStateRef.current;
@@ -1591,9 +1591,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     const handleWheel = (event: WheelEvent) => {
       // Trackpad pinches arrive as ctrl+wheel; don't turn them into scrolls.
       if (event.ctrlKey) return;
-      // Real pointers win: never interleave a synthesized finger with an
-      // active mouse/touch gesture or Alt two-finger mode (on iOS the held
-      // Alt key would turn the drag into a pinch).
+      // If the user is already touching/dragging (or holding Alt for the
+      // two-finger gesture), let that win - don't add a second fake finger.
       if (isAltHeldRef.current || twoFingerStateRef.current) return;
       const pointerCount = activePointers.current.size;
       if (pointerCount > 1 || (pointerCount === 1 && !activePointers.current.has(WHEEL_POINTER_ID))) return;
@@ -1630,14 +1629,14 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         s.endTimer = window.setTimeout(endWheelGesture, WHEEL_END_QUIET_MS);
       };
       if (dx === 0 && dy === 0) {
-        // Zero-delta ticks (momentum tails) must not trip the stuck-at-edge
-        // branch; just keep the gesture alive.
+        // Some wheel events carry no movement (momentum tails); just keep
+        // the gesture alive.
         if (wheelStateRef.current) armEnd(wheelStateRef.current);
         return;
       }
 
-      // Press point: the cursor, pulled into the 20-80% band along the
-      // dominant scroll axis so the drag has room to travel.
+      // Where to press the fake finger down: at the cursor, but nudged away
+      // from the screen edges so the drag has room to travel.
       const pressPoint = (): PointerGeometry => ({
         videoWidth: anchor.videoWidth,
         videoHeight: anchor.videoHeight,
@@ -1670,9 +1669,9 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       let pos = state.pos;
       let next = advance(pos);
       if (next.videoX === pos.videoX && next.videoY === pos.videoY) {
-        // Out of travel room: end this drag and continue from a fresh press
-        // point, applying this tick's delta from there so the new press moves
-        // immediately (a press that never moves would read as a tap).
+        // Finger reached the screen edge: lift it, press again with room to
+        // travel, and move right away (a press that never moves would count
+        // as a tap).
         applyPointerEvent(WHEEL_POINTER_ID, 'up', pos);
         pos = pressPoint();
         applyPointerEvent(WHEEL_POINTER_ID, 'down', pos);

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -1624,6 +1624,16 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         (ctx.videoHeight / ctx.actualHeight);
       const dx = -event.deltaX * scaleX;
       const dy = -event.deltaY * scaleY;
+      if (dx === 0 && dy === 0) {
+        // Zero-delta ticks (momentum tails) must not trip the stuck-at-edge
+        // branch; just keep the gesture alive.
+        const active = wheelStateRef.current;
+        if (active) {
+          window.clearTimeout(active.endTimer);
+          active.endTimer = window.setTimeout(endWheelGesture, WHEEL_END_QUIET_MS);
+        }
+        return;
+      }
 
       // Press point: the cursor, pulled into the 20-80% band along the
       // dominant scroll axis so the drag has room to travel.
@@ -1650,20 +1660,22 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         window.clearTimeout(state.endTimer);
       }
 
-      const nextX = Math.min(Math.max(state.pos.videoX + dx, 0), anchor.videoWidth);
-      const nextY = Math.min(Math.max(state.pos.videoY + dy, 0), anchor.videoHeight);
-      if (nextX === state.pos.videoX && nextY === state.pos.videoY) {
-        // Out of travel room: end this drag (it has moved, so it reads as a
-        // completed drag, not a tap) and continue from a fresh press point.
-        applyPointerEvent(WHEEL_POINTER_ID, 'up', state.pos);
-        const start = pressPoint();
-        applyPointerEvent(WHEEL_POINTER_ID, 'down', start);
-        state.pos = start;
-      } else {
-        const pos = { ...state.pos, videoX: nextX, videoY: nextY };
-        applyPointerEvent(WHEEL_POINTER_ID, 'move', pos);
-        state.pos = pos;
+      let pos = state.pos;
+      let nextX = Math.min(Math.max(pos.videoX + dx, 0), anchor.videoWidth);
+      let nextY = Math.min(Math.max(pos.videoY + dy, 0), anchor.videoHeight);
+      if (nextX === pos.videoX && nextY === pos.videoY) {
+        // Out of travel room: end this drag and continue from a fresh press
+        // point, applying this tick's delta from there so the new press moves
+        // immediately (a press that never moves would read as a tap).
+        applyPointerEvent(WHEEL_POINTER_ID, 'up', pos);
+        pos = pressPoint();
+        applyPointerEvent(WHEEL_POINTER_ID, 'down', pos);
+        nextX = Math.min(Math.max(pos.videoX + dx, 0), anchor.videoWidth);
+        nextY = Math.min(Math.max(pos.videoY + dy, 0), anchor.videoHeight);
       }
+      pos = { ...pos, videoX: nextX, videoY: nextY };
+      applyPointerEvent(WHEEL_POINTER_ID, 'move', pos);
+      state.pos = pos;
       state.endTimer = window.setTimeout(endWheelGesture, WHEEL_END_QUIET_MS);
     };
     useEffect(() => {

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -797,8 +797,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     };
 
     // Pointer ID used by inspect-driven taps. Distinct from human pointers
-    // (-1 mouse, -2 alt-mirror) and our touch identifiers so they never
-    // interfere with an in-progress drag.
+    // (-1 mouse, -2 alt-mirror), the synthesized wheel finger (-3), and our
+    // touch identifiers so they never interfere with an in-progress drag.
     const AX_TAP_POINTER_ID = -10;
 
     // Send a down+up tap at a viewport-space (clientX/Y) position. The point
@@ -862,6 +862,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // Fixed pointer IDs for Alt-simulated two-finger gestures
     const ALT_POINTER_ID_PRIMARY = -1;
     const ALT_POINTER_ID_MIRROR = -2;
+    // Synthesized finger for wheel-scroll drags.
     const WHEEL_POINTER_ID = -3;
 
     // Helper to send a single-touch control message (used by both single-finger and Android two-finger paths)
@@ -1594,8 +1595,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       // active mouse/touch gesture or Alt two-finger mode (on iOS the held
       // Alt key would turn the drag into a pinch).
       if (isAltHeldRef.current || twoFingerStateRef.current) return;
-      const othersActive = Array.from(activePointers.current.keys()).some((id) => id !== WHEEL_POINTER_ID);
-      if (othersActive) return;
+      const pointerCount = activePointers.current.size;
+      if (pointerCount > 1 || (pointerCount === 1 && !activePointers.current.has(WHEEL_POINTER_ID))) return;
 
       const ctx = computeVideoMappingContext();
       if (!ctx) return;
@@ -1624,14 +1625,14 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         (ctx.videoHeight / ctx.actualHeight);
       const dx = -event.deltaX * scaleX;
       const dy = -event.deltaY * scaleY;
+      const armEnd = (s: { endTimer: number }) => {
+        window.clearTimeout(s.endTimer);
+        s.endTimer = window.setTimeout(endWheelGesture, WHEEL_END_QUIET_MS);
+      };
       if (dx === 0 && dy === 0) {
         // Zero-delta ticks (momentum tails) must not trip the stuck-at-edge
         // branch; just keep the gesture alive.
-        const active = wheelStateRef.current;
-        if (active) {
-          window.clearTimeout(active.endTimer);
-          active.endTimer = window.setTimeout(endWheelGesture, WHEEL_END_QUIET_MS);
-        }
+        if (wheelStateRef.current) armEnd(wheelStateRef.current);
         return;
       }
 
@@ -1650,6 +1651,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           : anchor.videoY,
       });
 
+      const advance = (p: PointerGeometry): PointerGeometry => ({
+        ...p,
+        videoX: Math.min(Math.max(p.videoX + dx, 0), p.videoWidth),
+        videoY: Math.min(Math.max(p.videoY + dy, 0), p.videoHeight),
+      });
+
       let state = wheelStateRef.current;
       if (!state) {
         const start = pressPoint();
@@ -1661,22 +1668,19 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       }
 
       let pos = state.pos;
-      let nextX = Math.min(Math.max(pos.videoX + dx, 0), anchor.videoWidth);
-      let nextY = Math.min(Math.max(pos.videoY + dy, 0), anchor.videoHeight);
-      if (nextX === pos.videoX && nextY === pos.videoY) {
+      let next = advance(pos);
+      if (next.videoX === pos.videoX && next.videoY === pos.videoY) {
         // Out of travel room: end this drag and continue from a fresh press
         // point, applying this tick's delta from there so the new press moves
         // immediately (a press that never moves would read as a tap).
         applyPointerEvent(WHEEL_POINTER_ID, 'up', pos);
         pos = pressPoint();
         applyPointerEvent(WHEEL_POINTER_ID, 'down', pos);
-        nextX = Math.min(Math.max(pos.videoX + dx, 0), anchor.videoWidth);
-        nextY = Math.min(Math.max(pos.videoY + dy, 0), anchor.videoHeight);
+        next = advance(pos);
       }
-      pos = { ...pos, videoX: nextX, videoY: nextY };
-      applyPointerEvent(WHEEL_POINTER_ID, 'move', pos);
-      state.pos = pos;
-      state.endTimer = window.setTimeout(endWheelGesture, WHEEL_END_QUIET_MS);
+      applyPointerEvent(WHEEL_POINTER_ID, 'move', next);
+      state.pos = next;
+      armEnd(state);
     };
     useEffect(() => {
       wheelCallbacksRef.current = { handle: handleWheel, end: endWheelGesture };

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -688,6 +688,14 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       pointerId1: number;
     };
     const twoFingerStateRef = useRef<TwoFingerState | null>(null);
+    // Wheel-scroll drag state; lives for a single synthesized gesture.
+    const wheelStateRef = useRef<{ pos: PointerGeometry; endTimer: number } | null>(null);
+    // Latest wheel handlers, so the once-attached native listener and the
+    // pointer machinery always call the current render's closures.
+    const wheelCallbacksRef = useRef<{ handle: (event: WheelEvent) => void; end: () => void }>({
+      handle: () => {},
+      end: () => {},
+    });
 
     // Hover point for rendering two-finger indicators when Alt is held.
     // Only computed/set when Alt is held to avoid unnecessary re-renders.
@@ -854,6 +862,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // Fixed pointer IDs for Alt-simulated two-finger gestures
     const ALT_POINTER_ID_PRIMARY = -1;
     const ALT_POINTER_ID_MIRROR = -2;
+    const WHEEL_POINTER_ID = -3;
 
     // Helper to send a single-touch control message (used by both single-finger and Android two-finger paths)
     const sendSingleTouch = (
@@ -911,6 +920,11 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
 
       switch (eventType) {
         case 'down':
+          // A real pointer going down takes over from any synthesized
+          // wheel-scroll finger, so the tap isn't sent as a second finger.
+          if (pointerId !== WHEEL_POINTER_ID) {
+            wheelCallbacksRef.current.end();
+          }
           // For multi-touch: use ACTION_DOWN for first pointer, ACTION_POINTER_DOWN for additional pointers
           const currentPointerCount = activePointers.current.size;
           action = currentPointerCount === 0 ? AMOTION_EVENT.ACTION_DOWN : AMOTION_EVENT.ACTION_POINTER_DOWN;
@@ -1198,6 +1212,12 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         p0: { x: x0, y: y0, id: pointerId0 },
         p1: { x: x1, y: y1, id: pointerId1 },
       });
+
+      if (eventType === 'down') {
+        // A real two-finger gesture takes over from any synthesized
+        // wheel-scroll finger.
+        wheelCallbacksRef.current.end();
+      }
 
       if (platform === 'ios') {
         // iOS: use special two-finger message (type=18)
@@ -1553,6 +1573,116 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         return;
       }
     };
+
+    // Wheel scrolling synthesizes a touch drag: finger down near the cursor
+    // on the first tick, moves opposite the wheel delta, and lifts after a
+    // quiet period. The press point is pulled into the middle band of the
+    // screen along the dominant scroll axis so the drag has travel room; when
+    // the finger runs out of room mid-scroll it lifts and re-presses there.
+    const WHEEL_END_QUIET_MS = 150;
+    const endWheelGesture = () => {
+      const state = wheelStateRef.current;
+      if (!state) return;
+      window.clearTimeout(state.endTimer);
+      applyPointerEvent(WHEEL_POINTER_ID, 'up', state.pos);
+      wheelStateRef.current = null;
+    };
+    const handleWheel = (event: WheelEvent) => {
+      // Trackpad pinches arrive as ctrl+wheel; don't turn them into scrolls.
+      if (event.ctrlKey) return;
+      // Real pointers win: never interleave a synthesized finger with an
+      // active mouse/touch gesture or Alt two-finger mode (on iOS the held
+      // Alt key would turn the drag into a pinch).
+      if (isAltHeldRef.current || twoFingerStateRef.current) return;
+      const othersActive = Array.from(activePointers.current.keys()).some((id) => id !== WHEEL_POINTER_ID);
+      if (othersActive) return;
+
+      const ctx = computeVideoMappingContext();
+      if (!ctx) return;
+      // Outside the rendered video (frame, letterbox) let the page scroll.
+      const relativeX = event.clientX - ctx.videoRect.left - ctx.offsetX;
+      const relativeY = event.clientY - ctx.videoRect.top - ctx.offsetY;
+      if (relativeX < 0 || relativeX > ctx.actualWidth || relativeY < 0 || relativeY > ctx.actualHeight) {
+        return;
+      }
+      const anchor = mapClientPointToVideo(ctx, event.clientX, event.clientY);
+      if (!anchor) return;
+      event.preventDefault();
+
+      // deltaMode: 0=pixels, 1=lines, 2=pages. Deltas are CSS pixels; convert
+      // to stream pixels so a tick scrolls the same visual distance at any
+      // window size.
+      const scaleX =
+        (event.deltaMode === 1 ? 16
+        : event.deltaMode === 2 ? ctx.actualWidth
+        : 1) *
+        (ctx.videoWidth / ctx.actualWidth);
+      const scaleY =
+        (event.deltaMode === 1 ? 16
+        : event.deltaMode === 2 ? ctx.actualHeight
+        : 1) *
+        (ctx.videoHeight / ctx.actualHeight);
+      const dx = -event.deltaX * scaleX;
+      const dy = -event.deltaY * scaleY;
+
+      // Press point: the cursor, pulled into the 20-80% band along the
+      // dominant scroll axis so the drag has room to travel.
+      const pressPoint = (): PointerGeometry => ({
+        videoWidth: anchor.videoWidth,
+        videoHeight: anchor.videoHeight,
+        videoX:
+          Math.abs(dx) > Math.abs(dy) ?
+            Math.min(Math.max(anchor.videoX, anchor.videoWidth * 0.2), anchor.videoWidth * 0.8)
+          : anchor.videoX,
+        videoY:
+          Math.abs(dy) >= Math.abs(dx) ?
+            Math.min(Math.max(anchor.videoY, anchor.videoHeight * 0.2), anchor.videoHeight * 0.8)
+          : anchor.videoY,
+      });
+
+      let state = wheelStateRef.current;
+      if (!state) {
+        const start = pressPoint();
+        applyPointerEvent(WHEEL_POINTER_ID, 'down', start);
+        state = { pos: start, endTimer: 0 };
+        wheelStateRef.current = state;
+      } else {
+        window.clearTimeout(state.endTimer);
+      }
+
+      const nextX = Math.min(Math.max(state.pos.videoX + dx, 0), anchor.videoWidth);
+      const nextY = Math.min(Math.max(state.pos.videoY + dy, 0), anchor.videoHeight);
+      if (nextX === state.pos.videoX && nextY === state.pos.videoY) {
+        // Out of travel room: end this drag (it has moved, so it reads as a
+        // completed drag, not a tap) and continue from a fresh press point.
+        applyPointerEvent(WHEEL_POINTER_ID, 'up', state.pos);
+        const start = pressPoint();
+        applyPointerEvent(WHEEL_POINTER_ID, 'down', start);
+        state.pos = start;
+      } else {
+        const pos = { ...state.pos, videoX: nextX, videoY: nextY };
+        applyPointerEvent(WHEEL_POINTER_ID, 'move', pos);
+        state.pos = pos;
+      }
+      state.endTimer = window.setTimeout(endWheelGesture, WHEEL_END_QUIET_MS);
+    };
+    useEffect(() => {
+      wheelCallbacksRef.current = { handle: handleWheel, end: endWheelGesture };
+    });
+
+    // React attaches onWheel passively, so preventDefault (needed to keep the
+    // page from scrolling) requires a native non-passive listener. Cleanup
+    // lifts an in-flight synthesized finger before the channel goes away.
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      const listener = (event: WheelEvent) => wheelCallbacksRef.current.handle(event);
+      container.addEventListener('wheel', listener, { passive: false });
+      return () => {
+        wheelCallbacksRef.current.end();
+        container.removeEventListener('wheel', listener);
+      };
+    }, []);
 
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -2075,7 +2075,14 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       selector: AccessibilitySelector,
       options?: TapElementOptions,
     ): Promise<TapElementResult> => {
-      return sendRequest<TapElementResult>('tapElement', { selector, activate: options?.activate });
+      // Off-screen elements are found by scrolling and re-scanning server-side,
+      // which can take well over the default 30s on busy screens.
+      return sendRequest<TapElementResult>(
+        'tapElement',
+        { selector, activate: options?.activate },
+        undefined,
+        90_000,
+      );
     };
 
     const incrementElement = (selector: AccessibilitySelector): Promise<ElementResult> => {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -170,6 +170,40 @@ export type ScreenshotData = {
 export type TapElementResult = {
   elementLabel?: string;
   elementType?: string;
+  /** How the element was activated: 'touch' (real HID tap) or 'ax' (AXPress). */
+  method?: TapElementActivation;
+};
+
+/**
+ * How tapElement activates the matched element. 'touch' (the server default)
+ * scrolls the element into view when needed and synthesizes a real HID tap;
+ * 'ax' performs an accessibility press without real touch events.
+ */
+export type TapElementActivation = 'touch' | 'ax';
+
+export type TapElementOptions = {
+  activate?: TapElementActivation;
+};
+
+/**
+ * How typeText injects text. 'auto' (the server default) sets the
+ * accessibility value and falls back to HID key events; 'hid' always types
+ * real key events so UIKit text delegates fire; 'ax' only sets the
+ * accessibility value.
+ */
+export type TypeTextStrategy = 'auto' | 'ax' | 'hid';
+
+export type TypeTextOptions = {
+  strategy?: TypeTextStrategy;
+  /** Fail instead of blind-firing HID key events when nothing is focused (auto strategy only). */
+  requireFocus?: boolean;
+};
+
+export type TypeTextResult = {
+  /** Set when the text was typed but likely didn't land (e.g. no focused field). */
+  warning?: string;
+  /** The strategy that actually ran. */
+  usedStrategy?: 'ax' | 'hid';
 };
 
 export type ElementResult = {
@@ -399,6 +433,9 @@ export type AppInstallationOptions = {
  */
 export type PerformAction =
   | { type: 'tap'; x: number; y: number; screenWidth?: number; screenHeight?: number }
+  // tapElement/typeText deliberately carry no activate/strategy options in
+  // batches: the server's batch decoder does not read them (use the
+  // single-shot methods for strategy control).
   | { type: 'tapElement'; selector: AccessibilitySelector }
   | { type: 'incrementElement'; selector: AccessibilitySelector }
   | { type: 'decrementElement'; selector: AccessibilitySelector }
@@ -508,9 +545,12 @@ export type InstanceClient = {
   /**
    * Tap an accessibility element by selector
    * @param selector The selector criteria to find the element
-   * @returns Information about the tapped element
+   * @param options Optional activation control; the server default is a real
+   *   HID tap that scrolls the element into view first, `{ activate: 'ax' }`
+   *   forces an accessibility press
+   * @returns Information about the tapped element, including which method ran
    */
-  tapElement: (selector: AccessibilitySelector) => Promise<TapElementResult>;
+  tapElement: (selector: AccessibilitySelector, options?: TapElementOptions) => Promise<TapElementResult>;
 
   /**
    * Increment an accessibility element (useful for sliders, steppers, etc.)
@@ -539,8 +579,13 @@ export type InstanceClient = {
    * Type text into the currently focused input field
    * @param text The text to type
    * @param pressEnter If true, press Enter after typing
+   * @param options Optional typing strategy. `{ strategy: 'hid' }` types real
+   *   key events so UIKit text delegates fire; `{ requireFocus: true }` fails
+   *   instead of typing blind when nothing is focused
+   * @returns Warning and the strategy that ran; check `warning` to detect
+   *   text that likely didn't land
    */
-  typeText: (text: string, pressEnter?: boolean) => Promise<void>;
+  typeText: (text: string, pressEnter?: boolean, options?: TypeTextOptions) => Promise<TypeTextResult>;
 
   /**
    * Press a key on the keyboard, optionally with modifiers
@@ -1115,6 +1160,11 @@ type ServerResponse = {
   duration?: number;
   once?: boolean;
   status?: IosMicrophoneStatus;
+  // typeText result fields
+  warning?: string;
+  usedStrategy?: 'ax' | 'hid';
+  // tapElement result fields
+  method?: TapElementActivation;
 };
 
 /**
@@ -1724,11 +1774,12 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       tapElementResult: (msg) => ({
         elementLabel: msg.elementLabel,
         elementType: msg.elementType,
+        method: msg.method,
       }),
       incrementElementResult: (msg) => ({ elementLabel: msg.elementLabel }),
       decrementElementResult: (msg) => ({ elementLabel: msg.elementLabel }),
       setElementValueResult: (msg) => ({ elementLabel: msg.elementLabel }),
-      typeTextResult: () => undefined,
+      typeTextResult: (msg) => ({ warning: msg.warning, usedStrategy: msg.usedStrategy }),
       pressKeyResult: () => undefined,
       toggleKeyboardResult: () => undefined,
       launchAppResult: () => undefined,
@@ -2020,8 +2071,11 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       return sendRequest<void>('tap', { x, y, screenWidth, screenHeight });
     };
 
-    const tapElement = (selector: AccessibilitySelector): Promise<TapElementResult> => {
-      return sendRequest<TapElementResult>('tapElement', { selector });
+    const tapElement = (
+      selector: AccessibilitySelector,
+      options?: TapElementOptions,
+    ): Promise<TapElementResult> => {
+      return sendRequest<TapElementResult>('tapElement', { selector, activate: options?.activate });
     };
 
     const incrementElement = (selector: AccessibilitySelector): Promise<ElementResult> => {
@@ -2036,8 +2090,17 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       return sendRequest<ElementResult>('setElementValue', { text, selector });
     };
 
-    const typeText = (text: string, pressEnter?: boolean): Promise<void> => {
-      return sendRequest<void>('typeText', { text, pressEnter });
+    const typeText = (
+      text: string,
+      pressEnter?: boolean,
+      options?: TypeTextOptions,
+    ): Promise<TypeTextResult> => {
+      return sendRequest<TypeTextResult>('typeText', {
+        text,
+        pressEnter,
+        strategy: options?.strategy,
+        requireFocus: options?.requireFocus,
+      });
     };
 
     const pressKey = (key: string, modifiers?: string[]): Promise<void> => {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -2077,10 +2077,13 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
     const setElementValue = (text: string, selector?: AccessibilitySelector): Promise<ElementResult> => {
       // Selector omitted: the server resolves the currently focused element.
+      // Normalize null to undefined so IPC-deserialized calls (JSON turns
+      // undefined into null) omit the key instead of sending selector: null.
+      const target = selector ?? undefined;
       return sendRequest<ElementResult>('setElementValue', {
         text,
-        selector,
-        focused: selector ? undefined : true,
+        selector: target,
+        focused: target ? undefined : true,
       });
     };
 

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -186,9 +186,9 @@ export type TapElementActivation = 'touch' | 'ax';
 export type TapElementOptions = {
   activate?: TapElementActivation;
   /**
-   * Request timeout in milliseconds. Defaults to 90 seconds: off-screen
-   * elements are found by scrolling and re-scanning server-side, which can
-   * take well over the usual 30s on busy screens.
+   * Request timeout in milliseconds, default 90 seconds. The server scrolls
+   * to find off-screen elements, and that can take well over 30s on busy
+   * screens.
    */
   timeoutMs?: number;
 };
@@ -554,21 +554,21 @@ export type InstanceClient = {
   decrementElement: (selector: AccessibilitySelector) => Promise<ElementResult>;
 
   /**
-   * Set the value of an accessibility element (useful for text fields, etc.)
-   * This is much faster than typing character by character, but does not
-   * fire key-event-driven text delegates; use typeText for real typing.
+   * Set an element's value directly, without key events. Much faster than
+   * typing, but the app's key-event text delegates do not fire; use typeText
+   * for real typing.
    * @param text The text value to set
-   * @param selector The selector criteria to find the element; omit it to
-   *   target the currently focused element (the server resolves focus)
+   * @param selector The selector to find the element. Omit it to target the
+   *   focused element; the server resolves focus.
    * @returns Information about the modified element
    */
   setElementValue: (text: string, selector?: AccessibilitySelector) => Promise<ElementResult>;
 
   /**
-   * Type text into the currently focused input field as real HID key events,
-   * so text delegates fire like they would for a human. Fails when no field
-   * is focused. Slower than setElementValue (~20ms per character); prefer
-   * setElementValue for long strings that don't need key events.
+   * Type text into the focused field as real key events, so the app's text
+   * delegates fire. Fails when no field is focused. Typing costs ~20ms per
+   * character; use setElementValue for long strings that do not need key
+   * events.
    * @param text The text to type
    * @param pressEnter If true, press Enter after typing
    */
@@ -2076,9 +2076,9 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
     };
 
     const setElementValue = (text: string, selector?: AccessibilitySelector): Promise<ElementResult> => {
-      // Selector omitted: the server resolves the currently focused element.
-      // Normalize null to undefined so IPC-deserialized calls (JSON turns
-      // undefined into null) omit the key instead of sending selector: null.
+      // No selector targets the focused element; the server resolves it.
+      // JSON IPC turns undefined into null, so normalize back: the payload
+      // must omit the selector key, not send null.
       const target = selector ?? undefined;
       return sendRequest<ElementResult>('setElementValue', {
         text,

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -193,27 +193,6 @@ export type TapElementOptions = {
   timeoutMs?: number;
 };
 
-/**
- * How typeText injects text. 'auto' (the server default) sets the
- * accessibility value and falls back to HID key events; 'hid' always types
- * real key events so UIKit text delegates fire; 'ax' only sets the
- * accessibility value.
- */
-export type TypeTextStrategy = 'auto' | 'ax' | 'hid';
-
-export type TypeTextOptions = {
-  strategy?: TypeTextStrategy;
-  /** Fail instead of blind-firing HID key events when nothing is focused (auto strategy only). */
-  requireFocus?: boolean;
-};
-
-export type TypeTextResult = {
-  /** Set when the text was typed but likely didn't land (e.g. no focused field). */
-  warning?: string;
-  /** The strategy that actually ran. */
-  usedStrategy?: Exclude<TypeTextStrategy, 'auto'>;
-};
-
 export type ElementResult = {
   elementLabel?: string;
 };
@@ -576,24 +555,24 @@ export type InstanceClient = {
 
   /**
    * Set the value of an accessibility element (useful for text fields, etc.)
-   * This is much faster than typing character by character.
+   * This is much faster than typing character by character, but does not
+   * fire key-event-driven text delegates; use typeText for real typing.
    * @param text The text value to set
-   * @param selector The selector criteria to find the element
+   * @param selector The selector criteria to find the element; omit it to
+   *   target the currently focused element (the server resolves focus)
    * @returns Information about the modified element
    */
-  setElementValue: (text: string, selector: AccessibilitySelector) => Promise<ElementResult>;
+  setElementValue: (text: string, selector?: AccessibilitySelector) => Promise<ElementResult>;
 
   /**
-   * Type text into the currently focused input field
+   * Type text into the currently focused input field as real HID key events,
+   * so text delegates fire like they would for a human. Fails when no field
+   * is focused. Slower than setElementValue (~20ms per character); prefer
+   * setElementValue for long strings that don't need key events.
    * @param text The text to type
    * @param pressEnter If true, press Enter after typing
-   * @param options Optional typing strategy. `{ strategy: 'hid' }` types real
-   *   key events so UIKit text delegates fire; `{ requireFocus: true }` fails
-   *   instead of typing blind when nothing is focused
-   * @returns Warning and the strategy that ran; check `warning` to detect
-   *   text that likely didn't land
    */
-  typeText: (text: string, pressEnter?: boolean, options?: TypeTextOptions) => Promise<TypeTextResult>;
+  typeText: (text: string, pressEnter?: boolean) => Promise<void>;
 
   /**
    * Press a key on the keyboard, optionally with modifiers
@@ -1168,9 +1147,6 @@ type ServerResponse = {
   duration?: number;
   once?: boolean;
   status?: IosMicrophoneStatus;
-  // typeText result fields
-  warning?: string;
-  usedStrategy?: Exclude<TypeTextStrategy, 'auto'>;
   // tapElement result fields
   method?: TapElementActivation;
 };
@@ -1787,7 +1763,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       incrementElementResult: (msg) => ({ elementLabel: msg.elementLabel }),
       decrementElementResult: (msg) => ({ elementLabel: msg.elementLabel }),
       setElementValueResult: (msg) => ({ elementLabel: msg.elementLabel }),
-      typeTextResult: (msg) => ({ warning: msg.warning, usedStrategy: msg.usedStrategy }),
+      typeTextResult: () => undefined,
       pressKeyResult: () => undefined,
       toggleKeyboardResult: () => undefined,
       launchAppResult: () => undefined,
@@ -2099,21 +2075,17 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       return sendRequest<ElementResult>('decrementElement', { selector });
     };
 
-    const setElementValue = (text: string, selector: AccessibilitySelector): Promise<ElementResult> => {
-      return sendRequest<ElementResult>('setElementValue', { text, selector });
+    const setElementValue = (text: string, selector?: AccessibilitySelector): Promise<ElementResult> => {
+      // Selector omitted: the server resolves the currently focused element.
+      return sendRequest<ElementResult>('setElementValue', {
+        text,
+        selector,
+        focused: selector ? undefined : true,
+      });
     };
 
-    const typeText = (
-      text: string,
-      pressEnter?: boolean,
-      options?: TypeTextOptions,
-    ): Promise<TypeTextResult> => {
-      return sendRequest<TypeTextResult>('typeText', {
-        text,
-        pressEnter,
-        strategy: options?.strategy,
-        requireFocus: options?.requireFocus,
-      });
+    const typeText = (text: string, pressEnter?: boolean): Promise<void> => {
+      return sendRequest<void>('typeText', { text, pressEnter });
     };
 
     const pressKey = (key: string, modifiers?: string[]): Promise<void> => {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -30,6 +30,8 @@ export type ConnectionStateCallback = (state: ConnectionState) => void;
 const ACTIVE_RECORDING_FILENAME = 'recording.mp4';
 export const REVERSE_TUNNEL_REMOTE_PORT_MIN = 57090;
 export const REVERSE_TUNNEL_REMOTE_PORT_MAX = 57099;
+/** Default tapElement timeout; see TapElementOptions.timeoutMs. */
+export const TAP_ELEMENT_TIMEOUT_MS = 90_000;
 
 function buildDownloadUrl(apiUrl: string): string {
   return `${apiUrl}/files?name=${encodeURIComponent(ACTIVE_RECORDING_FILENAME)}`;
@@ -170,7 +172,7 @@ export type ScreenshotData = {
 export type TapElementResult = {
   elementLabel?: string;
   elementType?: string;
-  /** How the element was activated: 'touch' (real HID tap) or 'ax' (AXPress). */
+  /** The activation that ran. */
   method?: TapElementActivation;
 };
 
@@ -183,6 +185,12 @@ export type TapElementActivation = 'touch' | 'ax';
 
 export type TapElementOptions = {
   activate?: TapElementActivation;
+  /**
+   * Request timeout in milliseconds. Defaults to 90 seconds: off-screen
+   * elements are found by scrolling and re-scanning server-side, which can
+   * take well over the usual 30s on busy screens.
+   */
+  timeoutMs?: number;
 };
 
 /**
@@ -203,7 +211,7 @@ export type TypeTextResult = {
   /** Set when the text was typed but likely didn't land (e.g. no focused field). */
   warning?: string;
   /** The strategy that actually ran. */
-  usedStrategy?: 'ax' | 'hid';
+  usedStrategy?: Exclude<TypeTextStrategy, 'auto'>;
 };
 
 export type ElementResult = {
@@ -1162,7 +1170,7 @@ type ServerResponse = {
   status?: IosMicrophoneStatus;
   // typeText result fields
   warning?: string;
-  usedStrategy?: 'ax' | 'hid';
+  usedStrategy?: Exclude<TypeTextStrategy, 'auto'>;
   // tapElement result fields
   method?: TapElementActivation;
 };
@@ -2075,13 +2083,11 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       selector: AccessibilitySelector,
       options?: TapElementOptions,
     ): Promise<TapElementResult> => {
-      // Off-screen elements are found by scrolling and re-scanning server-side,
-      // which can take well over the default 30s on busy screens.
       return sendRequest<TapElementResult>(
         'tapElement',
         { selector, activate: options?.activate },
         undefined,
-        90_000,
+        options?.timeoutMs ?? TAP_ELEMENT_TIMEOUT_MS,
       );
     };
 

--- a/tests/ios-input.test.ts
+++ b/tests/ios-input.test.ts
@@ -18,7 +18,20 @@ jest.mock('ws', () => {
       const message = JSON.parse(data);
       sentMessages.push(message);
 
-      if (message.type === 'deviceInfo') {
+      if (message.type === 'setElementValue') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'setElementValueResult',
+                id: message.id,
+                elementLabel: 'Field',
+              }),
+            ),
+          );
+        });
+      } else if (message.type === 'deviceInfo') {
         process.nextTick(() => {
           this['emit'](
             'message',
@@ -36,19 +49,7 @@ jest.mock('ws', () => {
         });
       } else if (message.type === 'typeText') {
         process.nextTick(() => {
-          this['emit'](
-            'message',
-            Buffer.from(
-              JSON.stringify({
-                type: 'typeTextResult',
-                id: message.id,
-                // Echo warning fields only for the hid-warning fixture text
-                ...(message.text === 'unfocused' ?
-                  { warning: 'no focused accessibility element', usedStrategy: 'hid' }
-                : { usedStrategy: 'ax' }),
-              }),
-            ),
-          );
+          this['emit']('message', Buffer.from(JSON.stringify({ type: 'typeTextResult', id: message.id })));
         });
       } else if (message.type === 'tapElement') {
         process.nextTick(() => {
@@ -99,7 +100,7 @@ describe('iOS input serialization', () => {
     sentMessages.length = 0;
   });
 
-  it('omits strategy and requireFocus from legacy typeText calls so old servers see the old payload', async () => {
+  it('serializes typeText with its original payload shape', async () => {
     const client = await connect();
     await client.typeText('hello', true);
 
@@ -111,15 +112,19 @@ describe('iOS input serialization', () => {
     client.disconnect();
   });
 
-  it('serializes typing strategy options and surfaces the warning result', async () => {
+  it('targets the focused element when setElementValue is called without a selector', async () => {
     const client = await connect();
-    const result = await client.typeText('unfocused', false, { strategy: 'hid', requireFocus: true });
 
-    expect(sentMessages.find((message) => message['type'] === 'typeText')).toMatchObject({
-      strategy: 'hid',
-      requireFocus: true,
-    });
-    expect(result).toEqual({ warning: 'no focused accessibility element', usedStrategy: 'hid' });
+    await client.setElementValue('fast text');
+    const focusedSent = sentMessages.find((message) => message['type'] === 'setElementValue');
+    expect(focusedSent).toMatchObject({ focused: true });
+    expect(focusedSent).not.toHaveProperty('selector');
+
+    sentMessages.length = 0;
+    await client.setElementValue('fast text', { AXUniqueId: 'field' });
+    const selectorSent = sentMessages.find((message) => message['type'] === 'setElementValue');
+    expect(selectorSent).toMatchObject({ selector: { AXUniqueId: 'field' } });
+    expect(selectorSent).not.toHaveProperty('focused');
 
     client.disconnect();
   });

--- a/tests/ios-input.test.ts
+++ b/tests/ios-input.test.ts
@@ -1,0 +1,156 @@
+const sentMessages: Record<string, unknown>[] = [];
+
+jest.mock('ws', () => {
+  const { EventEmitter } = require('events');
+
+  class MockWebSocket extends EventEmitter {
+    static CONNECTING = 0;
+    static OPEN = 1;
+
+    readyState = MockWebSocket.OPEN;
+
+    constructor() {
+      super();
+      process.nextTick(() => this['emit']('open'));
+    }
+
+    send(data: string, callback?: (err?: Error) => void): void {
+      const message = JSON.parse(data);
+      sentMessages.push(message);
+
+      if (message.type === 'deviceInfo') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'deviceInfoResult',
+                id: message.id,
+                udid: 'test-udid',
+                screenWidth: 390,
+                screenHeight: 844,
+                model: 'iphone',
+              }),
+            ),
+          );
+        });
+      } else if (message.type === 'typeText') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'typeTextResult',
+                id: message.id,
+                // Echo warning fields only for the hid-warning fixture text
+                ...(message.text === 'unfocused' ?
+                  { warning: 'no focused accessibility element', usedStrategy: 'hid' }
+                : { usedStrategy: 'ax' }),
+              }),
+            ),
+          );
+        });
+      } else if (message.type === 'tapElement') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'tapElementResult',
+                id: message.id,
+                elementLabel: 'Submit',
+                elementType: 'Button',
+                method: message.activate ?? 'touch',
+              }),
+            ),
+          );
+        });
+      } else if (message.type === 'scroll') {
+        process.nextTick(() => {
+          this['emit']('message', Buffer.from(JSON.stringify({ type: 'scrollResult', id: message.id })));
+        });
+      }
+
+      callback?.();
+    }
+
+    ping(): void {}
+
+    close(): void {
+      this.readyState = 3;
+      this['emit']('close');
+    }
+  }
+
+  return { WebSocket: MockWebSocket };
+});
+
+async function connect() {
+  const { createInstanceClient } = await import('../src/ios-client');
+  return createInstanceClient({
+    apiUrl: 'https://example.test/v1/ios_123/api',
+    token: 'token',
+    logLevel: 'none',
+  });
+}
+
+describe('iOS input serialization', () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+  });
+
+  it('omits strategy and requireFocus from legacy typeText calls so old servers see the old payload', async () => {
+    const client = await connect();
+    await client.typeText('hello', true);
+
+    const sent = sentMessages.find((message) => message['type'] === 'typeText');
+    expect(sent).toMatchObject({ type: 'typeText', text: 'hello', pressEnter: true });
+    expect(sent).not.toHaveProperty('strategy');
+    expect(sent).not.toHaveProperty('requireFocus');
+
+    client.disconnect();
+  });
+
+  it('serializes typing strategy options and surfaces the warning result', async () => {
+    const client = await connect();
+    const result = await client.typeText('unfocused', false, { strategy: 'hid', requireFocus: true });
+
+    expect(sentMessages.find((message) => message['type'] === 'typeText')).toMatchObject({
+      strategy: 'hid',
+      requireFocus: true,
+    });
+    expect(result).toEqual({ warning: 'no focused accessibility element', usedStrategy: 'hid' });
+
+    client.disconnect();
+  });
+
+  it('serializes tapElement activation and surfaces the method result', async () => {
+    const client = await connect();
+
+    const legacy = await client.tapElement({ AXLabel: 'Submit' });
+    const legacySent = sentMessages.find((message) => message['type'] === 'tapElement');
+    expect(legacySent).not.toHaveProperty('activate');
+    expect(legacy.method).toBe('touch');
+
+    const ax = await client.tapElement({ AXLabel: 'Submit' }, { activate: 'ax' });
+    expect(sentMessages.filter((message) => message['type'] === 'tapElement')[1]).toMatchObject({
+      activate: 'ax',
+    });
+    expect(ax.method).toBe('ax');
+
+    client.disconnect();
+  });
+
+  it('serializes scroll coordinates', async () => {
+    const client = await connect();
+    await client.scroll('down', 300, { coordinate: [120, 500] });
+
+    expect(sentMessages.find((message) => message['type'] === 'scroll')).toMatchObject({
+      direction: 'down',
+      pixels: 300,
+      coordinate: [120, 500],
+    });
+
+    client.disconnect();
+  });
+});

--- a/tests/ios-input.test.ts
+++ b/tests/ios-input.test.ts
@@ -132,8 +132,9 @@ describe('iOS input serialization', () => {
     expect(legacySent).not.toHaveProperty('activate');
     expect(legacy.method).toBe('touch');
 
+    sentMessages.length = 0;
     const ax = await client.tapElement({ AXLabel: 'Submit' }, { activate: 'ax' });
-    expect(sentMessages.filter((message) => message['type'] === 'tapElement')[1]).toMatchObject({
+    expect(sentMessages.find((message) => message['type'] === 'tapElement')).toMatchObject({
       activate: 'ax',
     });
     expect(ax.method).toBe('ax');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core iOS input/gesture paths and remote pointer handling, so regressions could break automation or interactive control, but changes are additive and backward-compatible.
> 
> **Overview**
> Expands iOS input control with clearer typing strategies, richer gestures, and browser wheel scrolling over the remote stream.
> 
> **Text input:** Adds `ios set-text` for instant accessibility value setting (by selector or `--focused`), and clarifies that `ios type` sends real key events so text delegates fire. The client’s `setElementValue` now accepts an optional selector and targets the focused field when omitted.
> 
> **Gestures:** Adds `ios swipe --from/--to` (with duration and failed-batch finger cleanup), and lets `ios scroll` start from an explicit `--coordinate`. `tap-element` gains `--activate touch|ax` plus a longer timeout for scroll-to-find.
> 
> **Remote UI:** Mouse wheel / trackpad over the stream synthesizes a drag finger so users can scroll inside the simulator without page scrolling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29d9e7cfac7cc6274b48b5c0510f78cca6d54c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->