### PR TITLE
Add upload name and TTL build flags

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -449,7 +449,7 @@ lim xcode run -- make api
 lim xcode build ./MyProject --scheme MyApp --upload my-app-build --upload-ttl 24h
 
 # Select the built product when its name differs from the scheme
-lim xcode build ./MyProject --scheme "Hubble Dev" --artifact-name Hubble-dev --upload hubble-dev-build
+lim xcode build ./MyProject --scheme "Hubble Dev" --upload-name Hubble-dev --upload hubble-dev-build
 
 # Build with app config values available as Xcode build settings
 lim xcode build ./MyProject --scheme MyApp --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"
@@ -700,7 +700,7 @@ lim asset pull my-app-build -o ./build-output
 
 `lim xcode build [PATH]` automatically performs a one-shot code sync for the given project path before invoking `xcodebuild`. The sync step automatically ignores build artifacts (`build/`, `DerivedData/`, `.build/`), dependency folders (`Pods/`, `Carthage/Build/`, `.swiftpm/`), and user-specific files (`xcuserdata/`, `.dSYM/`).
 
-`--upload` names the destination asset. If the built `.app` name differs from the scheme, pass its product name with `--artifact-name` (the `.app` suffix is optional). `--upload-ttl` sets an expiry for named assets using a Go duration such as `24h` or `30m`.
+`--upload` names the destination asset. If the built `.app` name differs from the scheme, pass its product name with `--upload-name` (the `.app` suffix is optional). `--upload-ttl` sets an expiry for named assets using a Go duration such as `24h` or `30m`.
 
 For headless CI-style builds, pass `--detach --webhook-url <url>`. The command still creates or resolves the instance and syncs the project, but returns as soon as limbuild accepts the build rather than holding an SSE log stream open until completion. `--detach` requires a webhook so the terminal result remains observable. Pass `--inactivity-timeout <duration>` (for example `3s`) to skip any cached Xcode target and create a fresh one-shot instance with that timeout; it cannot be combined with `--id`. Active builds continually report activity, so a short timeout only starts expiring once build work stops. The inactivity controller checks approximately every 15 seconds, so actual teardown can lag the configured timeout by that interval.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -445,8 +445,11 @@ lim xcode build ./MyProject --scheme MyApp --workspace MyApp.xcworkspace
 # Run a project command (syncs the current directory first)
 lim xcode run -- make api
 
-# Build and upload artifact
-lim xcode build ./MyProject --scheme MyApp --upload my-app-build
+# Build and upload artifact with a 24-hour TTL
+lim xcode build ./MyProject --scheme MyApp --upload my-app-build --upload-ttl 24h
+
+# Select the built product when its name differs from the scheme
+lim xcode build ./MyProject --scheme "Hubble Dev" --artifact-name Hubble-dev --upload hubble-dev-build
 
 # Build with app config values available as Xcode build settings
 lim xcode build ./MyProject --scheme MyApp --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"
@@ -684,7 +687,7 @@ lim xcode attach-simulator ios_abc123 --id sandbox_def456
 lim xcode build ./MyProject --scheme MyApp --workspace MyApp.xcworkspace
 
 # 4. Upload build artifact
-lim xcode build ./MyProject --scheme MyApp --upload my-app-build
+lim xcode build ./MyProject --scheme MyApp --upload my-app-build --upload-ttl 24h
 
 # Signed device builds default to --sdk iphoneos when signing assets are provided
 lim xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa
@@ -696,6 +699,8 @@ lim asset pull my-app-build -o ./build-output
 #### Build Behavior
 
 `lim xcode build [PATH]` automatically performs a one-shot code sync for the given project path before invoking `xcodebuild`. The sync step automatically ignores build artifacts (`build/`, `DerivedData/`, `.build/`), dependency folders (`Pods/`, `Carthage/Build/`, `.swiftpm/`), and user-specific files (`xcuserdata/`, `.dSYM/`).
+
+`--upload` names the destination asset. If the built `.app` name differs from the scheme, pass its product name with `--artifact-name` (the `.app` suffix is optional). `--upload-ttl` sets an expiry for named assets using a Go duration such as `24h` or `30m`.
 
 For headless CI-style builds, pass `--detach --webhook-url <url>`. The command still creates or resolves the instance and syncs the project, but returns as soon as limbuild accepts the build rather than holding an SSE log stream open until completion. `--detach` requires a webhook so the terminal result remains observable. Pass `--inactivity-timeout <duration>` (for example `3s`) to skip any cached Xcode target and create a fresh one-shot instance with that timeout; it cannot be combined with `--id`. Active builds continually report activity, so a short timeout only starts expiring once build work stops. The inactivity controller checks approximately every 15 seconds, so actual teardown can lag the configured timeout by that interval.
 

--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -25,7 +25,7 @@ export default class GradleBuild extends BaseCommand {
 
   static examples = [
     '<%= config.bin %> gradle build',
-    '<%= config.bin %> gradle build ./my-app --artifact-name app-dev-debug.apk --upload myapp.apk --upload-ttl 24h',
+    '<%= config.bin %> gradle build ./my-app --upload-name app-dev-debug.apk --upload myapp.apk --upload-ttl 24h',
     '<%= config.bin %> gradle build --task bundleRelease',
     '<%= config.bin %> gradle build --id <gradle-instance-ID> --project-path android',
     '<%= config.bin %> gradle build ./my-monorepo --expo-app-dir apps/mobile',
@@ -75,7 +75,7 @@ export default class GradleBuild extends BaseCommand {
       description:
         'Delete the named --upload asset after this Go duration (for example 24h or 30m). Omit for no expiry.',
     }),
-    'artifact-name': Flags.string({
+    'upload-name': Flags.string({
       description:
         'Exact APK or AAB filename to upload when the build produces multiple artifacts, for example app-prod-release.aab.',
     }),

--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -25,7 +25,7 @@ export default class GradleBuild extends BaseCommand {
 
   static examples = [
     '<%= config.bin %> gradle build',
-    '<%= config.bin %> gradle build ./my-app --upload myapp.apk',
+    '<%= config.bin %> gradle build ./my-app --artifact-name app-dev-debug.apk --upload myapp.apk --upload-ttl 24h',
     '<%= config.bin %> gradle build --task bundleRelease',
     '<%= config.bin %> gradle build --id <gradle-instance-ID> --project-path android',
     '<%= config.bin %> gradle build ./my-monorepo --expo-app-dir apps/mobile',
@@ -70,7 +70,15 @@ export default class GradleBuild extends BaseCommand {
       multiple: true,
       options: [...gradleAndroidABIs],
     }),
-    upload: Flags.string({ description: 'Upload the resulting APK or AAB as an asset with this name' }),
+    upload: Flags.string({ description: 'Upload the resulting APK or AAB as an asset with this name.' }),
+    'upload-ttl': Flags.string({
+      description:
+        'Delete the named --upload asset after this Go duration (for example 24h or 30m). Omit for no expiry.',
+    }),
+    'artifact-name': Flags.string({
+      description:
+        'Exact APK or AAB filename to upload when the build produces multiple artifacts, for example app-prod-release.aab.',
+    }),
     'signed-upload-url': Flags.string({
       description: 'Presigned URL to upload the resulting APK or AAB to.',
     }),

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -56,7 +56,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --xcodegen-spec specs/app.yml --xcodegen-project ios',
-    '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
+    '<%= config.bin %> xcode build ./MyProject --scheme "Hubble Dev" --artifact-name Hubble-dev --upload signed-device-build.ipa --upload-ttl 24h',
     '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method release-testing --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method app-store-connect --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload-to-appstore',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
@@ -131,7 +131,15 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Relative path from the synced workspace root to the Expo app directory. Use for monorepos or ambiguous React Native workspaces.',
     }),
-    upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
+    upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name.' }),
+    'upload-ttl': Flags.string({
+      description:
+        'Delete the named --upload asset after this Go duration (for example 24h or 30m). Omit for no expiry.',
+    }),
+    'artifact-name': Flags.string({
+      description:
+        'Built product name to upload when it differs from the Xcode scheme, for example Hubble-dev. The .app suffix is optional.',
+    }),
     'signed-upload-url': Flags.string({
       description: 'Presigned URL to upload the resulting build artifact to.',
     }),
@@ -264,6 +272,9 @@ export default class XcodeBuild extends BaseCommand {
     if (flags.detach && !flags['webhook-url']) {
       this.error('--detach requires --webhook-url so the terminal build result is observable.');
     }
+    if (flags['upload-ttl'] && !flags.upload) {
+      this.error('--upload-ttl requires --upload.');
+    }
 
     await this.withAuth(async () => {
       const target =
@@ -284,6 +295,9 @@ export default class XcodeBuild extends BaseCommand {
       if (flags.configuration) settings.configuration = flags.configuration;
 
       const options: XcodeBuildOptions = {};
+      if (flags['artifact-name']) {
+        options.artifactName = flags['artifact-name'];
+      }
       if (flags['git-init']) {
         options.gitInit = true;
       }
@@ -348,7 +362,10 @@ export default class XcodeBuild extends BaseCommand {
         this.error('Use either --upload or --signed-upload-url, not both.');
       }
       if (flags.upload) {
-        options.upload = { assetName: flags.upload };
+        options.upload = {
+          assetName: flags.upload,
+          ...(flags['upload-ttl'] && { ttl: flags['upload-ttl'] }),
+        };
       } else if (flags['signed-upload-url']) {
         options.upload = {
           signedUploadUrl: flags['signed-upload-url'],

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -56,7 +56,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./repo --expo-app-dir apps/mobile --configuration Debug --dev-server-url "myapp://expo-development-client/?url=http%3A%2F%2F10.244.7.112%3A57090"',
     '<%= config.bin %> xcode build --scheme WatchApp --sdk watchsimulator',
     '<%= config.bin %> xcode build ./MyProject --xcodegen-spec specs/app.yml --xcodegen-project ios',
-    '<%= config.bin %> xcode build ./MyProject --scheme "Hubble Dev" --artifact-name Hubble-dev --upload signed-device-build.ipa --upload-ttl 24h',
+    '<%= config.bin %> xcode build ./MyProject --scheme "Hubble Dev" --upload-name Hubble-dev --upload signed-device-build.ipa --upload-ttl 24h',
     '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method release-testing --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method app-store-connect --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload-to-appstore',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
@@ -136,7 +136,7 @@ export default class XcodeBuild extends BaseCommand {
       description:
         'Delete the named --upload asset after this Go duration (for example 24h or 30m). Omit for no expiry.',
     }),
-    'artifact-name': Flags.string({
+    'upload-name': Flags.string({
       description:
         'Built product name to upload when it differs from the Xcode scheme, for example Hubble-dev. The .app suffix is optional.',
     }),
@@ -295,8 +295,8 @@ export default class XcodeBuild extends BaseCommand {
       if (flags.configuration) settings.configuration = flags.configuration;
 
       const options: XcodeBuildOptions = {};
-      if (flags['artifact-name']) {
-        options.artifactName = flags['artifact-name'];
+      if (flags['upload-name']) {
+        options.artifactName = flags['upload-name'];
       }
       if (flags['git-init']) {
         options.gitInit = true;

--- a/packages/cli/src/lib/gradle-build-options.ts
+++ b/packages/cli/src/lib/gradle-build-options.ts
@@ -149,12 +149,7 @@ export function gradleBuildOptionsFromFlags(flags: GradleBuildFlagValues): Gradl
   if (flags['upload-ttl'] && !flags.upload) {
     throw new Error('--upload-ttl requires --upload.');
   }
-  if (
-    flags['upload-name'] &&
-    !flags.upload &&
-    !flags['signed-upload-url'] &&
-    !flags['upload-to-playstore']
-  ) {
+  if (flags['upload-name'] && !flags.upload && !flags['signed-upload-url'] && !flags['upload-to-playstore']) {
     throw new Error('--upload-name requires --upload, --signed-upload-url, or --upload-to-playstore.');
   }
   validateSigningFlags(flags);

--- a/packages/cli/src/lib/gradle-build-options.ts
+++ b/packages/cli/src/lib/gradle-build-options.ts
@@ -21,7 +21,7 @@ export interface GradleBuildFlagValues extends WebhookFlagValues {
   abi?: string[];
   upload?: string;
   'upload-ttl'?: string;
-  'artifact-name'?: string;
+  'upload-name'?: string;
   'signed-upload-url'?: string;
   sign?: boolean;
   'application-id'?: string;
@@ -150,12 +150,12 @@ export function gradleBuildOptionsFromFlags(flags: GradleBuildFlagValues): Gradl
     throw new Error('--upload-ttl requires --upload.');
   }
   if (
-    flags['artifact-name'] &&
+    flags['upload-name'] &&
     !flags.upload &&
     !flags['signed-upload-url'] &&
     !flags['upload-to-playstore']
   ) {
-    throw new Error('--artifact-name requires --upload, --signed-upload-url, or --upload-to-playstore.');
+    throw new Error('--upload-name requires --upload, --signed-upload-url, or --upload-to-playstore.');
   }
   validateSigningFlags(flags);
   validatePlaystoreFlags(flags);
@@ -187,8 +187,8 @@ export function gradleBuildOptionsFromFlags(flags: GradleBuildFlagValues): Gradl
   } else if (flags['signed-upload-url']) {
     options.upload = { signedUploadUrl: flags['signed-upload-url'] };
   }
-  if (flags['artifact-name']) {
-    options.artifactName = flags['artifact-name'];
+  if (flags['upload-name']) {
+    options.artifactName = flags['upload-name'];
   }
   const webhook = webhookConfigFromFlags(flags);
   if (webhook) {

--- a/packages/cli/src/lib/gradle-build-options.ts
+++ b/packages/cli/src/lib/gradle-build-options.ts
@@ -20,6 +20,8 @@ export interface GradleBuildFlagValues extends WebhookFlagValues {
   'expo-app-dir'?: string;
   abi?: string[];
   upload?: string;
+  'upload-ttl'?: string;
+  'artifact-name'?: string;
   'signed-upload-url'?: string;
   sign?: boolean;
   'application-id'?: string;
@@ -144,6 +146,17 @@ export function gradleBuildOptionsFromFlags(flags: GradleBuildFlagValues): Gradl
   if (flags.upload && flags['signed-upload-url']) {
     throw new Error('Use either --upload or --signed-upload-url, not both.');
   }
+  if (flags['upload-ttl'] && !flags.upload) {
+    throw new Error('--upload-ttl requires --upload.');
+  }
+  if (
+    flags['artifact-name'] &&
+    !flags.upload &&
+    !flags['signed-upload-url'] &&
+    !flags['upload-to-playstore']
+  ) {
+    throw new Error('--artifact-name requires --upload, --signed-upload-url, or --upload-to-playstore.');
+  }
   validateSigningFlags(flags);
   validatePlaystoreFlags(flags);
   const options: GradleBuildOptions = {};
@@ -167,9 +180,15 @@ export function gradleBuildOptionsFromFlags(flags: GradleBuildFlagValues): Gradl
     };
   }
   if (flags.upload) {
-    options.upload = { assetName: flags.upload };
+    options.upload = {
+      assetName: flags.upload,
+      ...(flags['upload-ttl'] && { ttl: flags['upload-ttl'] }),
+    };
   } else if (flags['signed-upload-url']) {
     options.upload = { signedUploadUrl: flags['signed-upload-url'] };
+  }
+  if (flags['artifact-name']) {
+    options.artifactName = flags['artifact-name'];
   }
   const webhook = webhookConfigFromFlags(flags);
   if (webhook) {

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -49,6 +49,7 @@ export type XcodeBuildExecRequest = {
   testflight?: AppStoreUploadConfig;
   buildSettings?: Record<string, string>;
   gitInit?: boolean;
+  artifactName?: string;
   signedUploadUrl?: string;
   webhook?: WebhookConfig;
   additionalMetadata?: {
@@ -129,6 +130,7 @@ export type GradleBuildExecRequest = {
   reactNative?: GradleReactNativeConfig;
   signing?: GradleSigningConfig;
   playstore?: GradlePlaystoreConfig;
+  artifactName?: string;
   signedUploadUrl?: string;
   webhook?: WebhookConfig;
   additionalMetadata?: {

--- a/src/resources/gradle-instances-helpers.ts
+++ b/src/resources/gradle-instances-helpers.ts
@@ -56,7 +56,11 @@ export type GradleBuildOptions = {
   /** Relative path to the Gradle root when auto-discovery is ambiguous. */
   projectPath?: string;
   /** Upload the built artifact as a named org asset, or to a presigned URL. */
-  upload?: { assetName: string; signedUploadUrl?: never } | { signedUploadUrl: string; assetName?: never };
+  upload?:
+    | { assetName: string; ttl?: string; signedUploadUrl?: never }
+    | { signedUploadUrl: string; assetName?: never; ttl?: never };
+  /** Exact APK or AAB filename to upload when the build produces multiple artifacts. */
+  artifactName?: string;
   /** React Native / Expo tuning. */
   reactNative?: GradleReactNativeConfig;
   /** Release signing config; presence makes bundleRelease the default task. */
@@ -178,18 +182,21 @@ class GradleInstancesHelpers extends GradleInstances {
           ...(options?.projectPath && { projectPath: options.projectPath }),
           ...(options?.reactNative && { reactNative: options.reactNative }),
           ...(options?.signing && { signing: options.signing }),
+          ...(options?.artifactName && { artifactName: options.artifactName }),
           ...(options?.webhook && { webhook: options.webhook }),
           ...(options?.playstore && { playstore: options.playstore }),
         };
 
         if (options?.upload && 'assetName' in options.upload) {
-          const requestPromise = mintAssetUploadUrls(client.assets, options.upload.assetName).then(
-            (asset) => {
-              request.signedUploadUrl = asset.signedUploadUrl;
-              request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
-              return request;
-            },
-          );
+          const requestPromise = mintAssetUploadUrls(
+            client.assets,
+            options.upload.assetName,
+            options.upload.ttl,
+          ).then((asset) => {
+            request.signedUploadUrl = asset.signedUploadUrl;
+            request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
+            return request;
+          });
           return exec(requestPromise, { apiUrl, token, log });
         }
 

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -175,7 +175,14 @@ export type ReactNativeBuildConfig = {
 };
 
 export type XcodeBuildOptions = {
-  upload?: { assetName: string } | { signedUploadUrl: string };
+  upload?:
+    | { assetName: string; ttl?: string; signedUploadUrl?: never }
+    | { signedUploadUrl: string; assetName?: never; ttl?: never };
+  /**
+   * Built product name when it differs from the scheme. The `.app` suffix is
+   * optional. The server uses this to locate the artifact after xcodebuild.
+   */
+  artifactName?: string;
   signing?: XcodeSigningConfig;
   cloudSigning?: XcodeCloudSigningConfig;
   /**
@@ -802,17 +809,20 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ...(options?.appstore && { testflight: options.appstore }),
           ...(options?.buildSettings && { buildSettings: options.buildSettings }),
           ...(options?.gitInit !== undefined && { gitInit: options.gitInit }),
+          ...(options?.artifactName && { artifactName: options.artifactName }),
           ...(options?.webhook && { webhook: options.webhook }),
         };
 
         if (options?.upload && 'assetName' in options.upload) {
-          const requestPromise = mintAssetUploadUrls(client.assets, options.upload.assetName).then(
-            (asset) => {
-              request.signedUploadUrl = asset.signedUploadUrl;
-              request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
-              return request;
-            },
-          );
+          const requestPromise = mintAssetUploadUrls(
+            client.assets,
+            options.upload.assetName,
+            options.upload.ttl,
+          ).then((asset) => {
+            request.signedUploadUrl = asset.signedUploadUrl;
+            request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
+            return request;
+          });
           return exec(requestPromise, { apiUrl, token, log });
         }
 

--- a/tests/cli-gradle-build-options.test.ts
+++ b/tests/cli-gradle-build-options.test.ts
@@ -45,8 +45,8 @@ test('upload-ttl requires a named upload', () => {
   expect(() => gradleBuildOptionsFromFlags({ 'upload-ttl': '24h' })).toThrow('requires --upload');
 });
 
-test('artifact-name requires an upload destination', () => {
-  expect(() => gradleBuildOptionsFromFlags({ 'artifact-name': 'app-debug.apk' })).toThrow(
+test('upload-name requires an upload destination', () => {
+  expect(() => gradleBuildOptionsFromFlags({ 'upload-name': 'app-debug.apk' })).toThrow(
     'requires --upload',
   );
 });
@@ -56,7 +56,7 @@ test('tasks, project path, artifact name, and upload TTL map through', () => {
     gradleBuildOptionsFromFlags({
       task: ['assembleDebug'],
       'project-path': 'android',
-      'artifact-name': 'app-dev-debug.apk',
+      'upload-name': 'app-dev-debug.apk',
       upload: 'app.apk',
       'upload-ttl': '24h',
     }),

--- a/tests/cli-gradle-build-options.test.ts
+++ b/tests/cli-gradle-build-options.test.ts
@@ -46,9 +46,7 @@ test('upload-ttl requires a named upload', () => {
 });
 
 test('upload-name requires an upload destination', () => {
-  expect(() => gradleBuildOptionsFromFlags({ 'upload-name': 'app-debug.apk' })).toThrow(
-    'requires --upload',
-  );
+  expect(() => gradleBuildOptionsFromFlags({ 'upload-name': 'app-debug.apk' })).toThrow('requires --upload');
 });
 
 test('tasks, project path, artifact name, and upload TTL map through', () => {

--- a/tests/cli-gradle-build-options.test.ts
+++ b/tests/cli-gradle-build-options.test.ts
@@ -41,17 +41,30 @@ test('upload and signed-upload-url are mutually exclusive', () => {
   );
 });
 
-test('tasks, project path, and upload map through', () => {
+test('upload-ttl requires a named upload', () => {
+  expect(() => gradleBuildOptionsFromFlags({ 'upload-ttl': '24h' })).toThrow('requires --upload');
+});
+
+test('artifact-name requires an upload destination', () => {
+  expect(() => gradleBuildOptionsFromFlags({ 'artifact-name': 'app-debug.apk' })).toThrow(
+    'requires --upload',
+  );
+});
+
+test('tasks, project path, artifact name, and upload TTL map through', () => {
   expect(
     gradleBuildOptionsFromFlags({
       task: ['assembleDebug'],
       'project-path': 'android',
+      'artifact-name': 'app-dev-debug.apk',
       upload: 'app.apk',
+      'upload-ttl': '24h',
     }),
   ).toEqual({
     tasks: ['assembleDebug'],
     projectPath: 'android',
-    upload: { assetName: 'app.apk' },
+    artifactName: 'app-dev-debug.apk',
+    upload: { assetName: 'app.apk', ttl: '24h' },
   });
 });
 

--- a/tests/gradle-client-build.test.ts
+++ b/tests/gradle-client-build.test.ts
@@ -195,21 +195,26 @@ test('gradlebuild --upload mints asset URLs before posting exec', async () => {
   });
 
   const client = new Limrun({ apiKey: 'key' });
-  jest.spyOn(client.assets, 'getOrCreate').mockResolvedValue({
+  const getOrCreate = jest.spyOn(client.assets, 'getOrCreate').mockResolvedValue({
     signedUploadUrl: 'https://storage.example.com/up',
     signedDownloadUrl: 'https://storage.example.com/down',
   } as never);
   const gradle = await client.gradleInstances.createClient({ apiUrl: API_URL, token: TOKEN });
 
-  const result = await gradle.gradlebuild({ upload: { assetName: 'myapp.apk' } });
+  const result = await gradle.gradlebuild({
+    artifactName: 'app-dev-debug.apk',
+    upload: { assetName: 'myapp.apk', ttl: '24h' },
+  });
   expect(result.exitCode).toBe(0);
   expect(result.signedDownloadUrl).toBe('https://storage.example.com/down');
+  expect(getOrCreate).toHaveBeenCalledWith({ name: 'myapp.apk', ttl: '24h' });
 
   const execReq = requests.find((r) => r.url.endsWith('/exec'));
   // Exact match: the client-only additionalMetadata (signedDownloadUrl) must
   // stay OFF the wire; toMatchObject would pass even if it leaked.
   expect(execReq?.body).toEqual({
     command: 'gradlebuild',
+    artifactName: 'app-dev-debug.apk',
     signedUploadUrl: 'https://storage.example.com/up',
   });
 });

--- a/tests/ios-shim.test.ts
+++ b/tests/ios-shim.test.ts
@@ -6,7 +6,7 @@ import { startXcrunShimServer, type IosXcrunShimClient, type IosXcrunShimServer 
 const client = {
   deviceInfo: { udid: 'TEST-UDID' },
   listApps: async () => [],
-  simctl: () => ({ wait: async () => ({ code: 0, stdout: '', stderr: '' }) }),
+  simctl: jest.fn(() => ({ wait: async () => ({ code: 0, stdout: '', stderr: '' }) })),
   syncApp: async () => ({}),
 } as unknown as IosXcrunShimClient;
 
@@ -50,5 +50,12 @@ describe('xcrun shim server devicectl handling', () => {
   test('rejects other devicectl subcommands', async () => {
     const result = await callShim(server.url, ['devicectl', 'device', 'install', 'app', 'App.ipa']);
     expect(result.code).toBe(127);
+  });
+
+  test('forwards simctl privacy to the remote simulator', async () => {
+    const args = ['privacy', 'booted', 'grant', 'camera', 'com.example.app'];
+    const result = await callShim(server.url, ['simctl', ...args]);
+    expect(result.code).toBe(0);
+    expect(client.simctl).toHaveBeenCalledWith(args);
   });
 });

--- a/tests/xcode-client-signing.test.ts
+++ b/tests/xcode-client-signing.test.ts
@@ -109,6 +109,45 @@ describe('xcode client signing', () => {
       },
     });
   });
+
+  test('serializes artifact name and uses upload TTL when minting the asset URL', async () => {
+    const calls: Array<{ input: RequestInfo; init: RequestInit | undefined }> = [];
+    nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+      calls.push({ input, init });
+      if (String(input) === 'https://xcode.example.test/exec') {
+        return jsonResponse({ execId: 'build-3' });
+      }
+      throw new Error(`unexpected request: ${input}`);
+    });
+
+    const client = new Limrun({ apiKey: 'key' });
+    const getOrCreate = jest.spyOn(client.assets, 'getOrCreate').mockResolvedValue({
+      signedUploadUrl: 'https://storage.example.com/up',
+      signedDownloadUrl: 'https://storage.example.com/down',
+    } as never);
+    const xcode = await client.xcodeInstances.createClient({
+      apiUrl: 'https://xcode.example.test',
+      token: 'xcode-token',
+    });
+
+    const result = await xcode.xcodebuild(
+      { scheme: 'Hubble Dev' },
+      {
+        artifactName: 'Hubble-dev',
+        upload: { assetName: 'hubble-dev-build', ttl: '24h' },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.signedDownloadUrl).toBe('https://storage.example.com/down');
+    expect(getOrCreate).toHaveBeenCalledWith({ name: 'hubble-dev-build', ttl: '24h' });
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      command: 'xcodebuild',
+      xcodebuild: { scheme: 'Hubble Dev' },
+      artifactName: 'Hubble-dev',
+      signedUploadUrl: 'https://storage.example.com/up',
+    });
+  });
 });
 
 function jsonResponse(body: unknown): Response {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `--upload-name` to `lim xcode build` and `lim gradle build`
- add `--upload-ttl` for expiring named build assets
- pass upload selection and TTL through the TypeScript SDK
- pin existing Xcode `simctl privacy` forwarding with coverage

Companion server change: https://github.com/limrun-inc/limrun/pull/595

## Testing
- `./scripts/lint`
- `yarn test tests/cli-gradle-build-options.test.ts tests/gradle-client-build.test.ts tests/xcode-client-signing.test.ts tests/ios-shim.test.ts --runInBand`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18630bb8-06c5-4292-98f5-bbc3451545fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18630bb8-06c5-4292-98f5-bbc3451545fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

