### PR TITLE
CLI: delete instances by label selector

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -101,6 +101,15 @@ lim android tap --id android_abc123 100 200
 
 This avoids relying on locally cached "last created" state and keeps the target platform explicit.
 
+Delete commands also accept a label selector. They delete every active instance with all matching labels:
+
+```bash
+lim ios delete --label-selector env=ci,team=mobile
+lim android delete --label-selector env=ci,team=mobile
+lim xcode delete --label-selector env=ci,team=mobile
+lim gradle delete --label-selector env=ci,team=mobile
+```
+
 ## Commands
 
 - [Run](#run) — Get started with Limrun on your project or the sample app

--- a/packages/cli/src/commands/android/delete.ts
+++ b/packages/cli/src/commands/android/delete.ts
@@ -1,16 +1,18 @@
 import { NotFoundError } from '@limrun/api';
-import { Args } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { clearLastInstanceId } from '../../lib/config';
 import { stopDaemon } from '../../lib/daemon';
+import { deleteInstancesByLabels } from '../../lib/delete-instances';
 
 export default class AndroidDelete extends BaseCommand {
   static summary = 'Delete an Android instance';
-  static description = 'Delete an existing Android instance by ID.';
+  static description = 'Delete Android instances by ID or labels.';
   static examples = [
     '<%= config.bin %> android delete',
     '<%= config.bin %> android delete <ID>',
     '<%= config.bin %> android delete android_abc123',
+    '<%= config.bin %> android delete --label-selector env=ci,team=mobile',
   ];
 
   static args = {
@@ -20,26 +22,49 @@ export default class AndroidDelete extends BaseCommand {
     }),
   };
 
-  static flags = { ...BaseCommand.baseFlags };
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'label-selector': Flags.string({
+      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+    }),
+  };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(AndroidDelete);
     this.setParsedFlags(flags);
+    if (args.id && flags['label-selector']) {
+      this.error('Provide either an Android instance ID or --label-selector, not both.');
+    }
 
     await this.withAuth(async () => {
-      const resolvedInstance = this.resolveAndroidInstance(args.id);
-      const id = resolvedInstance.id;
-      try {
-        await this.client.androidInstances.delete(id);
-      } catch (err) {
-        if (!(err instanceof NotFoundError)) {
-          throw err;
+      if (flags['label-selector']) {
+        const deletedIds = await deleteInstancesByLabels(
+          flags['label-selector'],
+          (params) => this.client.androidInstances.list(params),
+          (id) => this.deleteInstance(id),
+        );
+        if (deletedIds.length === 0) {
+          this.log(`No active Android instances matched label selector: ${flags['label-selector']}`);
         }
+        return;
       }
 
-      stopDaemon(id);
-      clearLastInstanceId(id);
-      this.log(`Deleted Android instance: ${id}`);
+      const resolvedInstance = this.resolveAndroidInstance(args.id);
+      await this.deleteInstance(resolvedInstance.id);
     });
+  }
+
+  private async deleteInstance(id: string): Promise<void> {
+    try {
+      await this.client.androidInstances.delete(id);
+    } catch (err) {
+      if (!(err instanceof NotFoundError)) {
+        throw err;
+      }
+    }
+
+    stopDaemon(id);
+    clearLastInstanceId(id);
+    this.log(`Deleted Android instance: ${id}`);
   }
 }

--- a/packages/cli/src/commands/android/delete.ts
+++ b/packages/cli/src/commands/android/delete.ts
@@ -25,19 +25,20 @@ export default class AndroidDelete extends BaseCommand {
   static flags = {
     ...BaseCommand.baseFlags,
     'label-selector': Flags.string({
-      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+      description:
+        'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
     }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(AndroidDelete);
     this.setParsedFlags(flags);
-    if (args.id && flags['label-selector']) {
+    if (args.id && flags['label-selector'] !== undefined) {
       this.error('Provide either an Android instance ID or --label-selector, not both.');
     }
 
     await this.withAuth(async () => {
-      if (flags['label-selector']) {
+      if (flags['label-selector'] !== undefined) {
         const deletedIds = await deleteInstancesByLabels(
           flags['label-selector'],
           (params) => this.client.androidInstances.list(params),

--- a/packages/cli/src/commands/gradle/delete.ts
+++ b/packages/cli/src/commands/gradle/delete.ts
@@ -24,19 +24,20 @@ export default class GradleDelete extends BaseCommand {
   static flags = {
     ...BaseCommand.baseFlags,
     'label-selector': Flags.string({
-      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+      description:
+        'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
     }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(GradleDelete);
     this.setParsedFlags(flags);
-    if (args.id && flags['label-selector']) {
+    if (args.id && flags['label-selector'] !== undefined) {
       this.error('Provide either a gradle instance ID or --label-selector, not both.');
     }
 
     await this.withAuth(async () => {
-      if (flags['label-selector']) {
+      if (flags['label-selector'] !== undefined) {
         const deletedIds = await deleteInstancesByLabels(
           flags['label-selector'],
           (params) => this.client.gradleInstances.list(params),

--- a/packages/cli/src/commands/gradle/delete.ts
+++ b/packages/cli/src/commands/gradle/delete.ts
@@ -1,15 +1,17 @@
 import { NotFoundError } from '@limrun/api';
-import { Args } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { clearLastInstanceId } from '../../lib/config';
+import { deleteInstancesByLabels } from '../../lib/delete-instances';
 
 export default class GradleDelete extends BaseCommand {
   static summary = 'Delete a gradle instance';
-  static description = 'Delete an existing gradle build sandbox instance by ID.';
+  static description = 'Delete gradle build sandbox instances by ID or labels.';
   static examples = [
     '<%= config.bin %> gradle delete',
     '<%= config.bin %> gradle delete <ID>',
     '<%= config.bin %> gradle delete gradle_abc123',
+    '<%= config.bin %> gradle delete --label-selector env=ci,team=mobile',
   ];
 
   static args = {
@@ -19,24 +21,47 @@ export default class GradleDelete extends BaseCommand {
     }),
   };
 
-  static flags = { ...BaseCommand.baseFlags };
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'label-selector': Flags.string({
+      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+    }),
+  };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(GradleDelete);
     this.setParsedFlags(flags);
+    if (args.id && flags['label-selector']) {
+      this.error('Provide either a gradle instance ID or --label-selector, not both.');
+    }
 
     await this.withAuth(async () => {
-      const id = this.resolveGradleTarget(args.id).id;
-      try {
-        await this.client.gradleInstances.delete(id);
-      } catch (err) {
-        if (!(err instanceof NotFoundError)) {
-          throw err;
+      if (flags['label-selector']) {
+        const deletedIds = await deleteInstancesByLabels(
+          flags['label-selector'],
+          (params) => this.client.gradleInstances.list(params),
+          (id) => this.deleteInstance(id),
+        );
+        if (deletedIds.length === 0) {
+          this.log(`No active gradle instances matched label selector: ${flags['label-selector']}`);
         }
+        return;
       }
 
-      clearLastInstanceId(id);
-      this.log(`Deleted gradle instance: ${id}`);
+      await this.deleteInstance(this.resolveGradleTarget(args.id).id);
     });
+  }
+
+  private async deleteInstance(id: string): Promise<void> {
+    try {
+      await this.client.gradleInstances.delete(id);
+    } catch (err) {
+      if (!(err instanceof NotFoundError)) {
+        throw err;
+      }
+    }
+
+    clearLastInstanceId(id);
+    this.log(`Deleted gradle instance: ${id}`);
   }
 }

--- a/packages/cli/src/commands/ios/delete.ts
+++ b/packages/cli/src/commands/ios/delete.ts
@@ -1,16 +1,18 @@
 import { NotFoundError } from '@limrun/api';
-import { Args } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { clearLastInstanceId } from '../../lib/config';
 import { stopDaemon } from '../../lib/daemon';
+import { deleteInstancesByLabels } from '../../lib/delete-instances';
 
 export default class IosDelete extends BaseCommand {
   static summary = 'Delete an iOS instance';
-  static description = 'Delete an existing iOS instance by ID and remove any cached local metadata for it.';
+  static description = 'Delete iOS instances by ID or labels and remove their cached local metadata.';
   static examples = [
     '<%= config.bin %> ios delete',
     '<%= config.bin %> ios delete <ID>',
     '<%= config.bin %> ios delete ios_abc123',
+    '<%= config.bin %> ios delete --label-selector env=ci,team=mobile',
   ];
 
   static args = {
@@ -20,26 +22,49 @@ export default class IosDelete extends BaseCommand {
     }),
   };
 
-  static flags = { ...BaseCommand.baseFlags };
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'label-selector': Flags.string({
+      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+    }),
+  };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(IosDelete);
     this.setParsedFlags(flags);
+    if (args.id && flags['label-selector']) {
+      this.error('Provide either an iOS instance ID or --label-selector, not both.');
+    }
 
     await this.withAuth(async () => {
-      const resolvedInstance = this.resolveIosInstance(args.id);
-      const id = resolvedInstance.id;
-      try {
-        await this.client.iosInstances.delete(id);
-      } catch (err) {
-        if (!(err instanceof NotFoundError)) {
-          throw err;
+      if (flags['label-selector']) {
+        const deletedIds = await deleteInstancesByLabels(
+          flags['label-selector'],
+          (params) => this.client.iosInstances.list(params),
+          (id) => this.deleteInstance(id),
+        );
+        if (deletedIds.length === 0) {
+          this.log(`No active iOS instances matched label selector: ${flags['label-selector']}`);
         }
+        return;
       }
 
-      stopDaemon(id);
-      clearLastInstanceId(id);
-      this.log(`Deleted iOS instance: ${id}`);
+      const resolvedInstance = this.resolveIosInstance(args.id);
+      await this.deleteInstance(resolvedInstance.id);
     });
+  }
+
+  private async deleteInstance(id: string): Promise<void> {
+    try {
+      await this.client.iosInstances.delete(id);
+    } catch (err) {
+      if (!(err instanceof NotFoundError)) {
+        throw err;
+      }
+    }
+
+    stopDaemon(id);
+    clearLastInstanceId(id);
+    this.log(`Deleted iOS instance: ${id}`);
   }
 }

--- a/packages/cli/src/commands/ios/delete.ts
+++ b/packages/cli/src/commands/ios/delete.ts
@@ -25,19 +25,20 @@ export default class IosDelete extends BaseCommand {
   static flags = {
     ...BaseCommand.baseFlags,
     'label-selector': Flags.string({
-      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+      description:
+        'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
     }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(IosDelete);
     this.setParsedFlags(flags);
-    if (args.id && flags['label-selector']) {
+    if (args.id && flags['label-selector'] !== undefined) {
       this.error('Provide either an iOS instance ID or --label-selector, not both.');
     }
 
     await this.withAuth(async () => {
-      if (flags['label-selector']) {
+      if (flags['label-selector'] !== undefined) {
         const deletedIds = await deleteInstancesByLabels(
           flags['label-selector'],
           (params) => this.client.iosInstances.list(params),

--- a/packages/cli/src/commands/xcode/delete.ts
+++ b/packages/cli/src/commands/xcode/delete.ts
@@ -3,14 +3,16 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import { clearLastInstanceId } from '../../lib/config';
 import { stopDaemon } from '../../lib/daemon';
+import { deleteInstancesByLabels } from '../../lib/delete-instances';
 
 export default class XcodeDelete extends BaseCommand {
   static summary = 'Delete an Xcode instance';
-  static description = 'Delete an existing Xcode sandbox instance by ID.';
+  static description = 'Delete Xcode sandbox instances by ID or labels.';
   static examples = [
     '<%= config.bin %> xcode delete',
     '<%= config.bin %> xcode delete <ID>',
     '<%= config.bin %> xcode delete xcode_abc123',
+    '<%= config.bin %> xcode delete --label-selector env=ci,team=mobile',
     '<%= config.bin %> xcode delete --wait-cache',
   ];
 
@@ -28,43 +30,63 @@ export default class XcodeDelete extends BaseCommand {
         'Wait for the build cache to finish publishing, reporting each phase. Deletion returns as soon as it is accepted otherwise, while publication continues in the background.',
       default: false,
     }),
+    'label-selector': Flags.string({
+      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+    }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(XcodeDelete);
     this.setParsedFlags(flags);
+    if (args.id && flags['label-selector']) {
+      this.error('Provide either an Xcode instance ID or --label-selector, not both.');
+    }
 
     await this.withAuth(async () => {
-      const resolvedInstance = await this.resolveXcodeTarget(args.id);
-      const id = resolvedInstance.id;
-      // Subscribed, and subscribed *before* the delete, so a publication that is over in
-      // seconds is still seen. The stream takes a moment to open and an instance with nothing
-      // to publish is collected in about as long, which is a race the watcher loses in silence:
-      // the endpoint answers from the region, so it is a 404 by the time the stream gets there.
-      const following =
-        flags['wait-cache'] ?
-          this.startCachePublicationFollow(this.cacheInstanceId(resolvedInstance))
-        : undefined;
-      await following?.opened;
-      try {
-        await this.client.xcodeInstances.delete(id);
-      } catch (err) {
-        if (!(err instanceof NotFoundError)) {
-          throw err;
+      if (flags['label-selector']) {
+        const deletedIds = await deleteInstancesByLabels(
+          flags['label-selector'],
+          (params) => this.client.xcodeInstances.list(params),
+          (id) => this.deleteInstance(id, flags['wait-cache']),
+        );
+        if (deletedIds.length === 0) {
+          this.log(`No active Xcode instances matched label selector: ${flags['label-selector']}`);
         }
+        return;
       }
 
-      stopDaemon(id);
-      clearLastInstanceId(id);
-
-      // The deletion line comes after the publication rather than before it, both so the phases
-      // read as one block and because that is the order the two actually finish in: the instance
-      // is held open until its workspace has been published.
-      const published = following ? await this.renderCachePublication(following) : true;
-      this.log(`Deleted Xcode instance: ${id}`);
-      if (!published) {
-        this.error('The build cache was not published.');
-      }
+      await this.deleteInstance(args.id, flags['wait-cache']);
     });
+  }
+
+  private async deleteInstance(providedId: string | undefined, waitCache: boolean): Promise<void> {
+    const resolvedInstance = await this.resolveXcodeTarget(providedId);
+    const id = resolvedInstance.id;
+    // Subscribed, and subscribed *before* the delete, so a publication that is over in
+    // seconds is still seen. The stream takes a moment to open and an instance with nothing
+    // to publish is collected in about as long, which is a race the watcher loses in silence:
+    // the endpoint answers from the region, so it is a 404 by the time the stream gets there.
+    const following =
+      waitCache ? this.startCachePublicationFollow(this.cacheInstanceId(resolvedInstance)) : undefined;
+    await following?.opened;
+    try {
+      await this.client.xcodeInstances.delete(id);
+    } catch (err) {
+      if (!(err instanceof NotFoundError)) {
+        throw err;
+      }
+    }
+
+    stopDaemon(id);
+    clearLastInstanceId(id);
+
+    // The deletion line comes after the publication rather than before it, both so the phases
+    // read as one block and because that is the order the two actually finish in: the instance
+    // is held open until its workspace has been published.
+    const published = following ? await this.renderCachePublication(following) : true;
+    this.log(`Deleted Xcode instance: ${id}`);
+    if (!published) {
+      this.error('The build cache was not published.');
+    }
   }
 }

--- a/packages/cli/src/commands/xcode/delete.ts
+++ b/packages/cli/src/commands/xcode/delete.ts
@@ -31,19 +31,20 @@ export default class XcodeDelete extends BaseCommand {
       default: false,
     }),
     'label-selector': Flags.string({
-      description: 'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
+      description:
+        'Delete all active instances matching comma-separated labels, for example env=ci,team=mobile',
     }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(XcodeDelete);
     this.setParsedFlags(flags);
-    if (args.id && flags['label-selector']) {
+    if (args.id && flags['label-selector'] !== undefined) {
       this.error('Provide either an Xcode instance ID or --label-selector, not both.');
     }
 
     await this.withAuth(async () => {
-      if (flags['label-selector']) {
+      if (flags['label-selector'] !== undefined) {
         const deletedIds = await deleteInstancesByLabels(
           flags['label-selector'],
           (params) => this.client.xcodeInstances.list(params),

--- a/packages/cli/src/lib/delete-instances.ts
+++ b/packages/cli/src/lib/delete-instances.ts
@@ -16,6 +16,10 @@ export async function deleteInstancesByLabels<T extends LabelledInstance>(
   list: (params: DeleteByLabelParams) => AsyncIterable<T>,
   deleteInstance: (id: string) => Promise<void>,
 ): Promise<string[]> {
+  if (labelSelector.trim() === '') {
+    throw new Error('Label selector must not be empty.');
+  }
+
   const deletedIds: string[] = [];
   for await (const instance of list({
     labelSelector,

--- a/packages/cli/src/lib/delete-instances.ts
+++ b/packages/cli/src/lib/delete-instances.ts
@@ -1,0 +1,28 @@
+export interface LabelledInstance {
+  metadata: {
+    id: string;
+  };
+}
+
+interface DeleteByLabelParams {
+  labelSelector: string;
+  state: string;
+}
+
+const ACTIVE_INSTANCE_STATES = 'creating,assigned,ready,unknown';
+
+export async function deleteInstancesByLabels<T extends LabelledInstance>(
+  labelSelector: string,
+  list: (params: DeleteByLabelParams) => AsyncIterable<T>,
+  deleteInstance: (id: string) => Promise<void>,
+): Promise<string[]> {
+  const deletedIds: string[] = [];
+  for await (const instance of list({
+    labelSelector,
+    state: ACTIVE_INSTANCE_STATES,
+  })) {
+    await deleteInstance(instance.metadata.id);
+    deletedIds.push(instance.metadata.id);
+  }
+  return deletedIds;
+}

--- a/tests/cli-delete-instances.test.ts
+++ b/tests/cli-delete-instances.test.ts
@@ -1,0 +1,32 @@
+import { deleteInstancesByLabels, type LabelledInstance } from '../packages/cli/src/lib/delete-instances';
+
+async function* instances(ids: string[]): AsyncGenerator<LabelledInstance> {
+  for (const id of ids) {
+    yield { metadata: { id } };
+  }
+}
+
+test('deletes every active instance returned across label-filtered pages', async () => {
+  const list = jest.fn(() => instances(['ios_one', 'ios_two', 'ios_three']));
+  const deleteInstance = jest.fn(async () => {});
+
+  await expect(deleteInstancesByLabels('env=ci,team=mobile', list, deleteInstance)).resolves.toEqual([
+    'ios_one',
+    'ios_two',
+    'ios_three',
+  ]);
+  expect(list).toHaveBeenCalledWith({
+    labelSelector: 'env=ci,team=mobile',
+    state: 'creating,assigned,ready,unknown',
+  });
+  expect(deleteInstance.mock.calls).toEqual([['ios_one'], ['ios_two'], ['ios_three']]);
+});
+
+test('does not issue delete requests when no active instances match', async () => {
+  const deleteInstance = jest.fn(async () => {});
+
+  await expect(
+    deleteInstancesByLabels('env=missing', () => instances([]), deleteInstance),
+  ).resolves.toEqual([]);
+  expect(deleteInstance).not.toHaveBeenCalled();
+});

--- a/tests/cli-delete-instances.test.ts
+++ b/tests/cli-delete-instances.test.ts
@@ -25,8 +25,19 @@ test('deletes every active instance returned across label-filtered pages', async
 test('does not issue delete requests when no active instances match', async () => {
   const deleteInstance = jest.fn(async () => {});
 
-  await expect(
-    deleteInstancesByLabels('env=missing', () => instances([]), deleteInstance),
-  ).resolves.toEqual([]);
+  await expect(deleteInstancesByLabels('env=missing', () => instances([]), deleteInstance)).resolves.toEqual(
+    [],
+  );
+  expect(deleteInstance).not.toHaveBeenCalled();
+});
+
+test('rejects an empty selector instead of deleting every active instance', async () => {
+  const list = jest.fn(() => instances(['ios_one']));
+  const deleteInstance = jest.fn(async () => {});
+
+  await expect(deleteInstancesByLabels('  ', list, deleteInstance)).rejects.toThrow(
+    'Label selector must not be empty.',
+  );
+  expect(list).not.toHaveBeenCalled();
   expect(deleteInstance).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `--label-selector` to Android, iOS, Xcode, and Gradle delete commands
- auto-paginate matching active instances and preserve per-instance cleanup behavior
- reject empty selectors and ID/selector combinations to prevent unintended deletion
- document the new commands and cover shared deletion behavior with tests

## Testing
- `./scripts/lint`
- `yarn test tests/cli-delete-instances.test.ts --runInBand`
- `yarn --cwd packages/cli build`
- verified generated Android and Xcode delete help output
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37cd6f6b-930a-4320-ae44-8bba0a6d16aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37cd6f6b-930a-4320-ae44-8bba0a6d16aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

