### PR TITLE
examples/device-install: restructure into a QR-first staged flow

### DIFF
--- a/examples/device-install/README.md
+++ b/examples/device-install/README.md
@@ -1,23 +1,33 @@
 # Device Install
 
-An end-to-end physical iPhone installation example with two methods:
+An end-to-end physical iPhone installation example, optimized for QR-based
+over-the-air installation: one ad-hoc-signed build, then a QR code pointing
+at Limrun's short-lived private install page where the iPhone taps Install.
 
-- **WebUSB** registers and pairs the selected iPhone, creates development
-  signing, builds a private IPA, and starts installation automatically.
-- **QR / private OTA** registers the selected iPhone without requiring a pair
-  record, creates ad-hoc signing, builds a private IPA, and renders a QR code
-  for Limrun's short-lived private install page.
+## Flow
+
+1. **Ad-hoc signing** — on load the example checks the secret store for a
+   distribution certificate and an ad-hoc provisioning profile matching the
+   stored team and bundle ID. When both exist, no Apple sign-in is needed.
+   Otherwise the user signs in through `@limrun/apple-auth`, picks a team,
+   ensures the bundle ID, and the distribution certificate is created right
+   away.
+2. **Target iPhone** — registered devices are listed from the stored ad-hoc
+   profiles (plus the Developer Portal when signed in). The user either
+   continues with a covered device — no cable required — or registers a new
+   iPhone: WebUSB is used only to read the plugged-in device's UDID (its USB
+   serial number); there is no pairing. Registration creates/extends the
+   ad-hoc profile and needs an Apple session.
+3. **Build** — a single ad-hoc-signed build (distribution certificate +
+   ad-hoc profile picked server-side by the target UDID).
+4. **Install via QR** — after the build webhook, the browser exchanges the
+   install ID for a token scoped to exactly the uploaded asset and creates a
+   private OTA session in the registry. The QR code encodes the session's
+   install page URL; the iPhone scans it, opens the page in Safari, and taps
+   Install, which fires the `itms-services://` deeplink. The desktop UI polls
+   the session status to show how many IPA bytes the registry has served.
 
 ## Architecture
-
-The frontend signs into Apple through `@limrun/apple-auth`, selects a team and
-bundle ID, and uses `@limrun/device-install` for device discovery, pairing,
-automatic installation, and OTA progress. The selected iPhone's UDID is
-registered with Apple before a device-specific profile is created:
-
-- WebUSB uses a development certificate/profile and requires browser pairing.
-- QR uses a distribution certificate/ad-hoc profile and does not require
-  pairing. USB selection is used only to identify the target UDID.
 
 Signing material is written through a `SigningSecretStore` backed by the
 directory in the UI's "Secrets directory" field — pre-filled with the
@@ -31,7 +41,7 @@ installs without another Apple sign-in. The backend then runs:
 ```text
 lim xcode build <project> --sdk iphoneos --configuration Release \
   --certificate-p12 ... --provisioning-profile ... \
-  --upload device-install-<method>-<bundle>-<id>.ipa \
+  --upload device-install-<bundle>-<id>.ipa \
   --webhook-url ... --webhook-header X-Install-Token=... --detach
 ```
 
@@ -44,14 +54,9 @@ signing-secret store stay on port 3000.
 The browser initially receives only `device:*:install`. After a successful
 build webhook, it exchanges that build's install ID for a fresh scoped token
 containing `asset:<exact-uploaded-asset-id>:read`. There is no wildcard asset
-grant and no asset-name-only installation path.
-
-For WebUSB, the asset-scoped token is fed back into
-`useDeviceInstallRelay`, which automatically streams the IPA to the paired
-iPhone. For QR, `useOTAInstall` creates a private OTA capability from the IPA
-metadata in the build webhook. The UI renders its QR code and reports how many
-IPA bytes the registry has served. iOS does not expose final verification or
-installation completion.
+grant and no asset-name-only installation path. That token authorizes
+creating the OTA session in the registry; the session URLs the phone opens
+carry their own one-time secret, since the phone's Safari presents no token.
 
 ## Requirements
 
@@ -65,11 +70,9 @@ installation completion.
   (`ngrok http 3001`), or [requestbin.net](https://requestbin.net) if you
   only want to inspect the payload (the wizard then never sees completion)
 - An Apple Developer Program account
-- Desktop Chrome or Edge in a secure context (`http://localhost` works)
-- A physical, unlocked iPhone connected over USB for target selection
-
-Safari and Firefox do not expose WebUSB. Pairing is required only for the
-automatic WebUSB method; QR installation itself happens on the iPhone.
+- A physical iPhone. It only needs to be plugged in over USB (desktop Chrome
+  or Edge, secure context) when registering it for the first time; installs
+  onto already-registered devices need no cable and work from any browser
 
 ## Run
 
@@ -88,13 +91,14 @@ yarn --cwd examples/device-install/frontend dev
 
 Open `http://localhost:5173`:
 
-1. Enter the webhook URL in the sidebar (e.g. from `ngrok http 3001`), sign
-   in with Apple, choose a team, and choose or create a bundle ID.
-2. Enter the project path on the backend host and select WebUSB or QR.
-3. Select the iPhone. For WebUSB, pair it and tap Trust.
-4. Register the device and prepare method-specific signing.
-5. Start the detached build. Wait for automatic WebUSB installation or scan
-   the QR code on the registered iPhone.
+1. Enter the webhook URL in the sidebar (e.g. from `ngrok http 3001`). If
+   signing material is already stored, stage 1 shows a ready summary;
+   otherwise sign in with Apple, choose a team, and choose or create a
+   bundle ID.
+2. Pick a registered iPhone, or plug one in and register it via WebUSB.
+3. Enter the project path on the backend host and start the detached build.
+4. When the build webhook lands, create the QR install and scan it with the
+   registered iPhone.
 
 `backend/.secrets/` contains private keys and is gitignored. Build state is
 kept in memory for this example.

--- a/examples/device-install/backend/index.ts
+++ b/examples/device-install/backend/index.ts
@@ -209,6 +209,9 @@ hooks.post('/{*splat}', (req: Request, res: Response) => {
 hooks.listen(webhookPort, () => {
   console.log(`Webhook receiver listening at http://localhost:${webhookPort}`);
 });
-app.listen(port, () => {
+// Loopback only: these routes act on local paths the UI provides (project
+// directory, secrets directory), which is fine for the person running the
+// example on their own machine but must not be reachable from the network.
+app.listen(port, '127.0.0.1', () => {
   console.log(`Device install backend listening at http://localhost:${port}`);
 });

--- a/examples/device-install/backend/index.ts
+++ b/examples/device-install/backend/index.ts
@@ -155,24 +155,16 @@ app.delete('/secrets/:type/:name', async (req: Request<{ type: string; name: str
 // be a public URL that forwards to the webhook receiver's port 3001 (e.g.
 // from `ngrok http 3001`).
 app.post('/install', async (req: Request<{}, {}, Partial<InstallRequest>>, res: Response) => {
-  const { projectPath, method, teamId, bundleId, deviceUDID, scheme, secretsDir, webhookUrl } = req.body;
-  if (
-    !projectPath ||
-    !teamId ||
-    !bundleId ||
-    !deviceUDID ||
-    !webhookUrl ||
-    (method !== 'webusb' && method !== 'qr')
-  ) {
+  const { projectPath, teamId, bundleId, deviceUDID, scheme, secretsDir, webhookUrl } = req.body;
+  if (!projectPath || !teamId || !bundleId || !deviceUDID || !webhookUrl) {
     return res.status(400).json({
       status: 'error',
-      message: 'projectPath, teamId, bundleId, deviceUDID, webhookUrl and method (webusb | qr) are required',
+      message: 'projectPath, teamId, bundleId, deviceUDID and webhookUrl are required',
     });
   }
   try {
     const installId = await startInstall({
       projectPath,
-      method,
       teamId,
       bundleId,
       deviceUDID,

--- a/examples/device-install/backend/install.ts
+++ b/examples/device-install/backend/install.ts
@@ -7,11 +7,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { getSecret, listSecrets, type StoredSecret } from './secret-store.js';
 
-export type InstallMethod = 'webusb' | 'qr';
-
 export type InstallRequest = {
   projectPath: string;
-  method: InstallMethod;
   teamId: string;
   bundleId: string;
   deviceUDID: string;
@@ -53,17 +50,17 @@ function isUnexpired(expirationDate?: string) {
   return Number.isNaN(expiresAt) || expiresAt > Date.now();
 }
 
+// Builds are always ad-hoc signed for QR/OTA installation: distribution
+// certificate plus an ad-hoc profile covering the target device.
 async function resolveDeviceCredentials(request: InstallRequest): Promise<DeviceCredentials> {
-  const certificateKind = request.method === 'webusb' ? 'DEVELOPMENT' : 'DISTRIBUTION';
-  const profileLabel = request.method === 'webusb' ? 'development' : 'ad-hoc';
   const certificate = await getSecret(
     'appleCertificate',
-    `${request.teamId}/${certificateKind}`,
+    `${request.teamId}/DISTRIBUTION`,
     request.secretsDir,
   );
   if (!certificate || !isUnexpired(certificate.data.expirationDate)) {
     throw new Error(
-      `No valid ${profileLabel} signing certificate is stored. Prepare the selected iPhone first.`,
+      'No valid distribution signing certificate is stored. Prepare the selected iPhone first.',
     );
   }
 
@@ -90,7 +87,7 @@ async function resolveDeviceCredentials(request: InstallRequest): Promise<Device
     .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
   const profile = profiles[0];
   if (!profile) {
-    throw new Error(`No valid ${profileLabel} profile for ${request.bundleId} covers ${request.deviceUDID}.`);
+    throw new Error(`No valid ad-hoc profile for ${request.bundleId} covers ${request.deviceUDID}.`);
   }
   return { certificate, profile };
 }
@@ -149,7 +146,6 @@ export type InstallStatus = {
   id: string;
   state: 'running' | 'succeeded' | 'failed';
   startedAt: string;
-  method: InstallMethod;
   deviceUDID: string;
   assetName: string;
   webhook?: unknown;
@@ -215,13 +211,12 @@ export async function startInstall(request: InstallRequest): Promise<string> {
 
   const id = randomUUID();
   const token = randomBytes(32).toString('hex');
-  const assetName = `device-install-${request.method}-${request.bundleId}-${id}.ipa`;
+  const assetName = `device-install-${request.bundleId}-${id}.ipa`;
   installs.set(id, {
     status: {
       id,
       state: 'running',
       startedAt: new Date().toISOString(),
-      method: request.method,
       deviceUDID: request.deviceUDID,
       assetName,
     },
@@ -259,7 +254,7 @@ export async function startInstall(request: InstallRequest): Promise<string> {
   if (request.scheme) args.push('--scheme', request.scheme);
 
   const log = (line: string) => console.log(`[install ${id}] ${line}`);
-  log(`Building ${request.bundleId} for ${request.method} installation...`);
+  log(`Building ${request.bundleId} for QR/OTA installation...`);
   for (const line of await ensureExpoBundleIdentifier(request.projectPath, request.bundleId)) log(line);
   log(`$ lim ${args.join(' ')}`);
 

--- a/examples/device-install/frontend/src/App.tsx
+++ b/examples/device-install/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ConnectPhase } from './components/ConnectPhase';
-import { InstallPhase } from './components/InstallPhase';
+import { DevicesPhase } from './components/DevicesPhase';
+import { BuildPhase, InstallPhase } from './components/InstallPhase';
 import { ResultPanel } from './components/ResultPanel';
 import { INSTALLER_NAME } from './config';
 import { useConnect } from './hooks/useConnect';
@@ -25,7 +26,7 @@ export default function App() {
   });
   const build = useInstall();
   const device = useDeviceInstall({ connect, build, onError: setError });
-  const displayError = error ?? connect.appleLogin.error ?? device.install.error ?? device.ota.error;
+  const displayError = error ?? connect.appleLogin.error ?? device.ota.error;
 
   // The secrets directory on the backend host. The chosen value persists in
   // localStorage and rides every store operation and install build; the
@@ -55,8 +56,8 @@ export default function App() {
       <aside style={layout.sidebar}>
         <h1 style={layout.title}>{INSTALLER_NAME}</h1>
         <p style={hintText}>
-          Build and install an iOS app through automatic WebUSB or a private QR/OTA page. The backend needs
-          LIM_API_KEY and the lim CLI.
+          Build an ad-hoc-signed iOS app and install it on a registered iPhone through a private QR/OTA page.
+          The backend needs LIM_API_KEY and the lim CLI.
         </p>
         <label style={labelStyle}>Secrets directory (on the backend host)</label>
         <input
@@ -74,7 +75,9 @@ export default function App() {
         />
         {displayError && <div style={errorBox}>{displayError}</div>}
         <ConnectPhase connect={connect} />
-        <InstallPhase connect={connect} build={build} device={device} webhookUrl={webhookUrl} />
+        <DevicesPhase connect={connect} />
+        <BuildPhase connect={connect} build={build} webhookUrl={webhookUrl} />
+        <InstallPhase build={build} device={device} />
       </aside>
       <main style={layout.main}>
         <h2 style={{ margin: 0, fontSize: '16px' }}>Build result</h2>

--- a/examples/device-install/frontend/src/App.tsx
+++ b/examples/device-install/frontend/src/App.tsx
@@ -7,13 +7,7 @@ import { INSTALLER_NAME } from './config';
 import { useConnect } from './hooks/useConnect';
 import { useDeviceInstall } from './hooks/useDeviceInstall';
 import { useInstall } from './hooks/useInstall';
-import {
-  createBackendSecretStore,
-  getSecretsDir,
-  getWebhookUrl,
-  setSecretsDir,
-  setWebhookUrl,
-} from './lib/backend';
+import { createBackendSecretStore, getSecretsDir, setSecretsDir } from './lib/backend';
 import { errorBox, hintText, inputStyle, labelStyle, layout } from './theme';
 
 export default function App() {
@@ -42,15 +36,6 @@ export default function App() {
     setSecretsDir(dir);
   };
 
-  // The public URL limbuild POSTs build-finish webhooks to. It persists in
-  // localStorage and rides every install build request, where the backend
-  // hands it to the lim CLI verbatim.
-  const [webhookUrl, setWebhookUrlState] = useState(getWebhookUrl);
-  const updateWebhookUrl = (url: string) => {
-    setWebhookUrlState(url);
-    setWebhookUrl(url);
-  };
-
   return (
     <div style={layout.page}>
       <aside style={layout.sidebar}>
@@ -66,17 +51,10 @@ export default function App() {
           onChange={(event) => updateSecretsDir(event.target.value)}
           placeholder="backend default"
         />
-        <label style={labelStyle}>Webhook URL (Run `npx localtunnel --port 3001`)</label>
-        <input
-          style={inputStyle}
-          value={webhookUrl}
-          onChange={(event) => updateWebhookUrl(event.target.value)}
-          placeholder="https://your-subdomain.ngrok-free.app"
-        />
         {displayError && <div style={errorBox}>{displayError}</div>}
         <ConnectPhase connect={connect} />
         <DevicesPhase connect={connect} />
-        <BuildPhase connect={connect} build={build} webhookUrl={webhookUrl} />
+        <BuildPhase connect={connect} build={build} />
         <InstallPhase build={build} device={device} />
       </aside>
       <main style={layout.main}>

--- a/examples/device-install/frontend/src/App.tsx
+++ b/examples/device-install/frontend/src/App.tsx
@@ -25,7 +25,7 @@ export default function App() {
     onError: setError,
   });
   const build = useInstall();
-  const device = useDeviceInstall({ connect, build, onError: setError });
+  const device = useDeviceInstall({ build, onError: setError });
   const displayError = error ?? connect.appleLogin.error ?? device.ota.error;
 
   // The secrets directory on the backend host. The chosen value persists in

--- a/examples/device-install/frontend/src/components/ConnectPhase.tsx
+++ b/examples/device-install/frontend/src/components/ConnectPhase.tsx
@@ -70,20 +70,33 @@ function AppleLoginForm({ connect }: { connect: ConnectController }) {
   );
 }
 
+/**
+ * Stage 1: ad-hoc signing. With a stored connection the phase starts from
+ * the secret store: when the distribution certificate and an ad-hoc profile
+ * are already there, it only shows a ready summary. Apple sign-in appears
+ * when material is missing or a later stage flagged that it needs a portal
+ * session (e.g. registering a new device).
+ */
 export function ConnectPhase({ connect }: { connect: ConnectController }) {
   if (connect.connection) {
+    const needsLogin =
+      !connect.loggedIn &&
+      (connect.signing.status === 'missing' || connect.deviceEnrollment.status === 'needs-login');
     return (
-      <Section title="1. Apple setup">
+      <Section title="1. Ad-hoc signing">
         <div style={infoBox}>
           Team {connect.connection.teamId}, bundle ID {connect.connection.bundleId}.
         </div>
+        {connect.signing.status === 'checking' && <p style={hintText}>Checking stored signing secrets…</p>}
+        {connect.signing.note && (
+          <div style={connect.signing.status === 'ready' ? infoBox : warnBox}>{connect.signing.note}</div>
+        )}
         {connect.deviceEnrollment.status === 'needs-login' && (
-          <>
-            <div style={warnBox}>{connect.deviceEnrollment.note}</div>
-            {!connect.loggedIn ?
-              <AppleLoginForm connect={connect} />
-            : <div style={infoBox}>Apple reauthentication is ready. Prepare the device again below.</div>}
-          </>
+          <div style={warnBox}>{connect.deviceEnrollment.note}</div>
+        )}
+        {needsLogin && <AppleLoginForm connect={connect} />}
+        {connect.loggedIn && connect.signing.status !== 'ready' && (
+          <div style={infoBox}>Apple session is ready. Register a device below to create the profile.</div>
         )}
         <button style={secondaryButton(false)} onClick={connect.disconnect}>
           Disconnect and start over
@@ -93,12 +106,13 @@ export function ConnectPhase({ connect }: { connect: ConnectController }) {
   }
 
   return (
-    <Section title="1. Apple setup">
+    <Section title="1. Ad-hoc signing">
       {!connect.loggedIn ?
         <>
           <p style={hintText}>
-            Sign in through Limrun&apos;s Apple relay, choose a team, and ensure the app&apos;s bundle ID.
-            Credentials are created only after a target iPhone and installation method are selected.
+            Sign in through Limrun&apos;s Apple relay, choose a team, and ensure the app&apos;s bundle ID. A
+            distribution certificate is created right away; the ad-hoc provisioning profile follows when a
+            device is registered.
           </p>
           <AppleLoginForm connect={connect} />
         </>
@@ -144,7 +158,7 @@ export function ConnectPhase({ connect }: { connect: ConnectController }) {
             onChange={(event) => connect.setAppName(event.target.value)}
             placeholder="My App"
           />
-          <p style={hintText}>Used to label a new bundle ID, the OTA page, and the registered iPhone.</p>
+          <p style={hintText}>Used to label a new bundle ID, the OTA install page, and registered iPhones.</p>
           <button
             style={primaryButton(connect.busy === 'confirm')}
             disabled={connect.busy === 'confirm'}

--- a/examples/device-install/frontend/src/components/DevicesPhase.tsx
+++ b/examples/device-install/frontend/src/components/DevicesPhase.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { requestUSBAccess } from '@limrun/device-install';
+import type { ConnectController } from '../hooks/useConnect';
+import { errorMessage } from '../lib/backend';
+import { hintText, infoBox, inputStyle, labelStyle, primaryButton, secondaryButton, warnBox } from '../theme';
+import { Section } from './Section';
+
+/**
+ * Stage 2: pick the target iPhone. Devices covered by a stored ad-hoc
+ * profile can be continued with directly — no cable, no Apple session.
+ * WebUSB is used only to read a newly plugged-in iPhone's UDID (its USB
+ * serial number) so it can be registered on the portal and added to an
+ * ad-hoc profile; there is no pairing.
+ */
+export function DevicesPhase({ connect }: { connect: ConnectController }) {
+  const [usbBusy, setUsbBusy] = useState(false);
+  const [usbError, setUsbError] = useState<string>();
+  const [chosenUDID, setChosenUDID] = useState<string>();
+
+  if (!connect.connection) {
+    return (
+      <Section title="2. Target iPhone">
+        <p style={hintText}>Locked. Complete the signing setup first.</p>
+      </Section>
+    );
+  }
+
+  const chosen = connect.devices.find((device) => device.udid === chosenUDID);
+  const preparing = connect.busy === 'device-enrollment' || connect.deviceEnrollment.status === 'checking';
+
+  async function registerNewViaUSB() {
+    setUsbError(undefined);
+    setUsbBusy(true);
+    try {
+      // requestUSBAccess only opens the browser's device picker and reads
+      // the USB descriptor; the UDID is the serial number. No pairing, no
+      // relay session.
+      const target = await requestUSBAccess();
+      const udid = target.hello.serialNumber;
+      if (!udid) throw new Error('The selected device did not report a serial number.');
+      setChosenUDID(udid.replace(/[^a-fA-F0-9]/g, '').toUpperCase());
+      await connect.prepareDevice(udid, target.hello.productName ?? 'iPhone');
+    } catch (error) {
+      setUsbError(errorMessage(error, 'Could not read the iPhone over WebUSB'));
+    } finally {
+      setUsbBusy(false);
+    }
+  }
+
+  return (
+    <Section title="2. Target iPhone">
+      {connect.devices.length > 0 ?
+        <>
+          <label style={labelStyle}>Registered devices</label>
+          <select
+            style={inputStyle}
+            value={chosenUDID ?? connect.selectedDevice?.udid ?? ''}
+            onChange={(event) => setChosenUDID(event.target.value || undefined)}
+            disabled={preparing}
+          >
+            <option value="">Select a device…</option>
+            {connect.devices.map((device) => (
+              <option key={device.udid} value={device.udid}>
+                {device.name ? `${device.name} — ` : ''}
+                {device.udid}
+                {device.covered ? '' : ' (not in the ad-hoc profile yet)'}
+              </option>
+            ))}
+          </select>
+          <button
+            style={primaryButton(!chosen || preparing)}
+            disabled={!chosen || preparing}
+            onClick={() => {
+              if (!chosen) return;
+              if (chosen.covered) {
+                connect.selectDevice(chosen);
+              } else {
+                // Extending coverage to a portal-registered device needs an
+                // Apple session; prepareDevice flags needs-login otherwise.
+                void connect.prepareDevice(chosen.udid, chosen.name ?? 'iPhone');
+              }
+            }}
+          >
+            {preparing ?
+              'Preparing ad-hoc signing…'
+            : chosen && !chosen.covered ?
+              'Add to ad-hoc profile and continue'
+            : 'Continue with this device'}
+          </button>
+        </>
+      : <p style={hintText}>
+          No registered devices found in the stored profiles
+          {connect.loggedIn ? ' or on the Developer Portal' : ''}. Register one below.
+        </p>
+      }
+
+      <button
+        style={secondaryButton(usbBusy || preparing)}
+        disabled={usbBusy || preparing}
+        onClick={() => void registerNewViaUSB()}
+      >
+        {usbBusy ? 'Opening device picker…' : 'Register a new iPhone via USB'}
+      </button>
+      <p style={hintText}>
+        Reads the plugged-in iPhone&apos;s UDID over WebUSB and registers it with Apple. Registration requires
+        an Apple sign-in; installation later happens entirely over the QR page.
+      </p>
+      {usbError && <div style={warnBox}>{usbError}</div>}
+      {connect.deviceEnrollment.note && connect.deviceEnrollment.status !== 'idle' && (
+        <div
+          style={
+            connect.deviceEnrollment.status === 'error' || connect.deviceEnrollment.status === 'needs-login' ?
+              warnBox
+            : infoBox
+          }
+        >
+          {connect.deviceEnrollment.note}
+        </div>
+      )}
+      {connect.selectedDevice?.covered && (
+        <div style={infoBox}>
+          Target: {connect.selectedDevice.name ? `${connect.selectedDevice.name} — ` : ''}
+          {connect.selectedDevice.udid}
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/examples/device-install/frontend/src/components/InstallPhase.tsx
+++ b/examples/device-install/frontend/src/components/InstallPhase.tsx
@@ -3,32 +3,16 @@ import QRCode from 'qrcode';
 import type { ConnectController } from '../hooks/useConnect';
 import type { DeviceInstallController } from '../hooks/useDeviceInstall';
 import type { InstallController } from '../hooks/useInstall';
-import type { InstallMethod } from '../lib/backend';
 import {
   errorBox,
   hintText,
   infoBox,
   inputStyle,
   labelStyle,
-  methodCard,
   primaryButton,
   secondaryButton,
-  warnBox,
 } from '../theme';
 import { Section } from './Section';
-
-const METHODS: Array<{ id: InstallMethod; label: string; description: string }> = [
-  {
-    id: 'webusb',
-    label: 'WebUSB',
-    description: 'Development-sign, build, and automatically install on a paired iPhone.',
-  },
-  {
-    id: 'qr',
-    label: 'QR / private OTA',
-    description: 'Ad-hoc-sign and create a private install page; pairing is not required.',
-  },
-];
 
 function InstallQRCode({ url }: { url: string }) {
   const [dataUrl, setDataUrl] = useState<string>();
@@ -53,38 +37,35 @@ function bytes(value?: number) {
   return `${(value / 1024 / 1024).toFixed(1)} MiB`;
 }
 
-export function InstallPhase({
+/**
+ * Stage 3: the single ad-hoc-signed build (distribution certificate +
+ * ad-hoc profile, chosen server-side by the target device's UDID).
+ */
+export function BuildPhase({
   connect,
   build,
-  device,
   webhookUrl,
 }: {
   connect: ConnectController;
   build: InstallController;
-  device: DeviceInstallController;
   /** The sidebar's webhook URL; rides the build request. Empty blocks building. */
   webhookUrl: string;
 }) {
   const [projectPath, setProjectPath] = useState('');
-  if (!connect.connection) {
+  if (!connect.connection || !connect.selectedDevice?.covered) {
     return (
-      <Section title="2. Build and install">
-        <p style={hintText}>Locked. Complete Apple setup first.</p>
+      <Section title="3. Build">
+        <p style={hintText}>Locked. Pick a covered target iPhone first.</p>
       </Section>
     );
   }
 
-  const profileKind = build.method === 'qr' ? 'adhoc' : 'development';
   const running = build.state === 'running';
-  const deviceReady =
-    !!device.install.device &&
-    (build.method === 'qr' || device.install.hasPairRecord) &&
-    device.enrollmentReady(profileKind);
   const webhookUrlSet = webhookUrl.trim() !== '';
-  const canBuild = !running && !!projectPath.trim() && deviceReady && webhookUrlSet;
+  const canBuild = !running && !!projectPath.trim() && webhookUrlSet;
 
   return (
-    <Section title="2. Build and install">
+    <Section title="3. Build">
       <label style={labelStyle}>Project path (on the backend host)</label>
       <input
         style={inputStyle}
@@ -92,88 +73,6 @@ export function InstallPhase({
         onChange={(event) => setProjectPath(event.target.value)}
         placeholder="/path/to/MyApp"
       />
-      <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-        {METHODS.map((method) => (
-          <button
-            key={method.id}
-            style={methodCard(build.method === method.id, running)}
-            disabled={running}
-            onClick={() => build.setMethod(method.id)}
-          >
-            <strong>{method.label}</strong>
-            <br />
-            <span style={hintText}>{method.description}</span>
-          </button>
-        ))}
-      </div>
-
-      <label style={labelStyle}>Target iPhone</label>
-      <button
-        style={secondaryButton(device.install.busyAction === 'usb' || running)}
-        disabled={running}
-        onClick={() => {
-          device.install.clearError();
-          void device.install.requestUSBAccess();
-        }}
-      >
-        {device.install.device ?
-          `Selected: ${device.install.device.hello.productName}`
-        : device.install.busyAction === 'usb' ?
-          'Opening device picker…'
-        : 'Select iPhone'}
-      </button>
-
-      {build.method === 'webusb' && (
-        <>
-          <button
-            style={secondaryButton(!device.install.canPair || running)}
-            disabled={!device.install.canPair || running}
-            onClick={() => {
-              device.install.clearError();
-              void device.install.pairBrowser();
-            }}
-          >
-            {device.install.busyAction === 'pair' ? 'Pairing…' : 'Pair (tap Trust on iPhone)'}
-          </button>
-          {device.install.pairConfirmationRequired && (
-            <div style={warnBox}>Unlock the iPhone, tap Trust, then choose Pair again.</div>
-          )}
-          {device.install.hasPairRecord && (
-            <div style={infoBox}>Paired. The pair record is stored only in this browser.</div>
-          )}
-        </>
-      )}
-
-      <button
-        style={secondaryButton(
-          !device.install.device ||
-            (build.method === 'webusb' && !device.install.hasPairRecord) ||
-            connect.busy === 'device-enrollment',
-        )}
-        disabled={
-          !device.install.device ||
-          (build.method === 'webusb' && !device.install.hasPairRecord) ||
-          connect.busy === 'device-enrollment' ||
-          running
-        }
-        onClick={() => void device.prepareSelectedDevice(profileKind)}
-      >
-        {connect.busy === 'device-enrollment' || connect.deviceEnrollment.status === 'checking' ?
-          'Preparing signing…'
-        : `Register device and prepare ${profileKind === 'adhoc' ? 'ad-hoc' : 'development'} signing`}
-      </button>
-      {connect.deviceEnrollment.note && (
-        <div
-          style={
-            connect.deviceEnrollment.status === 'error' || connect.deviceEnrollment.status === 'needs-login' ?
-              warnBox
-            : infoBox
-          }
-        >
-          {connect.deviceEnrollment.note}
-        </div>
-      )}
-
       {!webhookUrlSet && (
         <p style={hintText}>Enter the webhook URL at the top of the sidebar to enable building.</p>
       )}
@@ -183,75 +82,121 @@ export function InstallPhase({
         onClick={() =>
           void build.build({
             projectPath: projectPath.trim(),
-            method: build.method,
             teamId: connect.connection!.teamId,
             bundleId: connect.connection!.bundleId,
-            deviceUDID: device.selectedUDID!,
+            deviceUDID: connect.selectedDevice!.udid,
             webhookUrl: webhookUrl.trim(),
           })
         }
       >
-        {running ?
-          'Waiting for build callback…'
-        : `Build and ${build.method === 'webusb' ? 'install automatically' : 'create QR install'}`}
+        {running ? 'Waiting for build callback…' : 'Build ad-hoc-signed IPA'}
       </button>
-
       {build.state === 'failed' && (
         <div style={errorBox}>Build failed{build.error ? `: ${build.error}` : '.'}</div>
       )}
-      {build.state === 'succeeded' && build.method === 'webusb' && (
-        <div style={infoBox}>
-          IPA uploaded.{' '}
-          {device.installState === 'authorizing' || device.installState === 'waiting' ?
-            'Authorizing automatic installation…'
-          : device.installState === 'installing' ?
-            'Starting installation…'
-          : device.installState === 'started' ?
-            'Installation started. Keep the iPhone connected and unlocked.'
-          : device.installState === 'failed' ?
-            <>
-              Automatic installation failed.{' '}
-              <button style={secondaryButton(false)} onClick={device.retryInstallation}>
-                Retry
-              </button>
-            </>
-          : 'Waiting to install…'}
+      {build.state === 'succeeded' && <div style={infoBox}>IPA built and uploaded.</div>}
+    </Section>
+  );
+}
+
+/**
+ * Stage 4: QR installation. Once the build's asset is authorized, one
+ * button creates the private OTA session; the QR code encodes its install
+ * page URL, where the phone taps Install to fire the itms-services
+ * deeplink. Progress comes from polling the session's status URL.
+ */
+export function InstallPhase({
+  build,
+  device,
+}: {
+  build: InstallController;
+  device: DeviceInstallController;
+}) {
+  if (build.state !== 'succeeded') {
+    return (
+      <Section title="4. Install via QR">
+        <p style={hintText}>Locked. Finish a build first.</p>
+      </Section>
+    );
+  }
+
+  return (
+    <Section title="4. Install via QR">
+      {device.authorization === 'authorizing' && (
+        <p style={hintText}>Authorizing the built IPA for installation…</p>
+      )}
+      {device.authorization === 'failed' && (
+        <div style={errorBox}>
+          Could not authorize the built IPA.{' '}
+          <button style={secondaryButton(false)} onClick={device.retryAuthorization}>
+            Retry
+          </button>
         </div>
       )}
-      {build.state === 'succeeded' && build.method === 'qr' && (
-        <div style={infoBox}>
-          {device.ota.session ?
-            <>
-              <InstallQRCode url={device.ota.session.installPageUrl} />
-              <div>
-                <a href={device.ota.session.installPageUrl} target="_blank" rel="noreferrer">
-                  Open the private iPhone install page
-                </a>
-              </div>
-              {device.ota.status && (
-                <div style={{ marginTop: '10px' }}>
-                  <progress max={1} value={device.ota.status.progress} style={{ width: '100%' }} />
-                  <div>
-                    {Math.round(device.ota.status.progress * 100)}% —{' '}
-                    {bytes(device.ota.status.bytesTransferred)} of {bytes(device.ota.status.totalBytes)}{' '}
-                    served
-                  </div>
-                  {device.ota.status.state === 'downloaded' && (
-                    <div>
-                      IPA bytes were delivered to iOS. Final verification and installation are not observable.
-                    </div>
-                  )}
-                </div>
-              )}
-            </>
-          : device.ota.error ?
-            <>
+      {device.authorization === 'ready' && !device.ota.session && (
+        <>
+          <button
+            style={primaryButton(device.ota.busy)}
+            disabled={device.ota.busy}
+            onClick={device.startQRInstall}
+          >
+            {device.ota.busy ? 'Creating install page…' : 'Create QR install'}
+          </button>
+          {device.ota.error && (
+            <div style={errorBox}>
               OTA session failed: {device.ota.error}{' '}
-              <button style={secondaryButton(false)} onClick={device.retryOTA}>
+              <button style={secondaryButton(false)} onClick={device.startQRInstall}>
                 Retry
               </button>
-            </>
-          : 'Authorizing the private OTA install page…'}
+            </div>
+          )}
+        </>
+      )}
+      {device.ota.session && (
+        <div style={infoBox}>
+          <InstallQRCode url={device.ota.session.installPageUrl} />
+          <div>
+            <a href={device.ota.session.installPageUrl} target="_blank" rel="noreferrer">
+              Open the private iPhone install page
+            </a>
+          </div>
+          <p style={hintText}>
+            Scan with the registered iPhone, then tap Install on the page. iOS shows its own confirmation
+            prompt.
+          </p>
+          {device.ota.status && (
+            <div style={{ marginTop: '10px' }}>
+              <progress max={1} value={device.ota.status.progress} style={{ width: '100%' }} />
+              <div>
+                {Math.round(device.ota.status.progress * 100)}% — {bytes(device.ota.status.bytesTransferred)}{' '}
+                of {bytes(device.ota.status.totalBytes)} served
+              </div>
+              {device.ota.status.state === 'downloaded' && (
+                <div>
+                  IPA bytes were delivered to iOS. Final verification and installation are not observable.
+                </div>
+              )}
+              {device.ota.status.state === 'failed' && (
+                <div style={errorBox}>
+                  Delivery failed{device.ota.status.error ? `: ${device.ota.status.error}` : '.'}
+                </div>
+              )}
+              {device.ota.status.state === 'expired' && (
+                <div style={errorBox}>
+                  The install page expired.{' '}
+                  <button
+                    style={secondaryButton(false)}
+                    onClick={() => {
+                      device.ota.reset();
+                      device.startQRInstall();
+                    }}
+                  >
+                    Create a new one
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </Section>

--- a/examples/device-install/frontend/src/components/InstallPhase.tsx
+++ b/examples/device-install/frontend/src/components/InstallPhase.tsx
@@ -3,6 +3,7 @@ import QRCode from 'qrcode';
 import type { ConnectController } from '../hooks/useConnect';
 import type { DeviceInstallController } from '../hooks/useDeviceInstall';
 import type { InstallController } from '../hooks/useInstall';
+import { getWebhookUrl, setWebhookUrl } from '../lib/backend';
 import {
   errorBox,
   hintText,
@@ -41,17 +42,16 @@ function bytes(value?: number) {
  * Stage 3: the single ad-hoc-signed build (distribution certificate +
  * ad-hoc profile, chosen server-side by the target device's UDID).
  */
-export function BuildPhase({
-  connect,
-  build,
-  webhookUrl,
-}: {
-  connect: ConnectController;
-  build: InstallController;
-  /** The sidebar's webhook URL; rides the build request. Empty blocks building. */
-  webhookUrl: string;
-}) {
+export function BuildPhase({ connect, build }: { connect: ConnectController; build: InstallController }) {
   const [projectPath, setProjectPath] = useState('');
+  // The public URL limbuild POSTs build-finish webhooks to. It persists in
+  // localStorage and rides the build request, where the backend hands it to
+  // the lim CLI verbatim.
+  const [webhookUrl, setWebhookUrlState] = useState(getWebhookUrl);
+  const updateWebhookUrl = (url: string) => {
+    setWebhookUrlState(url);
+    setWebhookUrl(url);
+  };
   if (!connect.connection || !connect.selectedDevice?.covered) {
     return (
       <Section title="3. Build">
@@ -73,9 +73,14 @@ export function BuildPhase({
         onChange={(event) => setProjectPath(event.target.value)}
         placeholder="/path/to/MyApp"
       />
-      {!webhookUrlSet && (
-        <p style={hintText}>Enter the webhook URL at the top of the sidebar to enable building.</p>
-      )}
+      <label style={labelStyle}>Webhook URL (Run `npx localtunnel --port 3001`)</label>
+      <input
+        style={inputStyle}
+        value={webhookUrl}
+        onChange={(event) => updateWebhookUrl(event.target.value)}
+        placeholder="https://your-subdomain.ngrok-free.app"
+      />
+      {!webhookUrlSet && <p style={hintText}>Enter the webhook URL to enable building.</p>}
       <button
         style={primaryButton(!canBuild)}
         disabled={!canBuild}

--- a/examples/device-install/frontend/src/config.ts
+++ b/examples/device-install/frontend/src/config.ts
@@ -2,9 +2,7 @@ export const INSTALLER_NAME = 'Acme Device Installer';
 
 export const naming = {
   certificateCommonName: (teamId: string) => `${INSTALLER_NAME} ${teamId}`,
-  webUsbProfileName: (bundleId: string, deviceUDID: string) =>
-    `${INSTALLER_NAME} WebUSB ${bundleId} ${deviceUDID.slice(-6)} ${Date.now()}`,
-  qrProfileName: (bundleId: string, deviceUDID: string) =>
+  profileName: (bundleId: string, deviceUDID: string) =>
     `${INSTALLER_NAME} QR ${bundleId} ${deviceUDID.slice(-6)} ${Date.now()}`,
   deviceName: (productName: string, deviceUDID: string) =>
     `${INSTALLER_NAME} ${productName || 'iPhone'} ${deviceUDID.slice(-6)}`,

--- a/examples/device-install/frontend/src/hooks/useConnect.ts
+++ b/examples/device-install/frontend/src/hooks/useConnect.ts
@@ -1,7 +1,9 @@
-// Apple account setup plus device-specific signing. Connect only chooses the
-// team and bundle ID; the selected installation method later determines
-// whether development or ad-hoc credentials are created.
-import { useEffect, useState } from 'react';
+// Ad-hoc signing setup for QR/OTA installation. On load the stored secrets
+// are checked first: when a distribution certificate and an ad-hoc profile
+// for the connection already exist, no Apple sign-in is needed at all.
+// Sign-in is required only to create missing material or to register a new
+// device into the profile.
+import { useEffect, useRef, useState } from 'react';
 import {
   APPLE_CERTIFICATE_SECRET_TYPE,
   APPLE_PROVISIONING_PROFILE_SECRET_TYPE,
@@ -31,10 +33,24 @@ export type Connection = {
   appName: string;
 };
 
+export type SigningState = {
+  status: 'idle' | 'checking' | 'ready' | 'missing';
+  certificateOk: boolean;
+  profileCount: number;
+  note?: string;
+};
+
+export type RegisteredDevice = {
+  /** Normalized (uppercase hex) UDID. */
+  udid: string;
+  name?: string;
+  /** Whether a stored ad-hoc profile already lets this device install the app. */
+  covered: boolean;
+};
+
 export type DeviceEnrollmentState = {
   status: 'idle' | 'checking' | 'needs-login' | 'ready' | 'error';
   deviceUDID?: string;
-  profileKind?: 'development' | 'adhoc';
   note?: string;
 };
 
@@ -76,23 +92,19 @@ function isUnexpired(expirationDate?: string) {
 }
 
 /**
- * Whether a stored provisioning profile already lets the connected app be
- * installed on the device: same team, binds the bundle ID, lists the
- * device, references the certificate, and neither profile nor certificate
- * has expired.
+ * Whether a stored provisioning profile is the ad-hoc signing material for
+ * the connection: same team, binds the bundle ID, references the
+ * distribution certificate, and neither has expired. Device coverage is
+ * judged separately from the profile's device list.
  */
-function profileCoversDevice(
+function profileMatchesConnection(
   profile: SigningSecret | undefined,
   certificate: SigningSecret | undefined,
   connection: Connection,
-  normalizedUDID: string,
 ): boolean {
   return (
     profile?.data.teamID === connection.teamId &&
     commaSeparated(profile.data.bundleIDs).includes(connection.bundleId) &&
-    parseProvisionedDevices(profile.data.deviceIDs).some(
-      (device) => normalizeUDID(device.udid) === normalizedUDID,
-    ) &&
     !!certificate?.data.serialNumber &&
     commaSeparated(profile.data.certificateSerialNumbers).includes(certificate.data.serialNumber) &&
     isUnexpired(certificate.data.expirationDate) &&
@@ -118,6 +130,13 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
   const [portalAppIds, setPortalAppIds] = useState<AppleBundleID[]>([]);
   const [bundleIdsLoading, setBundleIdsLoading] = useState(false);
   const [appName, setAppName] = useState(connection?.appName ?? '');
+  const [signing, setSigning] = useState<SigningState>({
+    status: 'idle',
+    certificateOk: false,
+    profileCount: 0,
+  });
+  const [devices, setDevices] = useState<RegisteredDevice[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<RegisteredDevice>();
   const [deviceEnrollment, setDeviceEnrollment] = useState<DeviceEnrollmentState>({ status: 'idle' });
 
   useEffect(() => {
@@ -142,6 +161,102 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
   const loggedIn = appleLogin.status === 'authenticated' && !!relay;
   const selectedTeam = teams.find((team) => team.teamId === selectedTeamId);
   const teamId = selectedTeam?.teamId;
+
+  /**
+   * The stored distribution certificate and the ad-hoc profiles that match
+   * the connection. This is the secret-store check the whole flow starts
+   * with; it needs no Apple session.
+   */
+  async function collectSigningMaterial(target: Connection) {
+    const certificate = await secretStore.get(
+      APPLE_CERTIFICATE_SECRET_TYPE,
+      appleCertificateSecretName(target.teamId, 'DISTRIBUTION'),
+    );
+    const certificateOk =
+      !!certificate && !!certificate.data.serialNumber && isUnexpired(certificate.data.expirationDate);
+    const profiles: SigningSecret[] = [];
+    if (certificateOk) {
+      const metadata = (await secretStore.list()).filter(
+        (secret) =>
+          secret.type === APPLE_PROVISIONING_PROFILE_SECRET_TYPE &&
+          secret.name.startsWith(`${target.teamId}/`),
+      );
+      for (const meta of metadata) {
+        const profile = await secretStore.get(APPLE_PROVISIONING_PROFILE_SECRET_TYPE, meta.name);
+        if (profileMatchesConnection(profile, certificate, target)) profiles.push(profile!);
+      }
+    }
+    return { certificate: certificateOk ? certificate : undefined, profiles };
+  }
+
+  /**
+   * Refreshes the signing summary and the registered-device list. Devices
+   * come from the matching profiles' device lists; when an Apple session is
+   * open, the team's portal devices are merged in (uncovered until a
+   * profile includes them).
+   */
+  async function refreshSigning(target?: Connection) {
+    const active = target ?? connection;
+    if (!active) return;
+    setSigning((current) => ({ ...current, status: 'checking' }));
+    try {
+      const { certificate, profiles } = await collectSigningMaterial(active);
+      const byUDID = new Map<string, RegisteredDevice>();
+      for (const profile of profiles) {
+        for (const device of parseProvisionedDevices(profile.data.deviceIDs)) {
+          const udid = normalizeUDID(device.udid);
+          if (!udid) continue;
+          byUDID.set(udid, { udid, name: device.name ?? byUDID.get(udid)?.name, covered: true });
+        }
+      }
+      if (relay && loggedIn) {
+        try {
+          const portalDevices = await listAppleDevices({ relay, teamId: active.teamId });
+          for (const portalDevice of portalDevices) {
+            const udid = normalizeUDID(portalDevice.deviceNumber);
+            if (!udid || byUDID.has(udid)) continue;
+            byUDID.set(udid, { udid, name: portalDevice.name, covered: false });
+          }
+        } catch (error) {
+          log('Could not list portal devices', errorMessage(error, 'unknown error'));
+        }
+      }
+      const nextDevices = [...byUDID.values()].sort((a, b) => a.udid.localeCompare(b.udid));
+      setDevices(nextDevices);
+      setSelectedDevice((current) => current && byUDID.get(current.udid));
+      const ready = !!certificate && profiles.length > 0;
+      setSigning({
+        status: ready ? 'ready' : 'missing',
+        certificateOk: !!certificate,
+        profileCount: profiles.length,
+        note:
+          ready ?
+            `Distribution certificate and ${profiles.length} ad-hoc profile${
+              profiles.length === 1 ? '' : 's'
+            } are stored.`
+          : certificate ?
+            'Distribution certificate is stored. An ad-hoc profile is created when a device is registered below.'
+          : 'No distribution certificate or ad-hoc profile is stored yet. Sign in with Apple so they can be created.',
+      });
+    } catch (error) {
+      setSigning({
+        status: 'missing',
+        certificateOk: false,
+        profileCount: 0,
+        note: errorMessage(error, 'Could not check the signing secrets'),
+      });
+    }
+  }
+
+  // The load-time secret-store check: with a restored connection the app
+  // starts by looking at what's stored, not by asking for a sign-in. The
+  // ref guard makes this a run-once effect without a dependency list.
+  const initialSigningChecked = useRef(false);
+  useEffect(() => {
+    if (initialSigningChecked.current) return;
+    initialSigningChecked.current = true;
+    if (connection) void refreshSigning(connection);
+  });
 
   /**
    * Existing bundle IDs on the portal for the team, so the user can pick
@@ -175,6 +290,12 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
     setTeams(loaded);
     setSelectedTeamId(loaded[0]?.teamId ?? '');
     log('Apple teams loaded', String(loaded.length));
+    // A returning user signing in to extend an existing connection skips
+    // the team/bundle forms; refresh the device list with portal data.
+    if (connection) {
+      void refreshSigning(connection);
+      return;
+    }
     if (loaded[0]) await loadBundleIds(relayClient, loaded[0]);
   }
 
@@ -232,9 +353,20 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
       } else {
         log('Bundle ID already registered', chosenBundleId);
       }
+      // The distribution certificate can be ensured right away; the ad-hoc
+      // profile is device-scoped and waits for a registered device.
+      await ensureAppleCertificateSecret({
+        relay,
+        teamId,
+        secretStore,
+        certificateKind: 'distribution',
+        commonName: naming.certificateCommonName(teamId),
+        log,
+      });
       const established = { teamId, bundleId: chosenBundleId, appName: appName.trim() };
       setConnection(established);
       localStorage.setItem(CONNECTION_STORAGE_KEY, JSON.stringify(established));
+      await refreshSigning(established);
     } catch (error) {
       onError(errorMessage(error, 'Device installer setup failed'));
     } finally {
@@ -242,56 +374,55 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
     }
   }
 
-  async function prepareDevice(
-    deviceUDID: string,
-    productName: string,
-    profileKind: 'development' | 'adhoc',
-  ) {
+  /**
+   * Makes sure a device is registered on the portal and covered by an
+   * ad-hoc profile referencing the stored distribution certificate. Used
+   * both for newly plugged-in devices (UDID read over WebUSB) and for
+   * portal-listed devices no stored profile covers yet.
+   */
+  async function prepareDevice(deviceUDID: string, productName: string): Promise<boolean> {
     if (!connection) return false;
     const normalizedUDID = normalizeUDID(deviceUDID);
     if (!normalizedUDID) {
-      onError('The selected iPhone did not report a UDID.');
+      onError('The iPhone did not report a UDID.');
       return false;
     }
     onError(undefined);
-    setDeviceEnrollment({ status: 'checking', deviceUDID: normalizedUDID, profileKind });
+    setDeviceEnrollment({ status: 'checking', deviceUDID: normalizedUDID });
     try {
-      const certificateKind = profileKind === 'adhoc' ? 'DISTRIBUTION' : 'DEVELOPMENT';
-      const certificate = await secretStore.get(
-        APPLE_CERTIFICATE_SECRET_TYPE,
-        appleCertificateSecretName(connection.teamId, certificateKind),
-      );
-      const profileMetadata = (await secretStore.list()).filter(
-        (secret) =>
-          secret.type === APPLE_PROVISIONING_PROFILE_SECRET_TYPE &&
-          secret.name.startsWith(`${connection.teamId}/`),
-      );
-      for (const metadata of profileMetadata) {
-        const profile = await secretStore.get(APPLE_PROVISIONING_PROFILE_SECRET_TYPE, metadata.name);
-        if (profileCoversDevice(profile, certificate, connection, normalizedUDID)) {
-          setDeviceEnrollment({
-            status: 'ready',
-            deviceUDID: normalizedUDID,
-            profileKind,
-            note: `Stored ${profileKind === 'adhoc' ? 'ad-hoc' : 'development'} signing covers this iPhone.`,
-          });
-          return true;
-        }
+      const { certificate, profiles } = await collectSigningMaterial(connection);
+      const coveringProfile =
+        certificate &&
+        profiles.find((profile) =>
+          parseProvisionedDevices(profile.data.deviceIDs).some(
+            (device) => normalizeUDID(device.udid) === normalizedUDID,
+          ),
+        );
+      if (coveringProfile) {
+        setDeviceEnrollment({
+          status: 'ready',
+          deviceUDID: normalizedUDID,
+          note: 'Stored ad-hoc signing already covers this iPhone.',
+        });
+        await refreshSigning(connection);
+        setSelectedDevice({ udid: normalizedUDID, name: productName, covered: true });
+        return true;
       }
 
       if (!relay || !loggedIn) {
         setDeviceEnrollment({
           status: 'needs-login',
           deviceUDID: normalizedUDID,
-          profileKind,
-          note: 'Sign in with Apple again to register this iPhone and create its signing profile.',
+          note: 'Sign in with Apple to register this iPhone and create its ad-hoc profile.',
         });
         return false;
       }
 
       setBusy('device-enrollment');
-      let devices = await listAppleDevices({ relay, teamId: connection.teamId });
-      let portalDevice = devices.find((device) => normalizeUDID(device.deviceNumber) === normalizedUDID);
+      let portalDevices = await listAppleDevices({ relay, teamId: connection.teamId });
+      let portalDevice = portalDevices.find(
+        (device) => normalizeUDID(device.deviceNumber) === normalizedUDID,
+      );
       if (!portalDevice) {
         await registerAppleDevice({
           relay,
@@ -299,8 +430,8 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
           deviceUDID: normalizedUDID,
           name: naming.deviceName(productName, normalizedUDID),
         });
-        devices = await listAppleDevices({ relay, teamId: connection.teamId });
-        portalDevice = devices.find((device) => normalizeUDID(device.deviceNumber) === normalizedUDID);
+        portalDevices = await listAppleDevices({ relay, teamId: connection.teamId });
+        portalDevice = portalDevices.find((device) => normalizeUDID(device.deviceNumber) === normalizedUDID);
         log('Registered iPhone with Apple', normalizedUDID);
       }
       if (!portalDevice?.deviceId) throw new Error('Apple did not return a device ID after registration.');
@@ -317,22 +448,19 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
         relay,
         teamId: connection.teamId,
         secretStore,
-        certificateKind: profileKind === 'adhoc' ? 'distribution' : 'development',
+        certificateKind: 'distribution',
         commonName: naming.certificateCommonName(connection.teamId),
         log,
       });
       const created = await createAppleProfile({
         relay,
         teamId: connection.teamId,
-        profileKind,
+        profileKind: 'adhoc',
         bundleId: connection.bundleId,
         appIdId,
         certificateIds: [signingCertificate.certificateId],
         deviceIds: [portalDevice.deviceId],
-        name:
-          profileKind === 'adhoc' ?
-            naming.qrProfileName(connection.bundleId, normalizedUDID)
-          : naming.webUsbProfileName(connection.bundleId, normalizedUDID),
+        name: naming.profileName(connection.bundleId, normalizedUDID),
       });
       await saveAppleProfileSecret({
         relay,
@@ -344,15 +472,14 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
       setDeviceEnrollment({
         status: 'ready',
         deviceUDID: normalizedUDID,
-        profileKind,
-        note: `The iPhone is registered and covered by ${
-          profileKind === 'adhoc' ? 'ad-hoc' : 'development'
-        } signing.`,
+        note: 'The iPhone is registered and covered by ad-hoc signing.',
       });
+      await refreshSigning(connection);
+      setSelectedDevice({ udid: normalizedUDID, name: productName, covered: true });
       return true;
     } catch (error) {
-      const message = errorMessage(error, 'Could not prepare the selected iPhone');
-      setDeviceEnrollment({ status: 'error', deviceUDID: normalizedUDID, profileKind, note: message });
+      const message = errorMessage(error, 'Could not prepare the iPhone');
+      setDeviceEnrollment({ status: 'error', deviceUDID: normalizedUDID, note: message });
       onError(message);
       return false;
     } finally {
@@ -363,6 +490,9 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
   function disconnect() {
     localStorage.removeItem(CONNECTION_STORAGE_KEY);
     setConnection(undefined);
+    setSigning({ status: 'idle', certificateOk: false, profileCount: 0 });
+    setDevices([]);
+    setSelectedDevice(undefined);
     setDeviceEnrollment({ status: 'idle' });
     setTeams([]);
     setSelectedTeamId('');
@@ -400,6 +530,11 @@ export function useConnect({ secretStore, log, onError }: ConnectContext) {
     setAppName,
     confirm,
     connection,
+    signing,
+    refreshSigning,
+    devices,
+    selectedDevice,
+    selectDevice: setSelectedDevice,
     deviceEnrollment,
     prepareDevice,
     disconnect,

--- a/examples/device-install/frontend/src/hooks/useDeviceInstall.ts
+++ b/examples/device-install/frontend/src/hooks/useDeviceInstall.ts
@@ -89,7 +89,13 @@ export function useDeviceInstall({
     };
   }, [authorizationAttempt, authorizedInstallId, build.state, build.status?.id, log, onError]);
 
-  /** Creates the private OTA session for the authorized build's asset. */
+  /**
+   * Creates the private OTA session for the authorized build's asset. The
+   * registry defaults the manifest identity (bundle identifier, versions,
+   * title, deep link, icon) to the app metadata limbuild recorded on the
+   * asset at build time; the webhook fields are forwarded as explicit
+   * fallbacks for builds whose asset carries no metadata yet.
+   */
   function startQRInstall() {
     onError(undefined);
     const webhook = build.status?.webhook;
@@ -97,18 +103,14 @@ export function useDeviceInstall({
       onError('The built IPA is not authorized yet.');
       return;
     }
-    if (!webhook?.bundleIdentifier || !webhook.shortVersion || !webhook.buildVersion) {
-      onError('The build webhook did not include signed IPA metadata for an OTA manifest.');
-      return;
-    }
     log('Creating the private OTA install session');
     void ota
       .start({
         assetId: session.assetId,
-        bundleIdentifier: webhook.bundleIdentifier,
-        shortVersion: webhook.shortVersion,
-        buildVersion: webhook.buildVersion,
-        title: connect.connection?.appName || webhook.bundleIdentifier,
+        bundleIdentifier: webhook?.bundleIdentifier,
+        shortVersion: webhook?.shortVersion,
+        buildVersion: webhook?.buildVersion,
+        title: webhook?.displayName || connect.connection?.appName || webhook?.bundleIdentifier,
       })
       .then((created) => {
         if (created) log('OTA install page ready', created.installPageUrl);

--- a/examples/device-install/frontend/src/hooks/useDeviceInstall.ts
+++ b/examples/device-install/frontend/src/hooks/useDeviceInstall.ts
@@ -5,7 +5,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useOTAInstall } from '@limrun/device-install/react';
 import { errorMessage, fetchDeviceSession, sleep, type DeviceSession } from '../lib/backend';
-import type { ConnectController } from './useConnect';
 import type { InstallController } from './useInstall';
 
 export type ActivityEntry = { at: string; message: string; detail?: string };
@@ -13,11 +12,9 @@ export type AuthorizationState = 'idle' | 'authorizing' | 'ready' | 'failed';
 export type DeviceInstallController = ReturnType<typeof useDeviceInstall>;
 
 export function useDeviceInstall({
-  connect,
   build,
   onError,
 }: {
-  connect: ConnectController;
   build: InstallController;
   onError: (message?: string) => void;
 }) {
@@ -91,30 +88,20 @@ export function useDeviceInstall({
 
   /**
    * Creates the private OTA session for the authorized build's asset. The
-   * registry defaults the manifest identity (bundle identifier, versions,
-   * title, deep link, icon) to the app metadata limbuild recorded on the
-   * asset at build time; the webhook fields are forwarded as explicit
-   * fallbacks for builds whose asset carries no metadata yet.
+   * manifest identity (bundle identifier, versions, title, deep link, icon)
+   * all comes from the app metadata limbuild recorded on the asset at build
+   * time; only the asset ID is sent.
    */
   function startQRInstall() {
     onError(undefined);
-    const webhook = build.status?.webhook;
     if (authorization !== 'ready' || !session?.assetId) {
       onError('The built IPA is not authorized yet.');
       return;
     }
     log('Creating the private OTA install session');
-    void ota
-      .start({
-        assetId: session.assetId,
-        bundleIdentifier: webhook?.bundleIdentifier,
-        shortVersion: webhook?.shortVersion,
-        buildVersion: webhook?.buildVersion,
-        title: webhook?.displayName || connect.connection?.appName || webhook?.bundleIdentifier,
-      })
-      .then((created) => {
-        if (created) log('OTA install page ready', created.installPageUrl);
-      });
+    void ota.start({ assetId: session.assetId }).then((created) => {
+      if (created) log('OTA install page ready', created.installPageUrl);
+    });
   }
 
   function retryAuthorization() {

--- a/examples/device-install/frontend/src/hooks/useDeviceInstall.ts
+++ b/examples/device-install/frontend/src/hooks/useDeviceInstall.ts
@@ -1,11 +1,15 @@
+// QR/OTA installation of the built IPA. After the build webhook proves the
+// upload finished, the install ID is exchanged for a token scoped to exactly
+// that asset; the user then explicitly creates the private OTA session whose
+// install page URL becomes the QR code.
 import { useCallback, useEffect, useState } from 'react';
-import { useDeviceInstallRelay, useOTAInstall } from '@limrun/device-install/react';
+import { useOTAInstall } from '@limrun/device-install/react';
 import { errorMessage, fetchDeviceSession, sleep, type DeviceSession } from '../lib/backend';
 import type { ConnectController } from './useConnect';
 import type { InstallController } from './useInstall';
 
 export type ActivityEntry = { at: string; message: string; detail?: string };
-export type AutomaticInstallState = 'idle' | 'authorizing' | 'waiting' | 'installing' | 'started' | 'failed';
+export type AuthorizationState = 'idle' | 'authorizing' | 'ready' | 'failed';
 export type DeviceInstallController = ReturnType<typeof useDeviceInstall>;
 
 export function useDeviceInstall({
@@ -19,14 +23,13 @@ export function useDeviceInstall({
 }) {
   const [session, setSession] = useState<DeviceSession>();
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
-  const [installState, setInstallState] = useState<AutomaticInstallState>('idle');
+  const [authorization, setAuthorization] = useState<AuthorizationState>('idle');
   const [authorizedInstallId, setAuthorizedInstallId] = useState<string>();
   const [authorizationAttempt, setAuthorizationAttempt] = useState(0);
-  const [otaStartedInstallId, setOtaStartedInstallId] = useState<string>();
 
   // The one memoized callback in this hook: log's identity feeds the
-  // effects below and the library hooks, so a plain function would re-run
-  // them (and refetch the session) on every render.
+  // effects below, so a plain function would re-run them (and refetch the
+  // session) on every render.
   const log = useCallback((message: string, detail?: string) => {
     setActivity((current) => [...current, { at: new Date().toLocaleTimeString(), message, detail }]);
   }, []);
@@ -37,48 +40,21 @@ export function useDeviceInstall({
       .then((fresh) => {
         if (!cancelled) {
           setSession(fresh);
-          log('Device session ready', `expires at ${fresh.expiresAt}`);
+          log('Install session ready', `expires at ${fresh.expiresAt}`);
         }
       })
       .catch((caught: unknown) => {
-        if (!cancelled) onError(errorMessage(caught, 'Could not start the device session'));
+        if (!cancelled) onError(errorMessage(caught, 'Could not start the install session'));
       });
     return () => {
       cancelled = true;
     };
   }, [log, onError]);
 
-  const install = useDeviceInstallRelay({
-    registryApiUrl: session?.registryUrl,
-    token: session?.token,
-    log,
-  });
   const ota = useOTAInstall({
     registryApiUrl: session?.registryUrl,
     token: session?.token,
   });
-
-  async function prepareSelectedDevice(profileKind: 'development' | 'adhoc') {
-    onError(undefined);
-    const device = install.device;
-    if (!device) {
-      onError('Select an iPhone first.');
-      return false;
-    }
-    if (profileKind === 'development' && !install.hasPairRecord) {
-      onError('Pair the selected iPhone before preparing WebUSB signing.');
-      return false;
-    }
-    if (!device.hello.serialNumber) {
-      onError('The selected iPhone did not report a UDID.');
-      return false;
-    }
-    return connect.prepareDevice(
-      device.hello.serialNumber,
-      device.hello.productName ?? 'iPhone',
-      profileKind,
-    );
-  }
 
   // The successful webhook proves upload completion. Exchange only that
   // install ID for a token scoped to the exact uploaded asset.
@@ -86,7 +62,7 @@ export function useDeviceInstall({
     const installId = build.status?.id;
     if (build.state !== 'succeeded' || !installId || authorizedInstallId === installId) return;
     let cancelled = false;
-    setInstallState('authorizing');
+    setAuthorization('authorizing');
     void (async () => {
       let lastError: unknown;
       for (let attempt = 0; attempt < 10; attempt += 1) {
@@ -95,7 +71,7 @@ export function useDeviceInstall({
           if (cancelled) return;
           setSession(fresh);
           setAuthorizedInstallId(installId);
-          setInstallState(build.method === 'webusb' ? 'waiting' : 'started');
+          setAuthorization('ready');
           log('Exact-asset install session ready', fresh.assetName);
           return;
         } catch (caught) {
@@ -104,88 +80,52 @@ export function useDeviceInstall({
         }
       }
       if (!cancelled) {
-        setInstallState('failed');
+        setAuthorization('failed');
         onError(errorMessage(lastError, 'Could not authorize the built IPA'));
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [authorizationAttempt, authorizedInstallId, build.method, build.state, build.status?.id, log, onError]);
+  }, [authorizationAttempt, authorizedInstallId, build.state, build.status?.id, log, onError]);
 
-  useEffect(() => {
-    if (build.method !== 'webusb' || installState !== 'waiting' || !session?.assetId || !install.canInstall)
-      return;
-    setInstallState('installing');
-    void install.startInstallation({ assetId: session.assetId }).then((relay) => {
-      setInstallState(relay ? 'started' : 'failed');
-    });
-  }, [build.method, install, installState, session?.assetId]);
-
-  useEffect(() => {
-    const installId = build.status?.id;
-    if (
-      build.method !== 'qr' ||
-      build.state !== 'succeeded' ||
-      !installId ||
-      authorizedInstallId !== installId ||
-      otaStartedInstallId === installId ||
-      !session?.assetId
-    ) {
+  /** Creates the private OTA session for the authorized build's asset. */
+  function startQRInstall() {
+    onError(undefined);
+    const webhook = build.status?.webhook;
+    if (authorization !== 'ready' || !session?.assetId) {
+      onError('The built IPA is not authorized yet.');
       return;
     }
-    const webhook = build.status?.webhook;
     if (!webhook?.bundleIdentifier || !webhook.shortVersion || !webhook.buildVersion) {
-      setOtaStartedInstallId(installId);
       onError('The build webhook did not include signed IPA metadata for an OTA manifest.');
       return;
     }
-    setOtaStartedInstallId(installId);
-    void ota.start({
-      assetId: session.assetId,
-      bundleIdentifier: webhook.bundleIdentifier,
-      shortVersion: webhook.shortVersion,
-      buildVersion: webhook.buildVersion,
-      title: connect.connection?.appName || webhook.bundleIdentifier,
-    });
-  }, [
-    authorizedInstallId,
-    build.method,
-    build.state,
-    build.status,
-    connect.connection?.appName,
-    onError,
-    ota,
-    otaStartedInstallId,
-    session?.assetId,
-  ]);
-
-  function retryInstallation() {
-    onError(undefined);
-    install.clearError();
-    if (session?.assetId) {
-      setInstallState('waiting');
-    } else {
-      setAuthorizedInstallId(undefined);
-      setAuthorizationAttempt((current) => current + 1);
-    }
+    log('Creating the private OTA install session');
+    void ota
+      .start({
+        assetId: session.assetId,
+        bundleIdentifier: webhook.bundleIdentifier,
+        shortVersion: webhook.shortVersion,
+        buildVersion: webhook.buildVersion,
+        title: connect.connection?.appName || webhook.bundleIdentifier,
+      })
+      .then((created) => {
+        if (created) log('OTA install page ready', created.installPageUrl);
+      });
   }
 
-  const selectedUDID = install.device?.hello.serialNumber;
-  const enrollmentReady = (profileKind: 'development' | 'adhoc') =>
-    connect.deviceEnrollment.status === 'ready' &&
-    connect.deviceEnrollment.profileKind === profileKind &&
-    connect.deviceEnrollment.deviceUDID === selectedUDID?.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+  function retryAuthorization() {
+    onError(undefined);
+    setAuthorizedInstallId(undefined);
+    setAuthorizationAttempt((current) => current + 1);
+  }
 
   return {
-    install,
     ota,
     activity,
-    installState,
-    selectedUDID,
-    enrollmentReady,
-    prepareSelectedDevice,
-    retryInstallation,
-    retryOTA: () => setOtaStartedInstallId(undefined),
+    authorization,
+    startQRInstall,
+    retryAuthorization,
   };
 }

--- a/examples/device-install/frontend/src/hooks/useInstall.ts
+++ b/examples/device-install/frontend/src/hooks/useInstall.ts
@@ -5,7 +5,6 @@ import {
   sleep,
   startInstall,
   type InstallInput,
-  type InstallMethod,
   type InstallStatus,
 } from '../lib/backend';
 
@@ -14,27 +13,17 @@ export type InstallController = ReturnType<typeof useInstall>;
 const POLL_INTERVAL_MS = 3000;
 
 export function useInstall() {
-  const [method, setMethod] = useState<InstallMethod>('webusb');
   const [state, setState] = useState<InstallBuildState>('idle');
   const [status, setStatus] = useState<InstallStatus>();
   const [error, setError] = useState<string>();
 
-  // Polling runs inside build() rather than in an effect. Switching the
-  // install method bumps this sequence so an abandoned build's loop stops
-  // writing state; the build itself keeps running server-side.
+  // Polling runs inside build() rather than in an effect. Starting a new
+  // build bumps this sequence so an abandoned build's loop stops writing
+  // state; the build itself keeps running server-side.
   const buildSeq = useRef(0);
-
-  function selectMethod(selected: InstallMethod) {
-    buildSeq.current++;
-    setMethod(selected);
-    setState('idle');
-    setStatus(undefined);
-    setError(undefined);
-  }
 
   async function build(input: InstallInput) {
     const seq = ++buildSeq.current;
-    setMethod(input.method);
     setState('running');
     setStatus(undefined);
     setError(undefined);
@@ -60,5 +49,5 @@ export function useInstall() {
     }
   }
 
-  return { method, setMethod: selectMethod, state, status, error, build };
+  return { state, status, error, build };
 }

--- a/examples/device-install/frontend/src/lib/backend.ts
+++ b/examples/device-install/frontend/src/lib/backend.ts
@@ -133,9 +133,17 @@ export type BuildWebhookPayload = {
   buildDurationMs?: number;
   consoleUrl?: string;
   logsUrl?: string;
+  /** Limrun asset the artifact was uploaded to, when the build named one. */
+  assetId?: string;
   bundleIdentifier?: string;
   shortVersion?: string;
   buildVersion?: string;
+  /** App title users see on iOS: CFBundleDisplayName or CFBundleName. */
+  displayName?: string;
+  /** The app's primary URL scheme, e.g. "myapp" for myapp:// links. */
+  deeplink?: string;
+  /** Presigned URL for the app icon PNG stored next to the bundle asset. */
+  iconUrl?: string;
 };
 
 export type InstallStatus = {

--- a/examples/device-install/frontend/src/lib/backend.ts
+++ b/examples/device-install/frontend/src/lib/backend.ts
@@ -117,11 +117,8 @@ export function createBackendSecretStore(): SigningSecretStore {
   };
 }
 
-export type InstallMethod = 'webusb' | 'qr';
-
 export type InstallInput = {
   projectPath: string;
-  method: InstallMethod;
   teamId: string;
   bundleId: string;
   deviceUDID: string;
@@ -145,7 +142,6 @@ export type InstallStatus = {
   id: string;
   state: 'running' | 'succeeded' | 'failed';
   startedAt: string;
-  method: InstallMethod;
   deviceUDID: string;
   assetName: string;
   webhook?: BuildWebhookPayload;

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -14,7 +14,7 @@ export default class AssetPush extends BaseCommand {
     '<%= config.bin %> asset push ./app.apk',
     '<%= config.bin %> asset push ./app.ipa -n my-app',
     '<%= config.bin %> asset push ./app.ipa --ttl 24h',
-    '<%= config.bin %> asset push ./app.ipa --upload-options bundleIdentifier=com.example.app --upload-options buildVersion=42 --upload-options "displayName=My App"',
+    '<%= config.bin %> asset push ./app.ipa --upload-option bundleIdentifier=com.example.app --upload-option buildVersion=42 --upload-option "displayName=My App"',
   ];
 
   static args = {
@@ -27,7 +27,7 @@ export default class AssetPush extends BaseCommand {
     ttl: Flags.string({
       description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
     }),
-    'upload-options': Flags.string({
+    'upload-option': Flags.string({
       multiple: true,
       description:
         'App metadata to record on the asset as key=value, repeatable. Keys: displayName, bundleIdentifier, shortVersion, buildVersion, deeplink. All optional; consumers like over-the-air installation use whichever are present.',
@@ -46,7 +46,7 @@ export default class AssetPush extends BaseCommand {
     const assetName = flags.name || path.basename(filePath);
     let uploadOptions;
     try {
-      uploadOptions = parseUploadOptions(flags['upload-options']);
+      uploadOptions = parseUploadOptions(flags['upload-option']);
     } catch (err) {
       this.error(err instanceof Error ? err.message : String(err));
     }

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { ByteProgressBar } from '../../lib/byte-progress';
+import { parseUploadOptions } from '../../lib/upload-options';
 
 export default class AssetPush extends BaseCommand {
   static summary = 'Upload an asset file';
@@ -13,6 +14,7 @@ export default class AssetPush extends BaseCommand {
     '<%= config.bin %> asset push ./app.apk',
     '<%= config.bin %> asset push ./app.ipa -n my-app',
     '<%= config.bin %> asset push ./app.ipa --ttl 24h',
+    '<%= config.bin %> asset push ./app.ipa --upload-options bundleIdentifier=com.example.app --upload-options buildVersion=42 --upload-options "displayName=My App"',
   ];
 
   static args = {
@@ -24,6 +26,11 @@ export default class AssetPush extends BaseCommand {
     name: Flags.string({ char: 'n', description: 'Asset name to store. Defaults to the source filename.' }),
     ttl: Flags.string({
       description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+    }),
+    'upload-options': Flags.string({
+      multiple: true,
+      description:
+        'App metadata to record on the asset as key=value, repeatable. Keys: displayName, bundleIdentifier, shortVersion, buildVersion, deeplink. Over-the-air installation of hand-uploaded IPAs requires at least bundleIdentifier and buildVersion.',
     }),
   };
 
@@ -37,6 +44,12 @@ export default class AssetPush extends BaseCommand {
     }
 
     const assetName = flags.name || path.basename(filePath);
+    let uploadOptions;
+    try {
+      uploadOptions = parseUploadOptions(flags['upload-options']);
+    } catch (err) {
+      this.error(err instanceof Error ? err.message : String(err));
+    }
     await this.withAuth(async () => {
       // Only opt into the streaming upload path when progress would actually be
       // reported (bar on a TTY, milestone lines otherwise); --json/--quiet keeps
@@ -49,6 +62,7 @@ export default class AssetPush extends BaseCommand {
           path: filePath,
           name: assetName,
           ttl: flags.ttl,
+          ...(uploadOptions && { uploadOptions }),
           ...(showProgress && {
             onUploadProgress: (uploadedBytes: number, totalBytes: number) =>
               bar.update(uploadedBytes, totalBytes),

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -30,7 +30,7 @@ export default class AssetPush extends BaseCommand {
     'upload-options': Flags.string({
       multiple: true,
       description:
-        'App metadata to record on the asset as key=value, repeatable. Keys: displayName, bundleIdentifier, shortVersion, buildVersion, deeplink. Over-the-air installation of hand-uploaded IPAs requires at least bundleIdentifier and buildVersion.',
+        'App metadata to record on the asset as key=value, repeatable. Keys: displayName, bundleIdentifier, shortVersion, buildVersion, deeplink. All optional; consumers like over-the-air installation use whichever are present.',
     }),
   };
 

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -9,6 +9,7 @@ import { cacheFlags } from '../../lib/cache-flags';
 import { parseAdditionalFileFlags } from '../../lib/additional-files';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
 import { webhookConfigFromFlags } from '../../lib/webhook-options';
+import { parseUploadOptions } from '../../lib/upload-options';
 import {
   cloudSigningFlagsProblem,
   hasCloudSigningFlags,
@@ -132,6 +133,12 @@ export default class XcodeBuild extends BaseCommand {
         'Relative path from the synced workspace root to the Expo app directory. Use for monorepos or ambiguous React Native workspaces.',
     }),
     upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
+    'upload-options': Flags.string({
+      multiple: true,
+      dependsOn: ['upload'],
+      description:
+        'App metadata to record on the uploaded asset as key=value, repeatable. Keys: displayName, bundleIdentifier, shortVersion, buildVersion, deeplink. limbuild extracts the same metadata from the built bundle and overwrites it; values set here survive only for fields the bundle does not declare (e.g. deeplink).',
+    }),
     'signed-upload-url': Flags.string({
       description: 'Presigned URL to upload the resulting build artifact to.',
     }),
@@ -348,7 +355,13 @@ export default class XcodeBuild extends BaseCommand {
         this.error('Use either --upload or --signed-upload-url, not both.');
       }
       if (flags.upload) {
-        options.upload = { assetName: flags.upload };
+        let uploadOptions;
+        try {
+          uploadOptions = parseUploadOptions(flags['upload-options']);
+        } catch (err) {
+          this.error(err instanceof Error ? err.message : String(err));
+        }
+        options.upload = { assetName: flags.upload, ...(uploadOptions && { uploadOptions }) };
       } else if (flags['signed-upload-url']) {
         options.upload = {
           signedUploadUrl: flags['signed-upload-url'],

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -133,7 +133,7 @@ export default class XcodeBuild extends BaseCommand {
         'Relative path from the synced workspace root to the Expo app directory. Use for monorepos or ambiguous React Native workspaces.',
     }),
     upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
-    'upload-options': Flags.string({
+    'upload-option': Flags.string({
       multiple: true,
       dependsOn: ['upload'],
       description:
@@ -357,7 +357,7 @@ export default class XcodeBuild extends BaseCommand {
       if (flags.upload) {
         let uploadOptions;
         try {
-          uploadOptions = parseUploadOptions(flags['upload-options']);
+          uploadOptions = parseUploadOptions(flags['upload-option']);
         } catch (err) {
           this.error(err instanceof Error ? err.message : String(err));
         }

--- a/packages/cli/src/lib/upload-options.ts
+++ b/packages/cli/src/lib/upload-options.ts
@@ -1,0 +1,36 @@
+import type { AssetUploadOptions } from '@limrun/api';
+
+const uploadOptionKeys = [
+  'displayName',
+  'bundleIdentifier',
+  'shortVersion',
+  'buildVersion',
+  'deeplink',
+] as const;
+
+/**
+ * Parses repeated --upload-options key=value flags into the app metadata
+ * recorded on the uploaded asset. The registry's OTA install flow reads the
+ * manifest identity from these fields, so hand-uploaded IPAs need at least
+ * bundleIdentifier and buildVersion to be installable over the air.
+ */
+export function parseUploadOptions(values?: string[]): AssetUploadOptions | undefined {
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+  const options: AssetUploadOptions = {};
+  for (const value of values) {
+    const separator = value.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(`--upload-options must be key=value, got ${JSON.stringify(value)}`);
+    }
+    const key = value.slice(0, separator) as (typeof uploadOptionKeys)[number];
+    if (!uploadOptionKeys.includes(key)) {
+      throw new Error(
+        `--upload-options key must be one of ${uploadOptionKeys.join(', ')}, got ${JSON.stringify(key)}`,
+      );
+    }
+    options[key] = value.slice(separator + 1);
+  }
+  return options;
+}

--- a/packages/cli/src/lib/upload-options.ts
+++ b/packages/cli/src/lib/upload-options.ts
@@ -9,7 +9,7 @@ const uploadOptionKeys = [
 ] as const;
 
 /**
- * Parses repeated --upload-options key=value flags into the app metadata
+ * Parses repeated --upload-option key=value flags into the app metadata
  * recorded on the uploaded asset. All fields are optional; consumers like
  * the registry's OTA install flow use whichever are present.
  */
@@ -21,12 +21,12 @@ export function parseUploadOptions(values?: string[]): AssetUploadOptions | unde
   for (const value of values) {
     const separator = value.indexOf('=');
     if (separator <= 0) {
-      throw new Error(`--upload-options must be key=value, got ${JSON.stringify(value)}`);
+      throw new Error(`--upload-option must be key=value, got ${JSON.stringify(value)}`);
     }
     const key = value.slice(0, separator) as (typeof uploadOptionKeys)[number];
     if (!uploadOptionKeys.includes(key)) {
       throw new Error(
-        `--upload-options key must be one of ${uploadOptionKeys.join(', ')}, got ${JSON.stringify(key)}`,
+        `--upload-option key must be one of ${uploadOptionKeys.join(', ')}, got ${JSON.stringify(key)}`,
       );
     }
     options[key] = value.slice(separator + 1);

--- a/packages/cli/src/lib/upload-options.ts
+++ b/packages/cli/src/lib/upload-options.ts
@@ -10,9 +10,8 @@ const uploadOptionKeys = [
 
 /**
  * Parses repeated --upload-options key=value flags into the app metadata
- * recorded on the uploaded asset. The registry's OTA install flow reads the
- * manifest identity from these fields, so hand-uploaded IPAs need at least
- * bundleIdentifier and buildVersion to be installable over the air.
+ * recorded on the uploaded asset. All fields are optional; consumers like
+ * the registry's OTA install flow use whichever are present.
  */
 export function parseUploadOptions(values?: string[]): AssetUploadOptions | undefined {
   if (!values || values.length === 0) {

--- a/packages/device-install/src/ota.test.ts
+++ b/packages/device-install/src/ota.test.ts
@@ -16,10 +16,7 @@ describe('OTA installation API', () => {
       token: 'scoped-token',
       organizationId: 'org_1',
       assetId: 'asset_1',
-      bundleIdentifier: 'com.example.app',
-      shortVersion: '1.2.3',
-      buildVersion: '42',
-      title: 'Example',
+      deepLinkOnCompletion: 'myapp://home',
       ttlSeconds: 900,
       fetch,
     });
@@ -32,37 +29,12 @@ describe('OTA installation API', () => {
       Authorization: 'Bearer scoped-token',
       'X-Limrun-Organization': 'org_1',
     });
+    // The app identity (bundle identifier, versions, title, icon) is never
+    // sent; the registry reads it from the metadata recorded on the asset.
     expect(JSON.parse(String(init.body))).toEqual({
       assetId: 'asset_1',
-      bundleIdentifier: 'com.example.app',
-      shortVersion: '1.2.3',
-      buildVersion: '42',
-      title: 'Example',
+      deepLinkOnCompletion: 'myapp://home',
       ttlSeconds: 900,
-    });
-  });
-
-  it('creates a session with just the asset id, deferring identity to asset metadata', async () => {
-    const payload = {
-      id: 'session_2',
-      installPageUrl: 'https://registry.example/ios/ota/sessions/session_2?k=signed',
-      statusUrl: 'https://registry.example/ios/ota/sessions/session_2/status?k=signed',
-      expiresAt: '2026-07-25T12:00:00Z',
-    };
-    const fetch = vi.fn(async () => Response.json(payload, { status: 201 }));
-    await createOTAInstallSession({
-      registryApiUrl: 'https://registry.example',
-      token: 'scoped-token',
-      assetId: 'asset_1',
-      deepLink: 'myapp://home',
-      fetch,
-    });
-    const [, init] = fetch.mock.calls[0]!;
-    // Omitted fields must stay out of the body so the registry falls back to
-    // the metadata limbuild recorded on the asset.
-    expect(JSON.parse(String(init.body))).toEqual({
-      assetId: 'asset_1',
-      deepLink: 'myapp://home',
     });
   });
 
@@ -97,10 +69,6 @@ describe('OTA installation API', () => {
         registryApiUrl: 'https://registry.example',
         token: 'token',
         assetId: 'asset_2',
-        bundleIdentifier: 'com.example.app',
-        shortVersion: '1.0',
-        buildVersion: '1',
-        title: 'Example',
         fetch,
       }),
     ).rejects.toThrow('asset scope does not cover the requested asset');

--- a/packages/device-install/src/ota.test.ts
+++ b/packages/device-install/src/ota.test.ts
@@ -42,6 +42,30 @@ describe('OTA installation API', () => {
     });
   });
 
+  it('creates a session with just the asset id, deferring identity to asset metadata', async () => {
+    const payload = {
+      id: 'session_2',
+      installPageUrl: 'https://registry.example/ios/ota/sessions/session_2?k=signed',
+      statusUrl: 'https://registry.example/ios/ota/sessions/session_2/status?k=signed',
+      expiresAt: '2026-07-25T12:00:00Z',
+    };
+    const fetch = vi.fn(async () => Response.json(payload, { status: 201 }));
+    await createOTAInstallSession({
+      registryApiUrl: 'https://registry.example',
+      token: 'scoped-token',
+      assetId: 'asset_1',
+      deepLink: 'myapp://home',
+      fetch,
+    });
+    const [, init] = fetch.mock.calls[0]!;
+    // Omitted fields must stay out of the body so the registry falls back to
+    // the metadata limbuild recorded on the asset.
+    expect(JSON.parse(String(init.body))).toEqual({
+      assetId: 'asset_1',
+      deepLink: 'myapp://home',
+    });
+  });
+
   it('fetches status from the sticky capability URL without bearer credentials', async () => {
     const payload = {
       id: 'session_1',

--- a/packages/device-install/src/ota.ts
+++ b/packages/device-install/src/ota.ts
@@ -21,32 +21,19 @@ export type CreateOTAInstallSessionOptions = {
   registryApiUrl: string;
   token: string;
   organizationId?: string;
+  /**
+   * The signed IPA asset to install. Its recorded app metadata (bundle
+   * identifier, versions, title, deep link scheme, icon) drives the whole
+   * install flow; limbuild records it at build time, or set it when
+   * uploading the asset.
+   */
   assetId: string;
-  /**
-   * CFBundleIdentifier of the signed IPA. Defaults to the metadata limbuild
-   * recorded on the asset at build time; required only when the asset
-   * carries none (e.g. a hand-uploaded IPA).
-   */
-  bundleIdentifier?: string;
-  /** CFBundleShortVersionString. Defaults to the asset's recorded metadata. */
-  shortVersion?: string;
-  /**
-   * CFBundleVersion. Defaults to the asset's recorded metadata; required
-   * only when the asset carries none.
-   */
-  buildVersion?: string;
-  /**
-   * App title shown on the install page and in the iOS install prompt.
-   * Defaults to the display name recorded on the asset, then to the bundle
-   * identifier.
-   */
-  title?: string;
   /**
    * URL the install page's Open button launches once the app is installed,
    * e.g. an Expo dev client URL. Defaults to the asset's recorded primary
    * URL scheme.
    */
-  deepLink?: string;
+  deepLinkOnCompletion?: string;
   ttlSeconds?: number;
   signal?: AbortSignal;
   fetch?: typeof globalThis.fetch;
@@ -63,11 +50,7 @@ export async function createOTAInstallSession({
   token,
   organizationId,
   assetId,
-  bundleIdentifier,
-  shortVersion,
-  buildVersion,
-  title,
-  deepLink,
+  deepLinkOnCompletion,
   ttlSeconds,
   signal,
   fetch: fetchImplementation = globalThis.fetch,
@@ -87,11 +70,7 @@ export async function createOTAInstallSession({
     headers,
     body: JSON.stringify({
       assetId,
-      ...(bundleIdentifier === undefined ? {} : { bundleIdentifier }),
-      ...(shortVersion === undefined ? {} : { shortVersion }),
-      ...(buildVersion === undefined ? {} : { buildVersion }),
-      ...(title === undefined ? {} : { title }),
-      ...(deepLink === undefined ? {} : { deepLink }),
+      ...(deepLinkOnCompletion === undefined ? {} : { deepLinkOnCompletion }),
       ...(ttlSeconds === undefined ? {} : { ttlSeconds }),
     }),
     signal,

--- a/packages/device-install/src/ota.ts
+++ b/packages/device-install/src/ota.ts
@@ -22,10 +22,31 @@ export type CreateOTAInstallSessionOptions = {
   token: string;
   organizationId?: string;
   assetId: string;
-  bundleIdentifier: string;
-  shortVersion: string;
-  buildVersion: string;
-  title: string;
+  /**
+   * CFBundleIdentifier of the signed IPA. Defaults to the metadata limbuild
+   * recorded on the asset at build time; required only when the asset
+   * carries none (e.g. a hand-uploaded IPA).
+   */
+  bundleIdentifier?: string;
+  /** CFBundleShortVersionString. Defaults to the asset's recorded metadata. */
+  shortVersion?: string;
+  /**
+   * CFBundleVersion. Defaults to the asset's recorded metadata; required
+   * only when the asset carries none.
+   */
+  buildVersion?: string;
+  /**
+   * App title shown on the install page and in the iOS install prompt.
+   * Defaults to the display name recorded on the asset, then to the bundle
+   * identifier.
+   */
+  title?: string;
+  /**
+   * URL the install page's Open button launches once the app is installed,
+   * e.g. an Expo dev client URL. Defaults to the asset's recorded primary
+   * URL scheme.
+   */
+  deepLink?: string;
   ttlSeconds?: number;
   signal?: AbortSignal;
   fetch?: typeof globalThis.fetch;
@@ -46,6 +67,7 @@ export async function createOTAInstallSession({
   shortVersion,
   buildVersion,
   title,
+  deepLink,
   ttlSeconds,
   signal,
   fetch: fetchImplementation = globalThis.fetch,
@@ -65,10 +87,11 @@ export async function createOTAInstallSession({
     headers,
     body: JSON.stringify({
       assetId,
-      bundleIdentifier,
-      shortVersion,
-      buildVersion,
-      title,
+      ...(bundleIdentifier === undefined ? {} : { bundleIdentifier }),
+      ...(shortVersion === undefined ? {} : { shortVersion }),
+      ...(buildVersion === undefined ? {} : { buildVersion }),
+      ...(title === undefined ? {} : { title }),
+      ...(deepLink === undefined ? {} : { deepLink }),
       ...(ttlSeconds === undefined ? {} : { ttlSeconds }),
     }),
     signal,

--- a/packages/device-install/src/react.test.tsx
+++ b/packages/device-install/src/react.test.tsx
@@ -60,13 +60,7 @@ describe('useOTAInstall', () => {
       renderer = create(<Harness />);
     });
     await act(async () => {
-      await hook!.start({
-        assetId: 'asset_1',
-        bundleIdentifier: 'com.example.app',
-        shortVersion: '1.2.3',
-        buildVersion: '42',
-        title: 'Example',
-      });
+      await hook!.start({ assetId: 'asset_1' });
       await Promise.resolve();
     });
     expect(hook!.status?.state).toBe('downloading');
@@ -119,13 +113,7 @@ describe('useOTAInstall', () => {
     await act(async () => {
       renderer = create(<Harness />);
     });
-    const input = {
-      assetId: 'asset_1',
-      bundleIdentifier: 'com.example.app',
-      shortVersion: '1.2.3',
-      buildVersion: '42',
-      title: 'Example',
-    };
+    const input = { assetId: 'asset_1' };
     await act(async () => {
       await hook!.start(input);
     });

--- a/packages/device-install/src/react.ts
+++ b/packages/device-install/src/react.ts
@@ -225,7 +225,9 @@ export function useOTAInstall({
   registryApiUrl,
   token,
   organizationId,
-  pollIntervalMs = 750,
+  // Matches the registry's install page, which also polls its status once
+  // per second.
+  pollIntervalMs = 1000,
 }: UseOTAInstallOptions): UseOTAInstallResult {
   const [session, setSession] = useState<OTAInstallSession | undefined>();
   const [status, setStatus] = useState<OTAInstallStatus | undefined>();

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -50,6 +50,13 @@ export type XcodeBuildExecRequest = {
   buildSettings?: Record<string, string>;
   gitInit?: boolean;
   signedUploadUrl?: string;
+  /**
+   * ID of the Limrun asset signedUploadUrl targets, when it was minted from
+   * one. Lets limbuild record the built app's metadata (title, bundle
+   * identifier, versions, deep link scheme, icon) on the asset, which the
+   * registry's OTA install flow reads. Older limbuild servers ignore it.
+   */
+  assetId?: string;
   webhook?: WebhookConfig;
   additionalMetadata?: {
     signedDownloadUrl?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export {
   type GradleBuildOptions,
   type GradleBuildLog,
 } from './resources/gradle-instances-helpers';
+export { type AssetUploadOptions } from './resources/daemon-client-shared';
 export {
   LIMRUN_DIR,
   TRY_IMPORT_LINE,

--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -5,6 +5,7 @@ import { promises as fs } from 'fs';
 import { RequestOptions } from '../internal/request-options';
 import { nodeProxyTransport } from '../internal/proxy-transport';
 import { Assets as GeneratedAssets, type AssetKind, type AssetPlatform } from './assets';
+import type { AssetUploadOptions } from './daemon-client-shared';
 
 export interface AssetGetOrUploadParams {
   /**
@@ -40,6 +41,13 @@ export interface AssetGetOrUploadParams {
    * and the upload is skipped.
    */
   onUploadProgress?: (uploadedBytes: number, totalBytes: number) => void;
+
+  /**
+   * App metadata to record on the asset (title, bundle identifier, versions,
+   * deep link scheme), for bundles that don't go through limbuild. The
+   * registry's OTA install flow reads the manifest identity from it.
+   */
+  uploadOptions?: AssetUploadOptions;
 }
 
 export interface AssetGetOrUploadResponse {
@@ -94,6 +102,7 @@ export class Assets extends GeneratedAssets {
         kind: body.kind ?? 'App',
         ...(body.platform && { platform: body.platform }),
         ...(body.ttl && { ttl: body.ttl }),
+        ...body.uploadOptions,
       },
       options,
     );

--- a/src/resources/assets.ts
+++ b/src/resources/assets.ts
@@ -197,8 +197,8 @@ export interface AssetGetOrCreateParams {
   displayName?: string;
 
   /**
-   * CFBundleIdentifier of the uploaded app bundle. Required for over-the-air
-   * installation of hand-uploaded IPAs.
+   * CFBundleIdentifier of the uploaded app bundle. Used by over-the-air
+   * installation when present.
    */
   bundleIdentifier?: string;
 
@@ -208,8 +208,8 @@ export interface AssetGetOrCreateParams {
   shortVersion?: string;
 
   /**
-   * CFBundleVersion of the uploaded app bundle, e.g. 42. Required for
-   * over-the-air installation of hand-uploaded IPAs.
+   * CFBundleVersion of the uploaded app bundle, e.g. 42. Used by
+   * over-the-air installation when present.
    */
   buildVersion?: string;
 

--- a/src/resources/assets.ts
+++ b/src/resources/assets.ts
@@ -188,6 +188,37 @@ export interface AssetGetOrCreateParams {
    * current expiry unchanged.
    */
   ttl?: string;
+
+  /**
+   * Human-readable app title for the uploaded bundle, as users see it on iOS.
+   * Builds through limbuild record it automatically from the bundle's
+   * Info.plist; set it here for hand-uploaded bundles.
+   */
+  displayName?: string;
+
+  /**
+   * CFBundleIdentifier of the uploaded app bundle. Required for over-the-air
+   * installation of hand-uploaded IPAs.
+   */
+  bundleIdentifier?: string;
+
+  /**
+   * CFBundleShortVersionString of the uploaded app bundle, e.g. 1.2.3.
+   */
+  shortVersion?: string;
+
+  /**
+   * CFBundleVersion of the uploaded app bundle, e.g. 42. Required for
+   * over-the-air installation of hand-uploaded IPAs.
+   */
+  buildVersion?: string;
+
+  /**
+   * The app's primary URL scheme, e.g. "myapp" for myapp:// deep links.
+   * Consumers such as the registry's OTA install page use it to offer an Open
+   * button after installation.
+   */
+  deeplink?: string;
 }
 
 export type AssetKind = 'App' | 'Keychain';

--- a/src/resources/daemon-client-shared.ts
+++ b/src/resources/daemon-client-shared.ts
@@ -68,18 +68,39 @@ export type SyncResult = {
   stopWatching?: () => Promise<void>;
 };
 
-export type AssetUploadUrls = { signedUploadUrl: string; signedDownloadUrl: string };
+export type AssetUploadUrls = { id: string; signedUploadUrl: string; signedDownloadUrl: string };
+
+/**
+ * App metadata recorded on the asset at upload time, for bundles that don't
+ * go through limbuild (which extracts and records it automatically). The
+ * registry's OTA install flow reads the manifest identity from these fields.
+ */
+export type AssetUploadOptions = {
+  /** Human-readable app title users see on iOS. */
+  displayName?: string;
+  /** CFBundleIdentifier of the uploaded app bundle. */
+  bundleIdentifier?: string;
+  /** CFBundleShortVersionString, e.g. 1.2.3. */
+  shortVersion?: string;
+  /** CFBundleVersion, e.g. 42. */
+  buildVersion?: string;
+  /** The app's primary URL scheme, e.g. "myapp" for myapp:// deep links. */
+  deeplink?: string;
+};
 
 /**
  * Mints presigned upload/download URLs for a named asset via assets.getOrCreate,
  * wrapping failures with the asset name (and the original error as cause).
  */
 export function mintAssetUploadUrls(
-  assets: { getOrCreate: (body: { name: string; ttl?: string }) => Promise<AssetUploadUrls> },
+  assets: {
+    getOrCreate: (body: { name: string; ttl?: string } & AssetUploadOptions) => Promise<AssetUploadUrls>;
+  },
   name: string,
   ttl?: string,
+  uploadOptions?: AssetUploadOptions,
 ): Promise<AssetUploadUrls> {
-  return assets.getOrCreate({ name, ...(ttl && { ttl }) }).catch((err) => {
+  return assets.getOrCreate({ name, ...(ttl && { ttl }), ...uploadOptions }).catch((err) => {
     const message = `Failed to create upload URL for asset '${name}': ${
       err instanceof Error ? err.message : err
     }`;

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -33,6 +33,7 @@ import {
   createDaemonLogger,
   deriveBasisCache,
   mintAssetUploadUrls,
+  type AssetUploadOptions,
   type BuildLog,
   type LogLevel,
   type SyncResult,
@@ -175,7 +176,18 @@ export type ReactNativeBuildConfig = {
 };
 
 export type XcodeBuildOptions = {
-  upload?: { assetName: string } | { signedUploadUrl: string };
+  upload?:
+    | {
+        assetName: string;
+        /**
+         * App metadata to record on the asset up front. limbuild extracts
+         * the same metadata from the built bundle after the build and
+         * overwrites whatever it found; values set here survive only for
+         * fields the bundle doesn't declare (e.g. a deep link scheme).
+         */
+        uploadOptions?: AssetUploadOptions;
+      }
+    | { signedUploadUrl: string };
   signing?: XcodeSigningConfig;
   cloudSigning?: XcodeCloudSigningConfig;
   /**
@@ -806,13 +818,18 @@ export class XcodeInstances extends GeneratedXcodeInstances {
         };
 
         if (options?.upload && 'assetName' in options.upload) {
-          const requestPromise = mintAssetUploadUrls(client.assets, options.upload.assetName).then(
-            (asset) => {
-              request.signedUploadUrl = asset.signedUploadUrl;
-              request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
-              return request;
-            },
-          );
+          const requestPromise = mintAssetUploadUrls(
+            client.assets,
+            options.upload.assetName,
+            undefined,
+            options.upload.uploadOptions,
+          ).then((asset) => {
+            request.signedUploadUrl = asset.signedUploadUrl;
+            // Lets limbuild record the built app's metadata on the asset.
+            request.assetId = asset.id;
+            request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
+            return request;
+          });
           return exec(requestPromise, { apiUrl, token, log });
         }
 


### PR DESCRIPTION
## Summary

- Restructures the example into four stages optimized for QR/OTA installation: **1. Ad-hoc signing** starts from the secret store — when the distribution certificate and an ad-hoc profile for the stored team/bundle already exist, no Apple sign-in is shown at all; **2. Target iPhone** lists registered devices from the stored profiles (plus the portal when signed in) with a continue action, and uses WebUSB only to read a newly plugged-in iPhone's UDID (USB serial) for registration — no pairing, no relay session; **3. Build** is a single ad-hoc-signed build (the `method` concept is removed from frontend and backend); **4. Install via QR** replaces the auto-start effects with an explicit "Create QR install" button — the QR encodes the registry's private install page URL, where the phone taps Install to fire the itms deeplink, while the desktop polls status for delivered bytes.
- Removes the development-certificate build path, the USB installation path (`useDeviceInstallRelay`, `pairBrowser`, `startInstallation`), and the pairing UI. The exact-asset scoped-token exchange after the build webhook is unchanged and now gates OTA session creation.
- No changes to `@limrun/device-install` or `@limrun/apple-auth`; the example uses their existing exports.

Depends on limrun-inc/limrun#583 (registry itms OTA sessions) being deployed for stage 4 to work end to end.

## Test plan

- [x] `./scripts/lint` (prettier, eslint, build, tsc, attw, publint)
- [x] `tsc -b && vite build` in the example frontend; `tsc -b` in the example backend; example frontend `eslint .`
- [x] `yarn --cwd packages/device-install test` (OTA client contract suite)
- [ ] After the limrun PR deploys: full manual run — fresh secrets dir, sign in, register an iPhone via WebUSB, build, scan the QR, install

Made with [Cursor](https://cursor.com)