### PR TITLE
exec: bound SSE reconnects instead of retrying for the full timeout

### DIFF
--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -295,8 +295,12 @@ export default class GradleBuild extends BaseCommand {
 
       if (result.exitCode !== 0) {
         if (result.timedOut) {
+          // 'timeout' means the stream was alive and the work outlived the
+          // budget; a lost or closed stream means the execution may be gone.
           this.error(
-            'Timed out waiting for the build to finish; the remote build may still be running. Check the instance before retrying.',
+            result.incomplete && result.incomplete.reason !== 'timeout' ?
+              `${result.incomplete.message}.`
+            : 'Timed out waiting for the build to finish; the remote build may still be running. Check the instance before retrying.',
             { exit: result.exitCode },
           );
         }

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -416,8 +416,12 @@ export default class XcodeBuild extends BaseCommand {
 
       if (result.exitCode !== 0) {
         if (result.timedOut) {
+          // 'timeout' means the stream was alive and the work outlived the
+          // budget; a lost or closed stream means the execution may be gone.
           this.error(
-            'Timed out waiting for the build to finish; the remote build may still be running. Check the instance before retrying.',
+            result.incomplete && result.incomplete.reason !== 'timeout' ?
+              `${result.incomplete.message}.`
+            : 'Timed out waiting for the build to finish; the remote build may still be running. Check the instance before retrying.',
             { exit: result.exitCode },
           );
         }

--- a/packages/cli/src/commands/xcode/run.ts
+++ b/packages/cli/src/commands/xcode/run.ts
@@ -114,8 +114,12 @@ export default class XcodeRun extends BaseCommand {
       const result = await proc;
       if (result.exitCode !== 0) {
         if (result.timedOut) {
+          // 'timeout' means the stream was alive and the work outlived the
+          // budget; a lost or closed stream means the execution may be gone.
           this.error(
-            'Timed out waiting for the command to finish; the remote command may still be running.',
+            result.incomplete && result.incomplete.reason !== 'timeout' ?
+              `${result.incomplete.message}.`
+            : 'Timed out waiting for the command to finish; the remote command may still be running.',
             { exit: result.exitCode },
           );
         }

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -7,14 +7,34 @@
 
 import { createEventSource, type EventSourceClient, type EventSourceMessage } from 'eventsource-client';
 import { nodeProxyTransport } from './internal/proxy-transport';
+import { sseFetch } from './internal/sse-fetch';
+import type { Fetch } from './internal/builtin-types';
 
-// Reconnect budget for the exec event stream. The EventSource reconnects
-// forever on its own, so a dead exec (deleted instance, expired record)
-// would retry every ~2s until the one-hour completion timeout. A connection
-// that delivers a message or stays open this long proves the server is
-// alive and refills the budget; each shorter cycle spends one attempt.
-const SSE_HEALTHY_CONNECTION_MS = 15_000;
-const SSE_MAX_FAILED_CYCLES = 20;
+/**
+ * Give-up policy for the exec event stream. The EventSource reconnects
+ * forever on its own, so a dead exec (deleted instance, expired record)
+ * would otherwise retry until the one-hour completion timeout. Proof of
+ * life resets the clock: a delivered event, or a clean connection that
+ * stays open healthyConnectionMs (long compiles stream nothing for
+ * minutes while intermediaries kill idle connections). The window is
+ * wide enough to ride out real transient outages (an ingress redeploy, a
+ * VPN reconnect); tightening it trades outage tolerance for faster
+ * dead-exec detection. It is measured in time, not attempts: the server
+ * steers the retry delay through SSE `retry:` frames, so an attempt
+ * count would put the give-up horizon under remote control.
+ *
+ * @internal Mutable for tests only.
+ */
+export const sseStreamPolicy = {
+  healthyConnectionMs: 15_000,
+  giveUpAfterMs: 300_000,
+};
+
+/** The event stream kept failing past the give-up window; remote state unknown. */
+export class ExecStreamLostError extends Error {}
+
+/** The server closed the event stream for good (HTTP 204). */
+export class ExecStreamClosedError extends Error {}
 
 // =============================================================================
 // Types
@@ -219,6 +239,14 @@ export type ExecResult = {
    * running and may yet succeed.
    */
   timedOut?: boolean;
+  /**
+   * Why the client gave up, present exactly when timedOut is true.
+   * 'timeout' is the completion budget expiring on a live stream;
+   * 'stream-lost' means the event stream kept failing (the execution may
+   * no longer exist); 'stream-closed' means the server ended the stream
+   * for good.
+   */
+  incomplete?: { reason: 'timeout' | 'stream-lost' | 'stream-closed'; message: string };
 };
 
 export type AppStoreEvent = {
@@ -509,12 +537,13 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
     }
     let exitCode: number;
     let timedOut = false;
+    let incomplete: ExecResult['incomplete'];
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       exitCode = await Promise.race([
         this.connectSSE(eventsUrl),
         new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(() => reject(new Error('SSE timeout')), timeoutMs);
+          timeoutId = setTimeout(() => reject(new Error('SSE completion timeout')), timeoutMs);
         }),
       ]);
     } catch (err) {
@@ -522,12 +551,17 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
         log('debug', 'Execution killed');
         exitCode = -1;
       } else {
-        // The client stopped waiting; the remote build may still be running.
-        // The fabricated exit code must not read as a build failure. Name
-        // the real reason: budget exhaustion and server-closed streams are
-        // actionable, a bare "timeout" is not.
-        const reason = err instanceof Error && err.message !== 'SSE timeout' ? err.message : 'SSE completion timeout';
-        log('warn', reason);
+        // The client stopped waiting; the fabricated exit code must not
+        // read as a build failure. The structured reason lets callers give
+        // the right advice: a dead stream means the execution may be gone,
+        // while a genuine timeout means it may still be running.
+        const message = err instanceof Error ? err.message : String(err);
+        const reason =
+          err instanceof ExecStreamClosedError ? 'stream-closed'
+          : err instanceof ExecStreamLostError ? 'stream-lost'
+          : 'timeout';
+        incomplete = { reason, message };
+        log('warn', message);
         exitCode = 1;
         timedOut = true;
       }
@@ -563,6 +597,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       ...(this.appStoreEvent ? { appstore: this.appStoreEvent } : {}),
       ...(this.playstoreEvent ? { playstore: this.playstoreEvent } : {}),
       ...(timedOut ? { timedOut } : {}),
+      ...(incomplete ? { incomplete } : {}),
     };
 
     this.log('debug', `Execution finished: ${result.status} (exit ${result.exitCode})`);
@@ -572,123 +607,165 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
   /**
    * Opens an SSE connection and routes streamed events to the exposed command/stdout/stderr streams.
    * Resolves with the exit code when an 'exitCode' event arrives.
-   * Rejects when the abort signal fires (kill or cleanup).
+   * Rejects when the abort signal fires (kill or cleanup), when the server
+   * closes the stream for good, or when the give-up clock runs out.
    */
   private connectSSE(eventsUrl: string): Promise<number> {
     return new Promise<number>((resolve, reject) => {
-      if (this.abortController.signal.aborted) {
+      const signal = this.abortController.signal;
+      if (signal.aborted) {
         reject(new Error('killed'));
         return;
       }
 
-      try {
-        let settled = false;
-        let connectedAt = 0;
-        let failedCycles = 0;
-        const fail = (error: Error) => {
-          settled = true;
-          eventSource.close();
-          reject(error);
-        };
-        const eventSource = createEventSource({
-          url: eventsUrl,
-          fetch: nodeProxyTransport.fetch,
-          headers: { Authorization: `Bearer ${this.options.token}` },
-          onConnect: () => {
-            connectedAt = Date.now();
-          },
-          // Fires once per broken cycle, before the retry timer is armed,
-          // on both failure paths (request rejected, stream ended). This is
-          // where the budget is spent and enforced.
-          onScheduleReconnect: () => {
-            if (settled || this.killed) {
-              return;
-            }
-            const lifetimeMs = connectedAt > 0 ? Date.now() - connectedAt : 0;
-            connectedAt = 0;
-            if (lifetimeMs >= SSE_HEALTHY_CONNECTION_MS) {
-              failedCycles = 0;
-              return;
-            }
-            failedCycles++;
-            if (failedCycles >= SSE_MAX_FAILED_CYCLES) {
-              this.log('warn', `SSE gave up after ${failedCycles} failed connections in a row`);
-              fail(
-                new Error(
-                  `event stream to ${eventsUrl} failed ${failedCycles} times in a row without receiving events; ` +
-                    'the execution may no longer exist (instance deleted or record expired)',
-                ),
-              );
-            }
-          },
-          onMessage: (message: EventSourceMessage) => {
-            failedCycles = 0;
-            const data = typeof message.data === 'string' ? message.data : String(message.data ?? '');
-            const eventType = message.event;
-            if (eventType === 'command') {
-              this.command.emit('data', data);
-            } else if (eventType === 'stdout') {
-              this.stdout.emit('data', data);
-            } else if (eventType === 'stderr') {
-              this.stderr.emit('data', data);
-            } else if (eventType === 'testflight') {
-              try {
-                this.appStoreEvent = JSON.parse(data) as AppStoreEvent;
-              } catch {
-                // The wire event itself proves the server ran the App Store upload,
-                // so never let a payload glitch look like a missing feature.
-                this.appStoreEvent = { state: 'unknown' };
-                this.log('warn', `SSE testflight event has invalid data: ${data}`);
-              }
-            } else if (eventType === 'playstore') {
-              try {
-                this.playstoreEvent = JSON.parse(data) as PlaystoreEvent;
-              } catch {
-                // Same contract as the App Store upload event: its presence proves the server
-                // ran the Play Store step, so a payload glitch must not
-                // read as a missing feature.
-                this.playstoreEvent = { state: 'unknown' };
-                this.log('warn', `SSE playstore event has invalid data: ${data}`);
-              }
-            } else if (eventType === 'exitCode') {
-              const exitCode = parseInt(data, 10);
-              if (Number.isNaN(exitCode)) {
-                this.log('warn', `SSE exitCode event has invalid data: ${data}`);
-                return;
-              }
-              this.log('debug', `Execution completed via SSE: exitCode=${exitCode}`);
-              settled = true;
-              resolve(exitCode);
-            }
-          },
-          onDisconnect: () => {
-            if (settled || this.killed) {
-              return;
-            }
-            // Warn once per failure streak; the budget above bounds the
-            // streak, so this cannot spam for the rest of the run.
-            this.log(failedCycles <= 1 ? 'warn' : 'debug', 'SSE disconnected');
-            // On HTTP 204 the client closes for good instead of scheduling
-            // a reconnect. Check after the close has run; without this the
-            // promise would silently hang until the completion timeout.
-            queueMicrotask(() => {
-              if (!settled && !this.killed && eventSource.readyState === 'closed') {
-                fail(new Error(`event stream to ${eventsUrl} was closed by the server (HTTP 204)`));
-              }
-            });
-          },
-        });
-        this.sseConnection = eventSource;
+      // Settle-once pair. Both paths close the source: the EventSource
+      // reconnects on its own otherwise, even after the promise is done.
+      let settled = false;
+      let connectedAt = 0;
+      let deadSince = 0;
+      let lastCycleAt = 0;
+      let proofOfLifeThisCycle = false;
+      let cleanResponseThisCycle = false;
+      let lastStreamError: Error | undefined;
+      const cleanup = () => {
+        eventSource.close();
+        signal.removeEventListener('abort', onAbort);
+      };
+      const succeed = (exitCode: number) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(exitCode);
+      };
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const onAbort = () => fail(new Error('killed'));
 
-        this.abortController.signal.addEventListener('abort', () => reject(new Error('killed')), {
-          once: true,
-        });
-      } catch (err) {
-        if (!this.killed) {
-          this.log('warn', `SSE setup failed: ${err}`);
+      // Stream health is judged at the fetch surface, where the response
+      // status is visible; the library fires onConnect for error responses
+      // too, so an error page held open must not read as a healthy
+      // connection. An HTTP 204 makes the EventSource close for good
+      // without reporting anything, so it must fail here. A rejected fetch
+      // never reaches onDisconnect (the hazard sseFetch exists for):
+      // capture it for the give-up message and let the clock decide, so
+      // one transient refusal does not kill a live build.
+      const fetchWithStreamPolicy: Fetch = async (input, init) => {
+        const response = await nodeProxyTransport.fetch(input, init);
+        if (response.status === 204) {
+          fail(new ExecStreamClosedError(`event stream to ${eventsUrl} was closed by the server (HTTP 204)`));
+        } else if (!response.ok) {
+          lastStreamError = new Error(`server answered HTTP ${response.status}`);
         }
-        reject(err);
-      }
+        cleanResponseThisCycle = response.ok;
+        return response;
+      };
+
+      const eventSource = createEventSource({
+        url: eventsUrl,
+        fetch: sseFetch(fetchWithStreamPolicy, (err) => {
+          lastStreamError = err instanceof Error ? err : new Error(String(err));
+        }),
+        headers: { Authorization: `Bearer ${this.options.token}` },
+        onConnect: () => {
+          connectedAt = Date.now();
+        },
+        // Comments count as proof of life, so a server-side keepalive
+        // works without a client change (onMessage never sees them).
+        onComment: () => {
+          proofOfLifeThisCycle = true;
+        },
+        // Fires once per broken cycle, before the retry timer is armed, on
+        // both failure paths (request rejected, stream ended). This is
+        // where the give-up clock runs.
+        onScheduleReconnect: () => {
+          if (settled || this.killed) {
+            return;
+          }
+          const now = Date.now();
+          const livedMs = connectedAt > 0 ? now - connectedAt : 0;
+          connectedAt = 0;
+          // Date.now() is wall clock: a laptop waking from sleep (or a
+          // clock step) would arrive with the whole window already
+          // "elapsed" and fail on its first attempt. An implausibly long
+          // gap between cycles restarts the streak instead.
+          if (deadSince > 0 && lastCycleAt > 0 && now - lastCycleAt > sseStreamPolicy.giveUpAfterMs) {
+            deadSince = now;
+          }
+          lastCycleAt = now;
+          const healthy =
+            proofOfLifeThisCycle ||
+            (cleanResponseThisCycle && livedMs >= sseStreamPolicy.healthyConnectionMs);
+          proofOfLifeThisCycle = false;
+          cleanResponseThisCycle = false;
+          if (healthy) {
+            deadSince = 0;
+            lastStreamError = undefined;
+            return;
+          }
+          if (deadSince === 0) {
+            deadSince = now;
+            this.log('warn', 'SSE disconnected; reconnecting');
+            return;
+          }
+          if (now - deadSince >= sseStreamPolicy.giveUpAfterMs) {
+            const seconds = Math.round((now - deadSince) / 1000);
+            const cause = lastStreamError ? `; last error: ${lastStreamError.message}` : '';
+            fail(
+              new ExecStreamLostError(
+                `event stream to ${eventsUrl} kept failing for ${seconds}s without delivering events${cause}; ` +
+                  'the execution may no longer exist (instance deleted or record expired)',
+              ),
+            );
+          }
+        },
+        onMessage: (message: EventSourceMessage) => {
+          deadSince = 0;
+          proofOfLifeThisCycle = true;
+          lastStreamError = undefined;
+          const data = typeof message.data === 'string' ? message.data : String(message.data ?? '');
+          const eventType = message.event;
+          if (eventType === 'command') {
+            this.command.emit('data', data);
+          } else if (eventType === 'stdout') {
+            this.stdout.emit('data', data);
+          } else if (eventType === 'stderr') {
+            this.stderr.emit('data', data);
+          } else if (eventType === 'testflight') {
+            try {
+              this.appStoreEvent = JSON.parse(data) as AppStoreEvent;
+            } catch {
+              // The wire event itself proves the server ran the App Store upload,
+              // so never let a payload glitch look like a missing feature.
+              this.appStoreEvent = { state: 'unknown' };
+              this.log('warn', `SSE testflight event has invalid data: ${data}`);
+            }
+          } else if (eventType === 'playstore') {
+            try {
+              this.playstoreEvent = JSON.parse(data) as PlaystoreEvent;
+            } catch {
+              // Same contract as the App Store upload event: its presence proves the server
+              // ran the Play Store step, so a payload glitch must not
+              // read as a missing feature.
+              this.playstoreEvent = { state: 'unknown' };
+              this.log('warn', `SSE playstore event has invalid data: ${data}`);
+            }
+          } else if (eventType === 'exitCode') {
+            const exitCode = parseInt(data, 10);
+            if (Number.isNaN(exitCode)) {
+              this.log('warn', `SSE exitCode event has invalid data: ${data}`);
+              return;
+            }
+            this.log('debug', `Execution completed via SSE: exitCode=${exitCode}`);
+            succeed(exitCode);
+          }
+        },
+      });
+      this.sseConnection = eventSource;
+      signal.addEventListener('abort', onAbort, { once: true });
     });
   }
 }

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -363,6 +363,10 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
   private abortController = new AbortController();
   private sseConnection: EventSourceClient | null = null;
   private killed = false;
+  // Start of the stream's current unbroken failure streak, 0 while
+  // healthy. run() reads it to classify a completion timeout that
+  // expired while the stream was already dead.
+  private streamDeadSince = 0;
   private detached = false;
   private appStoreEvent: AppStoreEvent | null = null;
   private playstoreEvent: PlaystoreEvent | null = null;
@@ -554,12 +558,21 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
         // The client stopped waiting; the fabricated exit code must not
         // read as a build failure. The structured reason lets callers give
         // the right advice: a dead stream means the execution may be gone,
-        // while a genuine timeout means it may still be running.
-        const message = err instanceof Error ? err.message : String(err);
-        const reason =
+        // while a genuine timeout means it may still be running. A budget
+        // that expires mid-failure-streak (short run timeouts undercut the
+        // stream's own give-up window) counts as a stream problem too.
+        let message = err instanceof Error ? err.message : String(err);
+        const streakMs = this.streamDeadSince > 0 ? Date.now() - this.streamDeadSince : 0;
+        let reason: NonNullable<ExecResult['incomplete']>['reason'] =
           err instanceof ExecStreamClosedError ? 'stream-closed'
           : err instanceof ExecStreamLostError ? 'stream-lost'
           : 'timeout';
+        if (reason === 'timeout' && streakMs > 0) {
+          reason = 'stream-lost';
+          message += `; the event stream had been failing for ${Math.round(
+            streakMs / 1000,
+          )}s when the budget expired`;
+        }
         incomplete = { reason, message };
         log('warn', message);
         exitCode = 1;
@@ -622,8 +635,8 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       // reconnects on its own otherwise, even after the promise is done.
       let settled = false;
       let connectedAt = 0;
-      let deadSince = 0;
       let lastCycleAt = 0;
+      let lastCycleMono = 0;
       let proofOfLifeThisCycle = false;
       let cleanResponseThisCycle = false;
       let lastStreamError: Error | undefined;
@@ -686,33 +699,42 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
             return;
           }
           const now = Date.now();
+          const mono = performance.now();
           const livedMs = connectedAt > 0 ? now - connectedAt : 0;
           connectedAt = 0;
           // Date.now() is wall clock: a laptop waking from sleep (or a
           // clock step) would arrive with the whole window already
-          // "elapsed" and fail on its first attempt. An implausibly long
-          // gap between cycles restarts the streak instead.
-          if (deadSince > 0 && lastCycleAt > 0 && now - lastCycleAt > sseStreamPolicy.giveUpAfterMs) {
-            deadSince = now;
+          // "elapsed" and fail on its first attempt. Sleep is the wall
+          // clock advancing while the monotonic clock stands still; a
+          // large drift between the two restarts the streak. Long server
+          // retry delays and hanging connects advance both clocks equally
+          // and keep counting.
+          if (this.streamDeadSince > 0 && lastCycleAt > 0) {
+            const wallGapMs = now - lastCycleAt;
+            const monoGapMs = mono - lastCycleMono;
+            if (wallGapMs - monoGapMs > 30_000) {
+              this.streamDeadSince = now;
+            }
           }
           lastCycleAt = now;
+          lastCycleMono = mono;
           const healthy =
             proofOfLifeThisCycle ||
             (cleanResponseThisCycle && livedMs >= sseStreamPolicy.healthyConnectionMs);
           proofOfLifeThisCycle = false;
           cleanResponseThisCycle = false;
           if (healthy) {
-            deadSince = 0;
+            this.streamDeadSince = 0;
             lastStreamError = undefined;
             return;
           }
-          if (deadSince === 0) {
-            deadSince = now;
+          if (this.streamDeadSince === 0) {
+            this.streamDeadSince = now;
             this.log('warn', 'SSE disconnected; reconnecting');
             return;
           }
-          if (now - deadSince >= sseStreamPolicy.giveUpAfterMs) {
-            const seconds = Math.round((now - deadSince) / 1000);
+          if (now - this.streamDeadSince >= sseStreamPolicy.giveUpAfterMs) {
+            const seconds = Math.round((now - this.streamDeadSince) / 1000);
             const cause = lastStreamError ? `; last error: ${lastStreamError.message}` : '';
             fail(
               new ExecStreamLostError(
@@ -723,7 +745,7 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
           }
         },
         onMessage: (message: EventSourceMessage) => {
-          deadSince = 0;
+          this.streamDeadSince = 0;
           proofOfLifeThisCycle = true;
           lastStreamError = undefined;
           const data = typeof message.data === 'string' ? message.data : String(message.data ?? '');

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -569,9 +569,10 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
           : 'timeout';
         if (reason === 'timeout' && streakMs > 0) {
           reason = 'stream-lost';
-          message += `; the event stream had been failing for ${Math.round(
-            streakMs / 1000,
-          )}s when the budget expired`;
+          message =
+            `the completion budget expired while the event stream had already been failing ` +
+            `for ${Math.round(streakMs / 1000)}s; the execution may no longer exist ` +
+            `(instance deleted or record expired)`;
         }
         incomplete = { reason, message };
         log('warn', message);

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -8,6 +8,14 @@
 import { createEventSource, type EventSourceClient, type EventSourceMessage } from 'eventsource-client';
 import { nodeProxyTransport } from './internal/proxy-transport';
 
+// Reconnect budget for the exec event stream. The EventSource reconnects
+// forever on its own, so a dead exec (deleted instance, expired record)
+// would retry every ~2s until the one-hour completion timeout. A connection
+// that delivers a message or stays open this long proves the server is
+// alive and refills the budget; each shorter cycle spends one attempt.
+const SSE_HEALTHY_CONNECTION_MS = 15_000;
+const SSE_MAX_FAILED_CYCLES = 20;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -509,14 +517,17 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
           timeoutId = setTimeout(() => reject(new Error('SSE timeout')), timeoutMs);
         }),
       ]);
-    } catch {
+    } catch (err) {
       if (this.killed) {
         log('debug', 'Execution killed');
         exitCode = -1;
       } else {
         // The client stopped waiting; the remote build may still be running.
-        // The fabricated exit code must not read as a build failure.
-        log('warn', 'SSE completion timeout');
+        // The fabricated exit code must not read as a build failure. Name
+        // the real reason: budget exhaustion and server-closed streams are
+        // actionable, a bare "timeout" is not.
+        const reason = err instanceof Error && err.message !== 'SSE timeout' ? err.message : 'SSE completion timeout';
+        log('warn', reason);
         exitCode = 1;
         timedOut = true;
       }
@@ -571,11 +582,47 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
       }
 
       try {
+        let settled = false;
+        let connectedAt = 0;
+        let failedCycles = 0;
+        const fail = (error: Error) => {
+          settled = true;
+          eventSource.close();
+          reject(error);
+        };
         const eventSource = createEventSource({
           url: eventsUrl,
           fetch: nodeProxyTransport.fetch,
           headers: { Authorization: `Bearer ${this.options.token}` },
+          onConnect: () => {
+            connectedAt = Date.now();
+          },
+          // Fires once per broken cycle, before the retry timer is armed,
+          // on both failure paths (request rejected, stream ended). This is
+          // where the budget is spent and enforced.
+          onScheduleReconnect: () => {
+            if (settled || this.killed) {
+              return;
+            }
+            const lifetimeMs = connectedAt > 0 ? Date.now() - connectedAt : 0;
+            connectedAt = 0;
+            if (lifetimeMs >= SSE_HEALTHY_CONNECTION_MS) {
+              failedCycles = 0;
+              return;
+            }
+            failedCycles++;
+            if (failedCycles >= SSE_MAX_FAILED_CYCLES) {
+              this.log('warn', `SSE gave up after ${failedCycles} failed connections in a row`);
+              fail(
+                new Error(
+                  `event stream to ${eventsUrl} failed ${failedCycles} times in a row without receiving events; ` +
+                    'the execution may no longer exist (instance deleted or record expired)',
+                ),
+              );
+            }
+          },
           onMessage: (message: EventSourceMessage) => {
+            failedCycles = 0;
             const data = typeof message.data === 'string' ? message.data : String(message.data ?? '');
             const eventType = message.event;
             if (eventType === 'command') {
@@ -610,13 +657,25 @@ export class ExecChildProcess implements PromiseLike<ExecResult> {
                 return;
               }
               this.log('debug', `Execution completed via SSE: exitCode=${exitCode}`);
+              settled = true;
               resolve(exitCode);
             }
           },
           onDisconnect: () => {
-            if (!this.killed) {
-              this.log('warn', 'SSE disconnected');
+            if (settled || this.killed) {
+              return;
             }
+            // Warn once per failure streak; the budget above bounds the
+            // streak, so this cannot spam for the rest of the run.
+            this.log(failedCycles <= 1 ? 'warn' : 'debug', 'SSE disconnected');
+            // On HTTP 204 the client closes for good instead of scheduling
+            // a reconnect. Check after the close has run; without this the
+            // promise would silently hang until the completion timeout.
+            queueMicrotask(() => {
+              if (!settled && !this.killed && eventSource.readyState === 'closed') {
+                fail(new Error(`event stream to ${eventsUrl} was closed by the server (HTTP 204)`));
+              }
+            });
           },
         });
         this.sseConnection = eventSource;

--- a/tests/exec-client-sse.test.ts
+++ b/tests/exec-client-sse.test.ts
@@ -1,0 +1,101 @@
+import { exec } from '../src/exec-client';
+import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
+import type { RequestInfo } from '../src/internal/builtin-types';
+
+const API_URL = 'https://xcode.example.test';
+const OPTIONS = { apiUrl: API_URL, token: 'test-token' };
+
+const originalFetch = nodeProxyTransport.fetch;
+
+afterEach(() => {
+  nodeProxyTransport.fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+/**
+ * A one-shot SSE response streaming the given frames, then closing. The
+ * `retry: 1` frame drops the client's reconnect delay to 1ms so reconnect
+ * cycles are fast under test.
+ */
+function sseResponse(frames: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('retry: 1\n\n'));
+      for (const frame of frames) {
+        controller.enqueue(new TextEncoder().encode(frame));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+/** Mocks POST /exec plus the events stream; `events` decides each cycle's response. */
+function mockTransport(events: (attempt: number) => Response): { eventsAttempts: () => number } {
+  let attempts = 0;
+  nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) => {
+    const url = String(input);
+    if (url.endsWith('/exec')) {
+      return new Response(JSON.stringify({ execId: 'run-1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/exec/run-1/events')) {
+      attempts++;
+      return events(attempts);
+    }
+    throw new Error(`unexpected request: ${url}`);
+  });
+  return { eventsAttempts: () => attempts };
+}
+
+// A dead event stream (the exec record is gone, or the instance was deleted)
+// must exhaust the reconnect budget and fail within seconds, not spin until
+// the one-hour completion timeout. This pins the budget: exactly
+// SSE_MAX_FAILED_CYCLES connections, then a fabricated timedOut failure.
+test('a stream that never delivers events gives up after the reconnect budget', async () => {
+  const transport = mockTransport(() => sseResponse([]));
+
+  const result = await exec({ command: 'run', commandLine: 'true', timeoutSeconds: 60 }, OPTIONS);
+
+  expect(result.status).toBe('FAILED');
+  expect(result.exitCode).toBe(1);
+  expect(result.timedOut).toBe(true);
+  expect(transport.eventsAttempts()).toBe(20);
+});
+
+// A flapping connection that still delivers events must never trip the
+// budget: each received message refills it. 25 broken cycles (more than the
+// budget) each carry one event; the run must still reach its exit code.
+test('messages reset the reconnect budget across broken connections', async () => {
+  const transport = mockTransport((attempt) =>
+    attempt < 25 ?
+      sseResponse([`event: stdout\ndata: chunk ${attempt}\n\n`])
+    : sseResponse(['event: exitCode\ndata: 0\n\n']),
+  );
+
+  const result = await exec({ command: 'run', commandLine: 'true', timeoutSeconds: 60 }, OPTIONS);
+
+  expect(result.status).toBe('SUCCEEDED');
+  expect(result.exitCode).toBe(0);
+  expect(transport.eventsAttempts()).toBe(25);
+});
+
+// On HTTP 204 the EventSource closes permanently without scheduling a
+// reconnect, so nothing else would ever settle the stream promise. The
+// client must detect the close and fail immediately instead of hanging
+// until the completion timeout.
+test('a 204 response fails the execution immediately instead of hanging', async () => {
+  const transport = mockTransport(() => new Response(null, { status: 204 }));
+
+  const result = await exec({ command: 'run', commandLine: 'true', timeoutSeconds: 60 }, OPTIONS);
+
+  expect(result.status).toBe('FAILED');
+  expect(result.exitCode).toBe(1);
+  expect(result.timedOut).toBe(true);
+  expect(transport.eventsAttempts()).toBe(1);
+});

--- a/tests/exec-client-sse.test.ts
+++ b/tests/exec-client-sse.test.ts
@@ -1,40 +1,45 @@
-import { exec } from '../src/exec-client';
+import { exec, sseStreamPolicy } from '../src/exec-client';
 import { nodeProxyTransport } from '@limrun/api/internal/proxy-transport';
 import type { RequestInfo } from '../src/internal/builtin-types';
 
 const API_URL = 'https://xcode.example.test';
-const OPTIONS = { apiUrl: API_URL, token: 'test-token' };
 
 const originalFetch = nodeProxyTransport.fetch;
+const originalPolicy = { ...sseStreamPolicy };
 
 afterEach(() => {
   nodeProxyTransport.fetch = originalFetch;
+  Object.assign(sseStreamPolicy, originalPolicy);
   jest.restoreAllMocks();
 });
 
 /**
- * A one-shot SSE response streaming the given frames, then closing. The
- * `retry: 1` frame drops the client's reconnect delay to 1ms so reconnect
+ * A one-shot SSE response with the given frames, closed immediately. The
+ * `retry: 1` prologue drops the client's reconnect delay to 1ms so broken
  * cycles are fast under test.
  */
-function sseResponse(frames: string[]): Response {
+const sseResponse = (frames: string[]): Response =>
+  new Response('retry: 1\n\n' + frames.join(''), {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+
+/** An SSE response that delivers its frames, then stays open for holdMs before closing. */
+const heldSseResponse = (frames: string[], holdMs: number, status = 200): Response => {
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       controller.enqueue(new TextEncoder().encode('retry: 1\n\n'));
       for (const frame of frames) {
         controller.enqueue(new TextEncoder().encode(frame));
       }
-      controller.close();
+      setTimeout(() => controller.close(), holdMs);
     },
   });
-  return new Response(body, {
-    status: 200,
-    headers: { 'Content-Type': 'text/event-stream' },
-  });
-}
+  return new Response(body, { status, headers: { 'Content-Type': 'text/event-stream' } });
+};
 
 /** Mocks POST /exec plus the events stream; `events` decides each cycle's response. */
-function mockTransport(events: (attempt: number) => Response): { eventsAttempts: () => number } {
+function mockTransport(events: (attempt: number) => Response): () => number {
   let attempts = 0;
   nodeProxyTransport.fetch = jest.fn(async (input: RequestInfo) => {
     const url = String(input);
@@ -50,52 +55,121 @@ function mockTransport(events: (attempt: number) => Response): { eventsAttempts:
     }
     throw new Error(`unexpected request: ${url}`);
   });
-  return { eventsAttempts: () => attempts };
+  return () => attempts;
 }
 
-// A dead event stream (the exec record is gone, or the instance was deleted)
-// must exhaust the reconnect budget and fail within seconds, not spin until
-// the one-hour completion timeout. This pins the budget: exactly
-// SSE_MAX_FAILED_CYCLES connections, then a fabricated timedOut failure.
-test('a stream that never delivers events gives up after the reconnect budget', async () => {
-  const transport = mockTransport(() => sseResponse([]));
+function run(log?: (level: string, msg: string) => void) {
+  return exec(
+    { command: 'run', commandLine: 'true', timeoutSeconds: 60 },
+    { apiUrl: API_URL, token: 'test-token', ...(log ? { log } : {}) },
+  );
+}
 
-  const result = await exec({ command: 'run', commandLine: 'true', timeoutSeconds: 60 }, OPTIONS);
+// A dead event stream (the exec record is gone, or the instance was
+// deleted) must exhaust the give-up clock and fail within it, not spin
+// until the one-hour completion timeout. The structured reason lets
+// callers distinguish this from a genuine completion timeout.
+test('a stream that never delivers events gives up after the policy window', async () => {
+  sseStreamPolicy.giveUpAfterMs = 200;
+  const attempts = mockTransport(() => sseResponse([]));
+
+  const result = await run();
 
   expect(result.status).toBe('FAILED');
   expect(result.exitCode).toBe(1);
   expect(result.timedOut).toBe(true);
-  expect(transport.eventsAttempts()).toBe(20);
+  expect(result.incomplete?.reason).toBe('stream-lost');
+  expect(result.incomplete?.message).toContain('may no longer exist');
+  expect(attempts()).toBeGreaterThan(2);
 });
 
 // A flapping connection that still delivers events must never trip the
-// budget: each received message refills it. 25 broken cycles (more than the
-// budget) each carry one event; the run must still reach its exit code.
-test('messages reset the reconnect budget across broken connections', async () => {
-  const transport = mockTransport((attempt) =>
+// clock: each received event resets it. Every cycle here holds 10ms, so
+// the 24 broken cycles span >240ms against a 100ms window; without the
+// event reset the run would fail around the tenth cycle.
+test('delivered events keep resetting the give-up clock', async () => {
+  sseStreamPolicy.giveUpAfterMs = 100;
+  const attempts = mockTransport((attempt) =>
     attempt < 25 ?
-      sseResponse([`event: stdout\ndata: chunk ${attempt}\n\n`])
+      heldSseResponse([`event: stdout\ndata: chunk ${attempt}\n\n`], 10)
     : sseResponse(['event: exitCode\ndata: 0\n\n']),
   );
 
-  const result = await exec({ command: 'run', commandLine: 'true', timeoutSeconds: 60 }, OPTIONS);
+  const result = await run();
 
   expect(result.status).toBe('SUCCEEDED');
   expect(result.exitCode).toBe(0);
-  expect(transport.eventsAttempts()).toBe(25);
+  expect(attempts()).toBe(25);
+});
+
+// A quiet build behind an idle-killing intermediary: connections stream
+// nothing but stay open. Each cleanly held connection counts as proof of
+// life, so cycling well past the give-up window must not abort the run.
+test('long-lived silent connections keep resetting the give-up clock', async () => {
+  sseStreamPolicy.healthyConnectionMs = 30;
+  sseStreamPolicy.giveUpAfterMs = 100;
+  const attempts = mockTransport((attempt) =>
+    attempt < 6 ? heldSseResponse([], 50) : sseResponse(['event: exitCode\ndata: 0\n\n']),
+  );
+
+  const result = await run();
+
+  expect(result.status).toBe('SUCCEEDED');
+  expect(result.exitCode).toBe(0);
+  expect(attempts()).toBe(6);
+});
+
+// An error response held open must NOT count as proof of life: only clean
+// responses do. Otherwise a dead exec behind a slow intermediary would
+// reset the clock every cycle and degrade back into the hour-long hang.
+// The give-up error must also name the status instead of speculating.
+test('a held-open error response neither resets the clock nor hides its status', async () => {
+  sseStreamPolicy.healthyConnectionMs = 30;
+  sseStreamPolicy.giveUpAfterMs = 100;
+  const attempts = mockTransport(() => heldSseResponse([], 50, 404));
+
+  const result = await run();
+
+  expect(result.status).toBe('FAILED');
+  expect(result.timedOut).toBe(true);
+  expect(result.incomplete?.reason).toBe('stream-lost');
+  expect(result.incomplete?.message).toContain('HTTP 404');
+  expect(attempts()).toBeGreaterThan(1);
 });
 
 // On HTTP 204 the EventSource closes permanently without scheduling a
 // reconnect, so nothing else would ever settle the stream promise. The
-// client must detect the close and fail immediately instead of hanging
+// fetch wrapper must detect it and fail immediately instead of hanging
 // until the completion timeout.
 test('a 204 response fails the execution immediately instead of hanging', async () => {
-  const transport = mockTransport(() => new Response(null, { status: 204 }));
+  const attempts = mockTransport(() => new Response(null, { status: 204 }));
 
-  const result = await exec({ command: 'run', commandLine: 'true', timeoutSeconds: 60 }, OPTIONS);
+  const result = await run();
 
   expect(result.status).toBe('FAILED');
   expect(result.exitCode).toBe(1);
   expect(result.timedOut).toBe(true);
-  expect(transport.eventsAttempts()).toBe(1);
+  expect(result.incomplete?.reason).toBe('stream-closed');
+  expect(attempts()).toBe(1);
+});
+
+// A rejected fetch (connection refused, DNS dead) never reaches the
+// library's disconnect callback; sseFetch captures it so the give-up error
+// names the real cause instead of a generic message.
+test('the give-up message carries the last fetch rejection', async () => {
+  sseStreamPolicy.giveUpAfterMs = 200;
+  const warns: string[] = [];
+  mockTransport((attempt) => {
+    if (attempt === 1) return sseResponse([]);
+    throw new Error('connect ECONNREFUSED 10.0.0.1:443');
+  });
+
+  const result = await run((level, msg) => {
+    if (level === 'warn') warns.push(msg);
+  });
+
+  expect(result.status).toBe('FAILED');
+  expect(result.timedOut).toBe(true);
+  expect(result.incomplete?.message).toContain('ECONNREFUSED');
+  expect(warns.some((msg) => msg.includes('ECONNREFUSED'))).toBe(true);
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core client-side failure detection for remote builds and runs, so mis-tuned give-up windows could abort live work early or still hang on dead streams. Covered by new SSE policy tests, but behavior under flaky networks is user-visible.
> 
> **Overview**
> Stops the exec event stream from reconnecting forever until the hour-long completion timeout when a remote execution is already gone.
> 
> Adds a **give-up policy** on the SSE connection: unbroken failure streaks fail after ~5 minutes unless proof of life arrives (events, comments, or a clean connection held open long enough). HTTP 204 closes immediately as `stream-closed`, and rejected fetches are captured so give-up errors name the real cause.
> 
> `ExecResult` now carries structured `incomplete` reasons (`timeout` | `stream-lost` | `stream-closed`). CLI xcode/gradle build and run commands use that to tell users when the remote work may still be running versus when the execution may no longer exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51a25a880d8128cdeba261300e26d9c8fcea392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->