### PR TITLE
Add destination-routed iOS tunnel client and CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
         "description": "Build Android projects on cloud gradle sandboxes"
       },
       "ios": {
-        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, keychain, record, perform, simctl, cp, xcrun, xcodebuild, lsof, reverse"
+        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, keychain, record, perform, simctl, cp, xcrun, xcodebuild, lsof, reverse, tunnel"
       },
       "session": {
         "description": "Manage persistent background sessions for device interaction: start, status, stop. Sessions are used to execute commands on remote devices without the need to reconnect to the device after each command."

--- a/packages/cli/src/commands/ios/tunnel/index.ts
+++ b/packages/cli/src/commands/ios/tunnel/index.ts
@@ -11,6 +11,7 @@ import {
   clearTunnelProcess,
   formatTunnelRoute,
   isProcessAlive,
+  isSpawnedTunnelProcessAlive,
   listTunnelProcesses,
   loadTunnelProcess,
   newTunnelOwner,
@@ -226,7 +227,7 @@ export default class IosTunnel extends BaseCommand {
 
     const readiness = await waitForTunnelProcessReady({
       load: () => loadTunnelProcess(instanceId, owner),
-      isAlive: () => isProcessAlive(pid),
+      isAlive: () => isSpawnedTunnelProcessAlive(child, pid),
       sleep: defaultSleep,
     });
     if (readiness.outcome === 'ready') {

--- a/packages/cli/src/commands/ios/tunnel/index.ts
+++ b/packages/cli/src/commands/ios/tunnel/index.ts
@@ -11,7 +11,6 @@ import {
   clearTunnelProcess,
   formatTunnelRoute,
   isProcessAlive,
-  isTunnelOwnerProcessAlive,
   listTunnelProcesses,
   loadTunnelProcess,
   newTunnelOwner,
@@ -19,6 +18,7 @@ import {
   prepareTunnelLog,
   readTunnelLogTail,
   tunnelChildEnvironment,
+  tunnelOwnerProcessIdentity,
   tunnelProcessPaths,
   tunnelProcessStartingLeaseExpired,
   updateTunnelProcess,
@@ -157,11 +157,13 @@ export default class IosTunnel extends BaseCommand {
   ): Promise<void> {
     await this.assertNoActiveTunnel(instanceId);
     this.clearDeadOwners(instanceId);
-    const liveOwner = listTunnelProcesses(instanceId).find(
-      (state) =>
-        (state.status === 'starting' && !tunnelProcessStartingLeaseExpired(state)) ||
-        isTunnelOwnerProcessAlive(state),
-    );
+    const liveOwner = listTunnelProcesses(instanceId).find((state) => {
+      if (state.status === 'starting' && !tunnelProcessStartingLeaseExpired(state)) {
+        return true;
+      }
+      const identity = tunnelOwnerProcessIdentity(state);
+      return identity === 'match' || identity === 'unknown';
+    });
     if (liveOwner) {
       this.error(
         `A local tunnel process is already ${liveOwner.status} for ${instanceId} (PID ${liveOwner.pid}). ` +
@@ -280,11 +282,18 @@ export default class IosTunnel extends BaseCommand {
 
   private clearDeadOwners(instanceId: string): void {
     for (const state of listTunnelProcesses(instanceId)) {
-      if (
-        !isTunnelOwnerProcessAlive(state) &&
-        (state.status === 'ready' || tunnelProcessStartingLeaseExpired(state))
-      ) {
-        clearTunnelProcess(instanceId, state.owner);
+      const identity = tunnelOwnerProcessIdentity(state);
+      if (identity === 'unknown') {
+        this.error(
+          `Cannot verify local tunnel owner PID ${state.pid}; ownership state was retained at ${state.logPath}.`,
+        );
+      }
+      if (identity === 'match') continue;
+      if (state.status === 'starting' && !tunnelProcessStartingLeaseExpired(state)) continue;
+      if (!clearTunnelProcess(instanceId, state.owner)) {
+        this.error(
+          `Cannot clean local tunnel owner PID ${state.pid}; stop it before starting another tunnel.`,
+        );
       }
     }
   }

--- a/packages/cli/src/commands/ios/tunnel/index.ts
+++ b/packages/cli/src/commands/ios/tunnel/index.ts
@@ -1,0 +1,364 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import { Flags } from '@oclif/core';
+import { defaultSleep, type Ios } from '@limrun/api';
+import { BaseCommand } from '../../../base-command';
+import { getIosInstanceClient } from '../../../lib/instance-client-factory';
+import {
+  buildTunnelServeArgs,
+  capTunnelLog,
+  claimTunnelProcess,
+  clearTunnelProcess,
+  formatTunnelRoute,
+  isProcessAlive,
+  isTunnelOwnerProcessAlive,
+  listTunnelProcesses,
+  loadTunnelProcess,
+  newTunnelOwner,
+  parseTunnelRoute,
+  prepareTunnelLog,
+  readTunnelLogTail,
+  tunnelChildEnvironment,
+  tunnelProcessPaths,
+  tunnelProcessStartingLeaseExpired,
+  updateTunnelProcess,
+  waitForTunnelProcessReady,
+  type IosTunnelProcessState,
+} from '../../../lib/ios-tunnel-process';
+
+export default class IosTunnel extends BaseCommand {
+  static summary = 'Expose declared local TCP destinations to the simulator';
+  static description =
+    'Start one destination-routed tunnel with exact host:port routes. The returned simulator endpoints map to those services on this machine. Use --detach to keep it running after this command returns.';
+  static examples = [
+    '<%= config.bin %> ios tunnel --route localhost:8000 --id <instance-ID>',
+    '<%= config.bin %> ios tunnel --route api.internal:443 --route localhost:8081 --detach',
+    '<%= config.bin %> ios tunnel status --id <instance-ID>',
+    '<%= config.bin %> ios tunnel stop --id <instance-ID>',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description:
+        'iOS instance ID to target. Defaults to the last created iOS instance, but --id is recommended for scripts and agents.',
+    }),
+    route: Flags.string({
+      description: 'Exact client-side TCP destination as host:port or [IPv6]:port. Repeat for more routes.',
+      multiple: true,
+      required: true,
+    }),
+    detach: Flags.boolean({
+      description: 'Run in a detached background process and return after READY.',
+      default: false,
+    }),
+    serve: Flags.boolean({
+      description: 'Internal: own the detached tunnel transport.',
+      default: false,
+      hidden: true,
+    }),
+    'tunnel-owner': Flags.string({
+      description: 'Internal: detached process ownership token.',
+      hidden: true,
+      dependsOn: ['serve'],
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosTunnel);
+    this.setParsedFlags(flags);
+    if (flags.detach && flags.serve) {
+      this.error('--detach cannot be combined with internal --serve mode.');
+    }
+    const routes = flags.route.map(parseTunnelRoute);
+
+    if (flags.serve) {
+      const owner = flags['tunnel-owner'];
+      if (!owner) this.error('--serve requires --tunnel-owner.');
+      await this.withAuth(async () => {
+        const resolvedInstance = this.resolveIosInstance(flags.id);
+        await this.serveDetached(resolvedInstance.id, owner, routes);
+      });
+      return;
+    }
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      if (flags.detach) {
+        await this.startDetached(resolvedInstance.id, routes, flags['api-key']);
+      } else {
+        await this.runForeground(resolvedInstance.id, routes);
+      }
+    });
+  }
+
+  private async runForeground(instanceId: string, routes: Ios.TunnelOptions['routes']): Promise<void> {
+    const resolvedInstance = this.resolveIosInstance(instanceId);
+    const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+    let tunnel: Ios.Tunnel | undefined;
+    try {
+      tunnel = await client.startTunnel({
+        routes,
+        logLevel: this.shouldSuppressInfo() ? 'none' : 'info',
+      });
+      this.printReady(instanceId, tunnel, false);
+      await this.awaitTunnel(tunnel, false);
+    } finally {
+      tunnel?.close();
+      disconnect();
+    }
+  }
+
+  private async serveDetached(
+    instanceId: string,
+    owner: string,
+    routes: Ios.TunnelOptions['routes'],
+  ): Promise<void> {
+    const ownershipDeadline = Date.now() + 2_000;
+    let starting = loadTunnelProcess(instanceId, owner);
+    while (starting?.pid !== process.pid && Date.now() < ownershipDeadline) {
+      await defaultSleep(25);
+      starting = loadTunnelProcess(instanceId, owner);
+    }
+    if (!starting || starting.pid !== process.pid) {
+      this.error('Detached tunnel ownership handshake failed.');
+    }
+
+    const resolvedInstance = this.resolveIosInstance(instanceId);
+    const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+    let tunnel: Ios.Tunnel | undefined;
+    const capLogs = setInterval(() => capTunnelLog(starting.logPath), 30_000);
+    try {
+      tunnel = await client.startTunnel({ routes, logLevel: 'info' });
+      updateTunnelProcess(
+        {
+          ...starting,
+          status: 'ready',
+          routes: tunnel.bindings.map((binding) => binding.route),
+          tunnelId: tunnel.tunnelId,
+          bindings: tunnel.bindings,
+        },
+        owner,
+      );
+      await this.awaitTunnel(tunnel, true);
+    } finally {
+      clearInterval(capLogs);
+      capTunnelLog(starting.logPath);
+      tunnel?.close();
+      disconnect();
+      clearTunnelProcess(instanceId, owner);
+    }
+  }
+
+  private async startDetached(
+    instanceId: string,
+    routes: Ios.TunnelOptions['routes'],
+    apiKey: string | undefined,
+  ): Promise<void> {
+    await this.assertNoActiveTunnel(instanceId);
+    this.clearDeadOwners(instanceId);
+    const liveOwner = listTunnelProcesses(instanceId).find(
+      (state) =>
+        (state.status === 'starting' && !tunnelProcessStartingLeaseExpired(state)) ||
+        isTunnelOwnerProcessAlive(state),
+    );
+    if (liveOwner) {
+      this.error(
+        `A local tunnel process is already ${liveOwner.status} for ${instanceId} (PID ${liveOwner.pid}). ` +
+          `Run \`lim ios tunnel status --id ${instanceId}\` or stop it first.`,
+      );
+    }
+
+    const owner = newTunnelOwner();
+    const paths = tunnelProcessPaths(instanceId, owner);
+    const starting: IosTunnelProcessState = {
+      owner,
+      pid: 0,
+      instanceId,
+      status: 'starting',
+      routes,
+      startedAt: new Date().toISOString(),
+      logPath: paths.log,
+    };
+    if (!claimTunnelProcess(starting)) {
+      this.error('Failed to claim detached tunnel process state.');
+    }
+
+    const scriptPath = process.argv[1];
+    if (!scriptPath) {
+      clearTunnelProcess(instanceId, owner);
+      this.error('Cannot locate the lim CLI entrypoint for detached startup.');
+    }
+
+    const logDescriptor = prepareTunnelLog(paths.log);
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(
+        process.execPath,
+        buildTunnelServeArgs({
+          scriptPath,
+          instanceId,
+          owner,
+          routes,
+        }),
+        {
+          detached: true,
+          windowsHide: true,
+          stdio: ['ignore', logDescriptor, logDescriptor],
+          env: tunnelChildEnvironment(apiKey),
+        },
+      );
+    } catch (error) {
+      fs.closeSync(logDescriptor);
+      clearTunnelProcess(instanceId, owner);
+      throw error;
+    }
+    fs.closeSync(logDescriptor);
+    child.unref();
+    const pid = child.pid;
+    if (!pid) {
+      clearTunnelProcess(instanceId, owner);
+      this.error('Failed to spawn the detached tunnel process.');
+    }
+    updateTunnelProcess({ ...starting, pid }, owner);
+
+    const readiness = await waitForTunnelProcessReady({
+      load: () => loadTunnelProcess(instanceId, owner),
+      isAlive: () => isProcessAlive(pid),
+      sleep: defaultSleep,
+    });
+    if (readiness.outcome === 'ready') {
+      const state = readiness.state;
+      this.printReady(
+        instanceId,
+        {
+          tunnelId: state.tunnelId,
+          bindings: state.bindings,
+        },
+        true,
+        { pid, logPath: paths.log },
+      );
+      return;
+    }
+    if (readiness.outcome === 'exited') {
+      clearTunnelProcess(instanceId, owner);
+      this.error(
+        `Detached tunnel exited during startup.\n${readTunnelLogTail(paths.log)}\nLogs: ${paths.log}`,
+      );
+    }
+    child.kill('SIGTERM');
+    let exited = await this.waitForProcessExit(child, pid, 20);
+    if (!exited) {
+      child.kill('SIGKILL');
+      exited = await this.waitForProcessExit(child, pid, 20);
+    }
+    if (exited) {
+      clearTunnelProcess(instanceId, owner);
+    }
+    const retainedOwnership = exited ? '' : ` and PID ${pid} did not exit; its ownership record was retained`;
+    this.error(
+      `Detached tunnel did not become ready within 30s${retainedOwnership}.\n` +
+        `${readTunnelLogTail(paths.log)}\nLogs: ${paths.log}`,
+    );
+  }
+
+  private async assertNoActiveTunnel(instanceId: string): Promise<void> {
+    const resolvedInstance = this.resolveIosInstance(instanceId);
+    const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+    try {
+      const status = await client.getTunnelStatus();
+      if (status.active) {
+        this.error(
+          `Tunnel ${status.active.tunnelId} is already ${status.active.state}. ` +
+            `Run \`lim ios tunnel status --id ${instanceId}\` or stop it first.`,
+        );
+      }
+    } finally {
+      disconnect();
+    }
+  }
+
+  private clearDeadOwners(instanceId: string): void {
+    for (const state of listTunnelProcesses(instanceId)) {
+      if (
+        !isTunnelOwnerProcessAlive(state) &&
+        (state.status === 'ready' || tunnelProcessStartingLeaseExpired(state))
+      ) {
+        clearTunnelProcess(instanceId, state.owner);
+      }
+    }
+  }
+
+  private async awaitTunnel(tunnel: Ios.Tunnel, remoteStopIsClean: boolean): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const keepAlive = setInterval(() => {}, 1 << 30);
+      let stopping = false;
+      const cleanup = () => {
+        clearInterval(keepAlive);
+        unsubscribe();
+        process.off('SIGINT', shutdown);
+        process.off('SIGTERM', shutdown);
+      };
+      const shutdown = () => {
+        stopping = true;
+        cleanup();
+        resolve();
+      };
+      const unsubscribe = tunnel.onConnectionStateChange((state) => {
+        if (state !== 'disconnected' || stopping) return;
+        cleanup();
+        if (remoteStopIsClean) {
+          resolve();
+        } else {
+          reject(new Error('Destination tunnel disconnected unexpectedly'));
+        }
+      });
+      process.once('SIGINT', shutdown);
+      process.once('SIGTERM', shutdown);
+    });
+  }
+
+  private async waitForProcessExit(
+    child: ReturnType<typeof spawn>,
+    pid: number,
+    attempts: number,
+  ): Promise<boolean> {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      if (child.exitCode !== null || child.signalCode !== null || !isProcessAlive(pid)) {
+        return true;
+      }
+      await defaultSleep(100);
+    }
+    return !isProcessAlive(pid);
+  }
+
+  private printReady(
+    instanceId: string,
+    tunnel: Pick<Ios.Tunnel, 'tunnelId' | 'bindings'>,
+    detached: boolean,
+    processInfo?: { pid: number; logPath: string },
+  ): void {
+    const ready = {
+      instanceId,
+      tunnelId: tunnel.tunnelId,
+      state: 'ready' as const,
+      bindings: tunnel.bindings,
+      detached,
+      ...processInfo,
+    };
+    if (this.isJsonEnabled()) {
+      this.outputJson(ready);
+      return;
+    }
+    this.output(`Tunnel ID: ${ready.tunnelId}`);
+    for (const binding of ready.bindings) {
+      this.output(`${formatTunnelRoute(binding.endpoint)} -> ${formatTunnelRoute(binding.route)}`);
+    }
+    if (detached) {
+      this.output(`Logs: ${processInfo?.logPath}`);
+      this.output(`Stop: lim ios tunnel stop --id ${instanceId}`);
+    } else {
+      this.info('Tunnel started. Press Ctrl+C to stop.');
+    }
+  }
+}

--- a/packages/cli/src/commands/ios/tunnel/status.ts
+++ b/packages/cli/src/commands/ios/tunnel/status.ts
@@ -2,6 +2,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base-command';
 import { getIosInstanceClient } from '../../../lib/instance-client-factory';
 import {
+  formatTunnelDialFailure,
   formatTunnelRoute,
   listTunnelProcesses,
   tunnelOwnerProcessIdentity,
@@ -68,6 +69,9 @@ export default class IosTunnelStatus extends BaseCommand {
         }
         if (status.lastFailure) {
           this.output(`Last failure: ${status.lastFailure.tunnelId} (${status.lastFailure.code})`);
+        }
+        if (status.lastDialFailure) {
+          this.output(formatTunnelDialFailure(status.lastDialFailure));
         }
         for (const owner of owners) {
           this.output(

--- a/packages/cli/src/commands/ios/tunnel/status.ts
+++ b/packages/cli/src/commands/ios/tunnel/status.ts
@@ -1,0 +1,84 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../../base-command';
+import { getIosInstanceClient } from '../../../lib/instance-client-factory';
+import {
+  formatTunnelRoute,
+  listTunnelProcesses,
+  tunnelOwnerProcessIdentity,
+} from '../../../lib/ios-tunnel-process';
+
+export default class IosTunnelStatus extends BaseCommand {
+  static summary = 'Show the active destination tunnel';
+  static description =
+    'Query the instance-authoritative tunnel state, listener mappings, most recent failure, and any local detached owner.';
+  static examples = [
+    '<%= config.bin %> ios tunnel status --id <instance-ID>',
+    '<%= config.bin %> ios tunnel status --id <instance-ID> --json',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    create: Flags.boolean({
+      description:
+        'Create a replacement instance if the target is gone. Disabled by default for status queries.',
+      default: false,
+      allowNo: true,
+      hidden: true,
+    }),
+    id: Flags.string({
+      description: 'iOS instance ID to query. Defaults to the last created iOS instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosTunnelStatus);
+    this.setParsedFlags(flags);
+    if (flags.create) {
+      this.error('Tunnel status cannot create a replacement instance.');
+    }
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      try {
+        const status = await client.getTunnelStatus();
+        const owners = listTunnelProcesses(resolvedInstance.id).map((state) => ({
+          owner: state.owner,
+          pid: state.pid,
+          status: state.status,
+          tunnelId: state.tunnelId,
+          logPath: state.logPath,
+          process: tunnelOwnerProcessIdentity(state),
+        }));
+        if (this.isJsonEnabled()) {
+          this.outputJson({
+            instanceId: resolvedInstance.id,
+            ...status,
+            localOwners: owners,
+          });
+          return;
+        }
+
+        if (status.active) {
+          this.output(`Tunnel ${status.active.tunnelId}: ${status.active.state}`);
+          for (const binding of status.active.bindings) {
+            this.output(`${formatTunnelRoute(binding.endpoint)} -> ${formatTunnelRoute(binding.route)}`);
+          }
+        } else {
+          this.output('No active destination tunnel.');
+        }
+        if (status.lastFailure) {
+          this.output(`Last failure: ${status.lastFailure.tunnelId} (${status.lastFailure.code})`);
+        }
+        for (const owner of owners) {
+          this.output(
+            `Local owner: PID ${owner.pid} (${owner.process}, ${owner.status})${
+              owner.logPath ? `, logs: ${owner.logPath}` : ''
+            }`,
+          );
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/ios/tunnel/stop.ts
+++ b/packages/cli/src/commands/ios/tunnel/stop.ts
@@ -1,0 +1,167 @@
+import { Flags } from '@oclif/core';
+import { defaultSleep } from '@limrun/api';
+import { BaseCommand } from '../../../base-command';
+import type { LastIosInstance } from '../../../lib/config';
+import { getIosInstanceClient } from '../../../lib/instance-client-factory';
+import {
+  clearTunnelProcess,
+  isProcessAlive,
+  listTunnelProcesses,
+  loadTunnelProcess,
+  selectTunnelOwnersForStop,
+  signalTunnelOwner,
+  stopTunnelErrorIsNotFound,
+  tunnelOwnerProcessIdentity,
+  type IosTunnelProcessState,
+  type TunnelOwnerProcessIdentity,
+} from '../../../lib/ios-tunnel-process';
+
+export default class IosTunnelStop extends BaseCommand {
+  static summary = 'Stop the active destination tunnel';
+  static description =
+    'Stop the instance-authoritative tunnel by its current ID, then gracefully stop and, if necessary, force-stop verified local detached owners.';
+  static examples = [
+    '<%= config.bin %> ios tunnel stop --id <instance-ID>',
+    '<%= config.bin %> ios tunnel stop --id <instance-ID> --json',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    create: Flags.boolean({
+      description: 'Create a replacement instance if the target is gone. Disabled by default for stop.',
+      default: false,
+      allowNo: true,
+      hidden: true,
+    }),
+    id: Flags.string({
+      description: 'iOS instance ID to stop. Defaults to the last created iOS instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosTunnelStop);
+    this.setParsedFlags(flags);
+    if (flags.create) {
+      this.error('Tunnel stop cannot create a replacement instance.');
+    }
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const ownerSnapshot = listTunnelProcesses(resolvedInstance.id);
+      const remote = await this.stopRemoteTunnel(resolvedInstance);
+      const expectedTunnelId = remote.outcome === 'none' ? undefined : remote.tunnelId;
+      const owners = selectTunnelOwnersForStop(ownerSnapshot, expectedTunnelId);
+      const local = await this.stopLocalOwners(resolvedInstance.id, owners, expectedTunnelId);
+
+      if (this.isJsonEnabled()) {
+        this.outputJson({
+          instanceId: resolvedInstance.id,
+          ...(remote.outcome === 'none' ? {} : { tunnelId: remote.tunnelId }),
+          outcome: remote.outcome,
+          localProcessesStopped: local.processesStopped,
+          localRecordsCleaned: local.recordsCleaned,
+        });
+      } else if (remote.outcome === 'stopped') {
+        this.output(`Stopped destination tunnel ${remote.tunnelId}.`);
+      } else if (remote.outcome === 'gone') {
+        this.output(`Destination tunnel ${remote.tunnelId} was already gone.`);
+      } else if (local.processesStopped > 0 || local.recordsCleaned > 0) {
+        this.output('Cleaned local destination tunnel ownership.');
+      } else {
+        this.output('No active destination tunnel.');
+      }
+    });
+  }
+
+  private async stopRemoteTunnel(
+    resolvedInstance: LastIosInstance,
+  ): Promise<{ outcome: 'none' } | { outcome: 'stopped' | 'gone'; tunnelId: string }> {
+    const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+    try {
+      const status = await client.getTunnelStatus();
+      if (!status.active) return { outcome: 'none' };
+      const tunnelId = status.active.tunnelId;
+      try {
+        await client.stopTunnel(tunnelId);
+      } catch (error) {
+        if (stopTunnelErrorIsNotFound(error)) {
+          return { outcome: 'gone', tunnelId };
+        }
+        throw error;
+      }
+      return { outcome: 'stopped', tunnelId };
+    } finally {
+      disconnect();
+    }
+  }
+
+  private async stopLocalOwners(
+    instanceId: string,
+    owners: IosTunnelProcessState[],
+    expectedTunnelId: string | undefined,
+  ): Promise<{ processesStopped: number; recordsCleaned: number }> {
+    let processesStopped = 0;
+    let recordsCleaned = 0;
+    const retainedOwners: IosTunnelProcessState[] = [];
+    for (const snapshot of owners) {
+      let state = loadTunnelProcess(instanceId, snapshot.owner) ?? snapshot;
+      let identity = tunnelOwnerProcessIdentity(state);
+      const wasRunning = identity === 'match';
+      if (identity === 'match') {
+        await this.waitForPIDExit(state.pid, 50);
+      }
+      state = loadTunnelProcess(instanceId, state.owner) ?? state;
+      identity = tunnelOwnerProcessIdentity(state);
+      if (expectedTunnelId && state.tunnelId !== expectedTunnelId) {
+        if (identity === 'missing' || identity === 'mismatch') {
+          if (clearTunnelProcess(instanceId, state.owner)) {
+            recordsCleaned++;
+          } else {
+            retainedOwners.push(state);
+          }
+        }
+        continue;
+      }
+      if (identity === 'match') {
+        identity = await this.signalOwnerAndRefreshIdentity(state, 'SIGTERM', 20);
+      }
+      if (identity === 'match') {
+        identity = await this.signalOwnerAndRefreshIdentity(state, 'SIGKILL', 20);
+      }
+
+      if (identity === 'match' || identity === 'unknown') {
+        retainedOwners.push(state);
+        continue;
+      }
+      if (!clearTunnelProcess(instanceId, state.owner)) {
+        retainedOwners.push(state);
+        continue;
+      }
+      recordsCleaned++;
+      if (wasRunning) processesStopped++;
+    }
+    if (retainedOwners.length > 0) {
+      this.error(
+        `Could not verify that ${retainedOwners.length} local tunnel process(es) exited. ` +
+          `Ownership records were retained: ${retainedOwners.map((state) => state.logPath).join(', ')}`,
+      );
+    }
+    return { processesStopped, recordsCleaned };
+  }
+
+  private async signalOwnerAndRefreshIdentity(
+    state: IosTunnelProcessState,
+    signal: NodeJS.Signals,
+    attempts: number,
+  ): Promise<TunnelOwnerProcessIdentity> {
+    const result = signalTunnelOwner(state, signal);
+    if (result !== 'signaled') return result;
+    await this.waitForPIDExit(state.pid, attempts);
+    return tunnelOwnerProcessIdentity(state);
+  }
+
+  private async waitForPIDExit(pid: number, attempts: number): Promise<void> {
+    for (let attempt = 0; attempt < attempts && isProcessAlive(pid); attempt++) {
+      await defaultSleep(100);
+    }
+  }
+}

--- a/packages/cli/src/commands/ios/tunnel/stop.ts
+++ b/packages/cli/src/commands/ios/tunnel/stop.ts
@@ -16,6 +16,10 @@ import {
   type TunnelOwnerProcessIdentity,
 } from '../../../lib/ios-tunnel-process';
 
+type RemoteStopOutcome =
+  | { outcome: 'none' }
+  | { outcome: 'stopped' | 'gone'; tunnelId: string };
+
 export default class IosTunnelStop extends BaseCommand {
   static summary = 'Stop the active destination tunnel';
   static description =
@@ -50,12 +54,7 @@ export default class IosTunnelStop extends BaseCommand {
       const remote = await this.stopRemoteTunnel(resolvedInstance);
       const expectedTunnelId = remote.outcome === 'none' ? undefined : remote.tunnelId;
       const owners = selectTunnelOwnersForStop(ownerSnapshot, expectedTunnelId);
-      const local = await this.stopLocalOwners(
-        resolvedInstance.id,
-        owners,
-        expectedTunnelId,
-        remote.outcome === 'stopped',
-      );
+      const local = await this.stopLocalOwners(resolvedInstance.id, owners, remote);
 
       if (this.isJsonEnabled()) {
         this.outputJson({
@@ -79,7 +78,7 @@ export default class IosTunnelStop extends BaseCommand {
 
   private async stopRemoteTunnel(
     resolvedInstance: LastIosInstance,
-  ): Promise<{ outcome: 'none' } | { outcome: 'stopped' | 'gone'; tunnelId: string }> {
+  ): Promise<RemoteStopOutcome> {
     const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
     try {
       const status = await client.getTunnelStatus();
@@ -102,9 +101,9 @@ export default class IosTunnelStop extends BaseCommand {
   private async stopLocalOwners(
     instanceId: string,
     owners: IosTunnelProcessState[],
-    expectedTunnelId: string | undefined,
-    waitForRemoteExit: boolean,
+    remote: RemoteStopOutcome,
   ): Promise<{ processesStopped: number; recordsCleaned: number }> {
+    const expectedTunnelId = remote.outcome === 'none' ? undefined : remote.tunnelId;
     let processesStopped = 0;
     let recordsCleaned = 0;
     const retainedOwners: IosTunnelProcessState[] = [];
@@ -112,7 +111,7 @@ export default class IosTunnelStop extends BaseCommand {
       let state = loadTunnelProcess(instanceId, snapshot.owner) ?? snapshot;
       let identity = tunnelOwnerProcessIdentity(state);
       const wasRunning = identity === 'match';
-      if (identity === 'match' && waitForRemoteExit) {
+      if (identity === 'match' && remote.outcome === 'stopped') {
         await this.waitForPIDExit(state.pid, 50);
       }
       state = loadTunnelProcess(instanceId, state.owner) ?? state;

--- a/packages/cli/src/commands/ios/tunnel/stop.ts
+++ b/packages/cli/src/commands/ios/tunnel/stop.ts
@@ -50,7 +50,12 @@ export default class IosTunnelStop extends BaseCommand {
       const remote = await this.stopRemoteTunnel(resolvedInstance);
       const expectedTunnelId = remote.outcome === 'none' ? undefined : remote.tunnelId;
       const owners = selectTunnelOwnersForStop(ownerSnapshot, expectedTunnelId);
-      const local = await this.stopLocalOwners(resolvedInstance.id, owners, expectedTunnelId);
+      const local = await this.stopLocalOwners(
+        resolvedInstance.id,
+        owners,
+        expectedTunnelId,
+        remote.outcome === 'stopped',
+      );
 
       if (this.isJsonEnabled()) {
         this.outputJson({
@@ -98,6 +103,7 @@ export default class IosTunnelStop extends BaseCommand {
     instanceId: string,
     owners: IosTunnelProcessState[],
     expectedTunnelId: string | undefined,
+    waitForRemoteExit: boolean,
   ): Promise<{ processesStopped: number; recordsCleaned: number }> {
     let processesStopped = 0;
     let recordsCleaned = 0;
@@ -106,7 +112,7 @@ export default class IosTunnelStop extends BaseCommand {
       let state = loadTunnelProcess(instanceId, snapshot.owner) ?? snapshot;
       let identity = tunnelOwnerProcessIdentity(state);
       const wasRunning = identity === 'match';
-      if (identity === 'match') {
+      if (identity === 'match' && waitForRemoteExit) {
         await this.waitForPIDExit(state.pid, 50);
       }
       state = loadTunnelProcess(instanceId, state.owner) ?? state;

--- a/packages/cli/src/commands/ios/tunnel/stop.ts
+++ b/packages/cli/src/commands/ios/tunnel/stop.ts
@@ -16,9 +16,7 @@ import {
   type TunnelOwnerProcessIdentity,
 } from '../../../lib/ios-tunnel-process';
 
-type RemoteStopOutcome =
-  | { outcome: 'none' }
-  | { outcome: 'stopped' | 'gone'; tunnelId: string };
+type RemoteStopOutcome = { outcome: 'none' } | { outcome: 'stopped' | 'gone'; tunnelId: string };
 
 export default class IosTunnelStop extends BaseCommand {
   static summary = 'Stop the active destination tunnel';
@@ -76,9 +74,7 @@ export default class IosTunnelStop extends BaseCommand {
     });
   }
 
-  private async stopRemoteTunnel(
-    resolvedInstance: LastIosInstance,
-  ): Promise<RemoteStopOutcome> {
+  private async stopRemoteTunnel(resolvedInstance: LastIosInstance): Promise<RemoteStopOutcome> {
     const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
     try {
       const status = await client.getTunnelStatus();

--- a/packages/cli/src/lib/ios-tunnel-process.test.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.test.ts
@@ -140,18 +140,8 @@ describe('iOS tunnel process state', () => {
   });
 
   test('does not mistake a reused PID for the spawned child', () => {
-    expect(
-      isSpawnedTunnelProcessAlive(
-        { exitCode: 0, signalCode: null },
-        process.pid,
-      ),
-    ).toBe(false);
-    expect(
-      isSpawnedTunnelProcessAlive(
-        { exitCode: null, signalCode: null },
-        process.pid,
-      ),
-    ).toBe(true);
+    expect(isSpawnedTunnelProcessAlive({ exitCode: 0, signalCode: null }, process.pid)).toBe(false);
+    expect(isSpawnedTunnelProcessAlive({ exitCode: null, signalCode: null }, process.pid)).toBe(true);
   });
 
   test('selects only owners correlated with the fetched server tunnel ID', () => {
@@ -349,10 +339,11 @@ describe('iOS tunnel process state', () => {
     pruneTunnelLogs(INSTANCE_ID, root, 2);
     const directory = tunnelProcessPaths(INSTANCE_ID, OWNER_1, root).directory;
     expect(
-      fs.readdirSync(directory).filter((entry) => entry.endsWith('.log')).sort(),
-    ).toEqual(
-      [`${OWNER_2}.log`, `${OWNER_3}.log`, `${activeOwner}.log`].sort(),
-    );
+      fs
+        .readdirSync(directory)
+        .filter((entry) => entry.endsWith('.log'))
+        .sort(),
+    ).toEqual([`${OWNER_2}.log`, `${OWNER_3}.log`, `${activeOwner}.log`].sort());
     expect(fs.existsSync(`${oldestPaths.log}.1`)).toBe(false);
   });
 

--- a/packages/cli/src/lib/ios-tunnel-process.test.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.test.ts
@@ -1,0 +1,211 @@
+import { spawn } from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  claimTunnelProcess,
+  capTunnelLog,
+  clearTunnelProcess,
+  isTunnelOwnerProcessAlive,
+  listTunnelProcesses,
+  loadTunnelProcess,
+  parseTunnelRoute,
+  prepareTunnelLog,
+  pruneTunnelLogs,
+  readTunnelLogTail,
+  tunnelProcessStartingLeaseExpired,
+  tunnelProcessPaths,
+  updateTunnelProcess,
+  type IosTunnelProcessState,
+} from './ios-tunnel-process';
+
+const INSTANCE_ID = 'ios_test_123';
+const OWNER_1 = '1'.repeat(32);
+const OWNER_2 = '2'.repeat(32);
+
+describe('iOS tunnel process state', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'lim-ios-tunnel-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test.each([
+    ['localhost:8000', { host: 'localhost', port: 8000 }],
+    ['API.Example.COM:443', { host: 'API.Example.COM', port: 443 }],
+    ['[2001:db8::1]:8443', { host: '2001:db8::1', port: 8443 }],
+  ])('parses route %s', (input, expected) => {
+    expect(parseTunnelRoute(input)).toEqual(expected);
+  });
+
+  test.each(['localhost', ':8000', 'localhost:0', 'localhost:65536', '2001:db8::1:443'])(
+    'rejects malformed route %s',
+    (input) => {
+      expect(() => parseTunnelRoute(input)).toThrow();
+    },
+  );
+
+  test('keeps each owner state isolated through update and clear', () => {
+    const state = makeState({ owner: OWNER_1, pid: process.pid, status: 'starting' });
+    expect(claimTunnelProcess(state, root)).toBe(true);
+    expect(claimTunnelProcess(makeState({ owner: OWNER_2 }), root)).toBe(true);
+    expect(listTunnelProcesses(INSTANCE_ID, root)).toHaveLength(2);
+
+    const ready = makeState({
+      owner: OWNER_1,
+      pid: process.pid,
+      status: 'ready',
+      tunnelId: 'tunnel-1',
+      bindings: [
+        {
+          routeId: 'route-1',
+          route: { host: 'localhost', port: 8000 },
+          endpoint: { host: '10.0.0.8', port: 57090 },
+        },
+      ],
+    });
+    updateTunnelProcess(ready, OWNER_1, root);
+    expect(loadTunnelProcess(INSTANCE_ID, OWNER_1, root)).toEqual(ready);
+    expect(() => updateTunnelProcess(ready, OWNER_2, root)).toThrow(
+      'Tunnel process ownership changed during startup',
+    );
+
+    expect(clearTunnelProcess(INSTANCE_ID, OWNER_2, root)).toBe(true);
+    expect(loadTunnelProcess(INSTANCE_ID, OWNER_1, root)).toEqual(ready);
+    expect(clearTunnelProcess(INSTANCE_ID, OWNER_1, root)).toBe(true);
+    expect(listTunnelProcesses(INSTANCE_ID, root)).toEqual([]);
+  });
+
+  test('keeps expired ownership visible for process cleanup', () => {
+    const abandoned = makeState({
+      owner: OWNER_1,
+      pid: process.pid,
+      status: 'starting',
+      startedAt: new Date(Date.now() - 31_000).toISOString(),
+    });
+    expect(claimTunnelProcess(abandoned, root)).toBe(true);
+    expect(loadTunnelProcess(abandoned.instanceId, OWNER_1, root)).toEqual(abandoned);
+    expect(tunnelProcessStartingLeaseExpired(abandoned)).toBe(true);
+
+    const replacement = makeState({ owner: OWNER_2, pid: 0, status: 'starting' });
+    expect(claimTunnelProcess(replacement, root)).toBe(true);
+    expect(
+      listTunnelProcesses(INSTANCE_ID, root)
+        .map((state) => state.owner)
+        .sort(),
+    ).toEqual([OWNER_1, OWNER_2]);
+  });
+
+  test('does not overwrite the same owner claim', () => {
+    expect(claimTunnelProcess(makeState({ owner: OWNER_1, pid: 0 }), root)).toBe(true);
+    expect(claimTunnelProcess(makeState({ owner: OWNER_1, pid: 0 }), root)).toBe(false);
+  });
+
+  test('verifies process identity before treating a PID as the owner', async () => {
+    const owner = crypto.randomBytes(16).toString('hex');
+    const child = spawn(
+      process.execPath,
+      ['-e', 'setInterval(() => {}, 1000)', '--', `--tunnel-owner=${owner}`],
+      { stdio: 'ignore' },
+    );
+    const pid = child.pid;
+    if (!pid) throw new Error('child process did not start');
+    const state = makeState({ owner, pid, status: 'starting' });
+    expect(claimTunnelProcess(state, root)).toBe(true);
+    await waitFor(() => isTunnelOwnerProcessAlive(state));
+    expect(isTunnelOwnerProcessAlive({ ...state, owner: OWNER_1 })).toBe(false);
+    expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(false);
+    child.kill('SIGKILL');
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(true);
+  });
+
+  test.each([
+    { startedAt: new Date(Date.now() + 120_000).toISOString() },
+    { startedAt: 123 as unknown as string },
+    { startedAt: new Date().toUTCString() },
+    { logPath: '/tmp/attacker.log' },
+    { tunnelId: 'premature' },
+    { bindings: [] },
+    { status: 'ready', pid: 0, tunnelId: 'tunnel-1', bindings: [] },
+    { routes: [{ host: '*.example.com', port: 443 }] },
+  ] satisfies Array<Partial<IosTunnelProcessState>>)('rejects malformed persisted state %#', (overrides) => {
+    const state = makeState(overrides);
+    const paths = tunnelProcessPaths(state.instanceId, state.owner, root);
+    fs.mkdirSync(paths.directory, { recursive: true });
+    fs.writeFileSync(paths.state, JSON.stringify(state));
+    expect(loadTunnelProcess(state.instanceId, state.owner, root)).toBeUndefined();
+  });
+
+  test('uses a bounded hashed path and reads the log tail', () => {
+    const paths = tunnelProcessPaths('ios_region_secret-customer-id', OWNER_1, root);
+    expect(paths.directory).not.toContain('secret-customer-id');
+    expect(paths.directory.length).toBeLessThan(root.length + 20);
+    fs.mkdirSync(paths.directory, { recursive: true });
+    fs.writeFileSync(paths.log, `${'x'.repeat(128 * 1024)}\none\ntwo\nthree\n`);
+    expect(readTunnelLogTail(paths.log, 2, 64 * 1024)).toBe('two\nthree');
+  });
+
+  test('rotates an oversized retained log', () => {
+    const paths = tunnelProcessPaths(INSTANCE_ID, OWNER_1, root);
+    fs.mkdirSync(paths.directory, { recursive: true });
+    fs.writeFileSync(paths.log, 'old log');
+    fs.closeSync(prepareTunnelLog(paths.log, 1));
+    expect(fs.readFileSync(`${paths.log}.1`, 'utf8')).toBe('g');
+    expect(fs.readFileSync(paths.log, 'utf8')).toBe('');
+  });
+
+  test('caps a log while its append descriptor remains open', () => {
+    const paths = tunnelProcessPaths(INSTANCE_ID, OWNER_1, root);
+    const descriptor = prepareTunnelLog(paths.log, 1024);
+    fs.writeSync(descriptor, 'old log');
+    expect(capTunnelLog(paths.log, 4)).toBe(true);
+    fs.writeSync(descriptor, 'new');
+    fs.closeSync(descriptor);
+
+    expect(fs.readFileSync(`${paths.log}.1`, 'utf8')).toBe(' log');
+    expect(fs.readFileSync(paths.log, 'utf8')).toBe('new');
+  });
+
+  test('retains only the newest completed tunnel logs', () => {
+    for (let index = 1; index <= 7; index++) {
+      const owner = index.toString(16).padStart(32, '0');
+      const paths = tunnelProcessPaths(INSTANCE_ID, owner, root);
+      fs.mkdirSync(paths.directory, { recursive: true });
+      fs.writeFileSync(paths.log, owner);
+      const modified = new Date(Date.now() + index * 1000);
+      fs.utimesSync(paths.log, modified, modified);
+    }
+
+    pruneTunnelLogs(INSTANCE_ID, root, 2);
+    const directory = tunnelProcessPaths(INSTANCE_ID, OWNER_1, root).directory;
+    expect(fs.readdirSync(directory).filter((entry) => entry.endsWith('.log'))).toHaveLength(2);
+  });
+
+  function makeState(overrides: Partial<IosTunnelProcessState>): IosTunnelProcessState {
+    const owner = overrides.owner ?? OWNER_1;
+    return {
+      owner,
+      pid: 0,
+      instanceId: INSTANCE_ID,
+      status: 'starting',
+      routes: [{ host: 'localhost', port: 8000 }],
+      startedAt: new Date().toISOString(),
+      logPath: tunnelProcessPaths(INSTANCE_ID, owner, root).log,
+      ...overrides,
+    };
+  }
+
+  async function waitFor(predicate: () => boolean): Promise<void> {
+    const deadline = Date.now() + 3000;
+    while (!predicate()) {
+      if (Date.now() >= deadline) throw new Error('waitFor timed out');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+});

--- a/packages/cli/src/lib/ios-tunnel-process.test.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.test.ts
@@ -4,19 +4,24 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
-  claimTunnelProcess,
+  buildTunnelServeArgs,
   capTunnelLog,
+  claimTunnelProcess,
   clearTunnelProcess,
+  formatTunnelRoute,
   isTunnelOwnerProcessAlive,
   listTunnelProcesses,
   loadTunnelProcess,
+  newTunnelOwner,
   parseTunnelRoute,
   prepareTunnelLog,
   pruneTunnelLogs,
   readTunnelLogTail,
-  tunnelProcessStartingLeaseExpired,
+  tunnelChildEnvironment,
   tunnelProcessPaths,
+  tunnelProcessStartingLeaseExpired,
   updateTunnelProcess,
+  waitForTunnelProcessReady,
   type IosTunnelProcessState,
 } from './ios-tunnel-process';
 
@@ -49,6 +54,89 @@ describe('iOS tunnel process state', () => {
       expect(() => parseTunnelRoute(input)).toThrow();
     },
   );
+
+  test('builds a child command with an exact owner and IPv6 route', () => {
+    const owner = newTunnelOwner();
+    expect(owner).toMatch(/^[0-9a-f]{32}$/);
+    expect(
+      buildTunnelServeArgs({
+        scriptPath: '/lim/run.js',
+        instanceId: INSTANCE_ID,
+        owner,
+        routes: [
+          { host: 'localhost', port: 8000 },
+          { host: '2001:db8::1', port: 8443 },
+        ],
+      }),
+    ).toEqual([
+      '/lim/run.js',
+      'ios',
+      'tunnel',
+      '--serve',
+      '--no-create',
+      '--id',
+      INSTANCE_ID,
+      `--tunnel-owner=${owner}`,
+      '--route',
+      'localhost:8000',
+      '--route',
+      '[2001:db8::1]:8443',
+    ]);
+    expect(formatTunnelRoute({ host: '2001:db8::1', port: 443 })).toBe('[2001:db8::1]:443');
+  });
+
+  test('forwards an explicit API key only through the child environment', () => {
+    expect(tunnelChildEnvironment('secret', { PATH: '/bin', LIM_API_KEY: 'old' })).toEqual({
+      PATH: '/bin',
+      LIM_API_KEY: 'secret',
+    });
+    expect(tunnelChildEnvironment(undefined, { PATH: '/bin' })).toEqual({
+      PATH: '/bin',
+    });
+  });
+
+  test('accepts READY written exactly at the parent deadline', async () => {
+    let now = 0;
+    let reads = 0;
+    const ready = makeReadyState();
+    await expect(
+      waitForTunnelProcessReady({
+        load: () => {
+          reads += 1;
+          if (reads === 1) return makeState({ pid: 123 });
+          return ready;
+        },
+        isAlive: () => true,
+        sleep: async (milliseconds) => {
+          now += milliseconds;
+        },
+        now: () => now,
+        timeoutMs: 100,
+        pollMs: 100,
+      }),
+    ).resolves.toEqual({ outcome: 'ready', state: ready });
+  });
+
+  test('reports a child exit before READY', async () => {
+    await expect(
+      waitForTunnelProcessReady({
+        load: () => undefined,
+        isAlive: () => false,
+        sleep: async () => {},
+      }),
+    ).resolves.toEqual({ outcome: 'exited' });
+  });
+
+  test('does not accept stale READY from an exited child', async () => {
+    const ready = makeReadyState();
+    await expect(
+      waitForTunnelProcessReady({
+        load: () => ready,
+        isAlive: () => false,
+        sleep: async () => {},
+      }),
+    ).resolves.toEqual({ outcome: 'exited' });
+  });
 
   test('keeps each owner state isolated through update and clear', () => {
     const state = makeState({ owner: OWNER_1, pid: process.pid, status: 'starting' });
@@ -116,12 +204,17 @@ describe('iOS tunnel process state', () => {
     const pid = child.pid;
     if (!pid) throw new Error('child process did not start');
     const state = makeState({ owner, pid, status: 'starting' });
-    expect(claimTunnelProcess(state, root)).toBe(true);
-    await waitFor(() => isTunnelOwnerProcessAlive(state));
-    expect(isTunnelOwnerProcessAlive({ ...state, owner: OWNER_1 })).toBe(false);
-    expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(false);
-    child.kill('SIGKILL');
-    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    try {
+      expect(claimTunnelProcess(state, root)).toBe(true);
+      await waitFor(() => isTunnelOwnerProcessAlive(state));
+      expect(isTunnelOwnerProcessAlive({ ...state, owner: OWNER_1 })).toBe(false);
+      expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(false);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL');
+        await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+      }
+    }
     expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(true);
   });
 
@@ -186,6 +279,21 @@ describe('iOS tunnel process state', () => {
     const directory = tunnelProcessPaths(INSTANCE_ID, OWNER_1, root).directory;
     expect(fs.readdirSync(directory).filter((entry) => entry.endsWith('.log'))).toHaveLength(2);
   });
+
+  function makeReadyState(): IosTunnelProcessState {
+    return makeState({
+      pid: 123,
+      status: 'ready',
+      tunnelId: 'tunnel-1',
+      bindings: [
+        {
+          routeId: 'route-1',
+          route: { host: 'localhost', port: 8000 },
+          endpoint: { host: '10.0.0.8', port: 57090 },
+        },
+      ],
+    });
+  }
 
   function makeState(overrides: Partial<IosTunnelProcessState>): IosTunnelProcessState {
     const owner = overrides.owner ?? OWNER_1;

--- a/packages/cli/src/lib/ios-tunnel-process.test.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.test.ts
@@ -17,6 +17,9 @@ import {
   prepareTunnelLog,
   pruneTunnelLogs,
   readTunnelLogTail,
+  selectTunnelOwnersForStop,
+  signalTunnelOwner,
+  stopTunnelErrorIsNotFound,
   tunnelChildEnvironment,
   tunnelProcessPaths,
   tunnelProcessStartingLeaseExpired,
@@ -28,6 +31,7 @@ import {
 const INSTANCE_ID = 'ios_test_123';
 const OWNER_1 = '1'.repeat(32);
 const OWNER_2 = '2'.repeat(32);
+const OWNER_3 = '3'.repeat(32);
 
 describe('iOS tunnel process state', () => {
   let root: string;
@@ -138,6 +142,32 @@ describe('iOS tunnel process state', () => {
     ).resolves.toEqual({ outcome: 'exited' });
   });
 
+  test('selects only owners correlated with the fetched server tunnel ID', () => {
+    const oldOwner = makeReadyState({
+      owner: OWNER_1,
+      tunnelId: 'old-tunnel',
+    });
+    const replacement = makeReadyState({
+      owner: OWNER_2,
+      tunnelId: 'replacement',
+    });
+    const starting = makeState({ owner: OWNER_3, pid: 456 });
+    expect(selectTunnelOwnersForStop([oldOwner, replacement, starting], 'old-tunnel')).toEqual([
+      oldOwner,
+      starting,
+    ]);
+    expect(selectTunnelOwnersForStop([oldOwner, replacement, starting], undefined)).toEqual([
+      oldOwner,
+      replacement,
+      starting,
+    ]);
+  });
+
+  test('classifies only the stable stop 404 error as already gone', () => {
+    expect(stopTunnelErrorIsNotFound(new Error('stopTunnel failed: 404 missing'))).toBe(true);
+    expect(stopTunnelErrorIsNotFound(new Error('stopTunnel failed: 500 broken'))).toBe(false);
+  });
+
   test('keeps each owner state isolated through update and clear', () => {
     const state = makeState({ owner: OWNER_1, pid: process.pid, status: 'starting' });
     expect(claimTunnelProcess(state, root)).toBe(true);
@@ -194,6 +224,18 @@ describe('iOS tunnel process state', () => {
     expect(claimTunnelProcess(makeState({ owner: OWNER_1, pid: 0 }), root)).toBe(false);
   });
 
+  test('cannot update or reclaim an owner after cleanup starts', () => {
+    const starting = makeState({ owner: OWNER_1, pid: 0 });
+    expect(claimTunnelProcess(starting, root)).toBe(true);
+    expect(clearTunnelProcess(INSTANCE_ID, OWNER_1, root)).toBe(true);
+    expect(clearTunnelProcess(INSTANCE_ID, OWNER_1, root)).toBe(true);
+    expect(() => updateTunnelProcess(makeReadyState({ owner: OWNER_1, pid: 123 }), OWNER_1, root)).toThrow(
+      'Tunnel process ownership changed during startup',
+    );
+    expect(claimTunnelProcess(starting, root)).toBe(false);
+    expect(loadTunnelProcess(INSTANCE_ID, OWNER_1, root)).toBeUndefined();
+  });
+
   test('verifies process identity before treating a PID as the owner', async () => {
     const owner = crypto.randomBytes(16).toString('hex');
     const child = spawn(
@@ -209,10 +251,14 @@ describe('iOS tunnel process state', () => {
       await waitFor(() => isTunnelOwnerProcessAlive(state));
       expect(isTunnelOwnerProcessAlive({ ...state, owner: OWNER_1 })).toBe(false);
       expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(false);
+      const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+      expect(signalTunnelOwner(state, 'SIGKILL')).toBe('signaled');
+      await exited;
     } finally {
       if (child.exitCode === null && child.signalCode === null) {
+        const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
         child.kill('SIGKILL');
-        await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+        await exited;
       }
     }
     expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(true);
@@ -280,7 +326,7 @@ describe('iOS tunnel process state', () => {
     expect(fs.readdirSync(directory).filter((entry) => entry.endsWith('.log'))).toHaveLength(2);
   });
 
-  function makeReadyState(): IosTunnelProcessState {
+  function makeReadyState(overrides: Partial<IosTunnelProcessState> = {}): IosTunnelProcessState {
     return makeState({
       pid: 123,
       status: 'ready',
@@ -292,6 +338,7 @@ describe('iOS tunnel process state', () => {
           endpoint: { host: '10.0.0.8', port: 57090 },
         },
       ],
+      ...overrides,
     });
   }
 

--- a/packages/cli/src/lib/ios-tunnel-process.test.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.test.ts
@@ -8,6 +8,7 @@ import {
   capTunnelLog,
   claimTunnelProcess,
   clearTunnelProcess,
+  formatTunnelDialFailure,
   formatTunnelRoute,
   isTunnelOwnerProcessAlive,
   listTunnelProcesses,
@@ -87,6 +88,18 @@ describe('iOS tunnel process state', () => {
       '[2001:db8::1]:8443',
     ]);
     expect(formatTunnelRoute({ host: '2001:db8::1', port: 443 })).toBe('[2001:db8::1]:443');
+  });
+
+  test('formats dial failures with every correlation ID', () => {
+    expect(
+      formatTunnelDialFailure({
+        tunnelId: 'tunnel-1',
+        connectionId: 7,
+        routeId: 'route-3',
+        reason: 'dns_not_found',
+        osCode: 'ENOTFOUND',
+      }),
+    ).toBe('Last dial failure: tunnel tunnel-1, connection 7, route-3 (dns_not_found, ENOTFOUND)');
   });
 
   test('forwards an explicit API key only through the child environment', () => {

--- a/packages/cli/src/lib/ios-tunnel-process.test.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.test.ts
@@ -9,8 +9,7 @@ import {
   claimTunnelProcess,
   clearTunnelProcess,
   formatTunnelDialFailure,
-  formatTunnelRoute,
-  isTunnelOwnerProcessAlive,
+  isSpawnedTunnelProcessAlive,
   listTunnelProcesses,
   loadTunnelProcess,
   newTunnelOwner,
@@ -22,6 +21,7 @@ import {
   signalTunnelOwner,
   stopTunnelErrorIsNotFound,
   tunnelChildEnvironment,
+  tunnelOwnerProcessIdentity,
   tunnelProcessPaths,
   tunnelProcessStartingLeaseExpired,
   updateTunnelProcess,
@@ -47,7 +47,6 @@ describe('iOS tunnel process state', () => {
 
   test.each([
     ['localhost:8000', { host: 'localhost', port: 8000 }],
-    ['API.Example.COM:443', { host: 'API.Example.COM', port: 443 }],
     ['[2001:db8::1]:8443', { host: '2001:db8::1', port: 8443 }],
   ])('parses route %s', (input, expected) => {
     expect(parseTunnelRoute(input)).toEqual(expected);
@@ -62,7 +61,6 @@ describe('iOS tunnel process state', () => {
 
   test('builds a child command with an exact owner and IPv6 route', () => {
     const owner = newTunnelOwner();
-    expect(owner).toMatch(/^[0-9a-f]{32}$/);
     expect(
       buildTunnelServeArgs({
         scriptPath: '/lim/run.js',
@@ -87,7 +85,6 @@ describe('iOS tunnel process state', () => {
       '--route',
       '[2001:db8::1]:8443',
     ]);
-    expect(formatTunnelRoute({ host: '2001:db8::1', port: 443 })).toBe('[2001:db8::1]:443');
   });
 
   test('formats dial failures with every correlation ID', () => {
@@ -106,9 +103,6 @@ describe('iOS tunnel process state', () => {
     expect(tunnelChildEnvironment('secret', { PATH: '/bin', LIM_API_KEY: 'old' })).toEqual({
       PATH: '/bin',
       LIM_API_KEY: 'secret',
-    });
-    expect(tunnelChildEnvironment(undefined, { PATH: '/bin' })).toEqual({
-      PATH: '/bin',
     });
   });
 
@@ -134,16 +128,6 @@ describe('iOS tunnel process state', () => {
     ).resolves.toEqual({ outcome: 'ready', state: ready });
   });
 
-  test('reports a child exit before READY', async () => {
-    await expect(
-      waitForTunnelProcessReady({
-        load: () => undefined,
-        isAlive: () => false,
-        sleep: async () => {},
-      }),
-    ).resolves.toEqual({ outcome: 'exited' });
-  });
-
   test('does not accept stale READY from an exited child', async () => {
     const ready = makeReadyState();
     await expect(
@@ -153,6 +137,21 @@ describe('iOS tunnel process state', () => {
         sleep: async () => {},
       }),
     ).resolves.toEqual({ outcome: 'exited' });
+  });
+
+  test('does not mistake a reused PID for the spawned child', () => {
+    expect(
+      isSpawnedTunnelProcessAlive(
+        { exitCode: 0, signalCode: null },
+        process.pid,
+      ),
+    ).toBe(false);
+    expect(
+      isSpawnedTunnelProcessAlive(
+        { exitCode: null, signalCode: null },
+        process.pid,
+      ),
+    ).toBe(true);
   });
 
   test('selects only owners correlated with the fetched server tunnel ID', () => {
@@ -213,15 +212,22 @@ describe('iOS tunnel process state', () => {
   });
 
   test('keeps expired ownership visible for process cleanup', () => {
+    const now = Date.now();
     const abandoned = makeState({
       owner: OWNER_1,
       pid: process.pid,
       status: 'starting',
-      startedAt: new Date(Date.now() - 31_000).toISOString(),
+      startedAt: new Date(now - 30_000).toISOString(),
     });
     expect(claimTunnelProcess(abandoned, root)).toBe(true);
     expect(loadTunnelProcess(abandoned.instanceId, OWNER_1, root)).toEqual(abandoned);
-    expect(tunnelProcessStartingLeaseExpired(abandoned)).toBe(true);
+    expect(tunnelProcessStartingLeaseExpired(abandoned, now)).toBe(true);
+    expect(
+      tunnelProcessStartingLeaseExpired(
+        { ...abandoned, startedAt: new Date(now - 29_999).toISOString() },
+        now,
+      ),
+    ).toBe(false);
 
     const replacement = makeState({ owner: OWNER_2, pid: 0, status: 'starting' });
     expect(claimTunnelProcess(replacement, root)).toBe(true);
@@ -261,8 +267,9 @@ describe('iOS tunnel process state', () => {
     const state = makeState({ owner, pid, status: 'starting' });
     try {
       expect(claimTunnelProcess(state, root)).toBe(true);
-      await waitFor(() => isTunnelOwnerProcessAlive(state));
-      expect(isTunnelOwnerProcessAlive({ ...state, owner: OWNER_1 })).toBe(false);
+      await waitFor(() => tunnelOwnerProcessIdentity(state) === 'match');
+      expect(tunnelOwnerProcessIdentity({ ...state, owner: OWNER_1 })).toBe('mismatch');
+      expect(signalTunnelOwner({ ...state, owner: OWNER_1 }, 'SIGTERM')).toBe('mismatch');
       expect(clearTunnelProcess(state.instanceId, owner, root)).toBe(false);
       const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
       expect(signalTunnelOwner(state, 'SIGKILL')).toBe('signaled');
@@ -284,10 +291,10 @@ describe('iOS tunnel process state', () => {
     { logPath: '/tmp/attacker.log' },
     { tunnelId: 'premature' },
     { bindings: [] },
-    { status: 'ready', pid: 0, tunnelId: 'tunnel-1', bindings: [] },
+    { status: 'ready', pid: 0 },
     { routes: [{ host: '*.example.com', port: 443 }] },
   ] satisfies Array<Partial<IosTunnelProcessState>>)('rejects malformed persisted state %#', (overrides) => {
-    const state = makeState(overrides);
+    const state = overrides.status === 'ready' ? makeReadyState(overrides) : makeState(overrides);
     const paths = tunnelProcessPaths(state.instanceId, state.owner, root);
     fs.mkdirSync(paths.directory, { recursive: true });
     fs.writeFileSync(paths.state, JSON.stringify(state));
@@ -297,7 +304,6 @@ describe('iOS tunnel process state', () => {
   test('uses a bounded hashed path and reads the log tail', () => {
     const paths = tunnelProcessPaths('ios_region_secret-customer-id', OWNER_1, root);
     expect(paths.directory).not.toContain('secret-customer-id');
-    expect(paths.directory.length).toBeLessThan(root.length + 20);
     fs.mkdirSync(paths.directory, { recursive: true });
     fs.writeFileSync(paths.log, `${'x'.repeat(128 * 1024)}\none\ntwo\nthree\n`);
     expect(readTunnelLogTail(paths.log, 2, 64 * 1024)).toBe('two\nthree');
@@ -325,18 +331,29 @@ describe('iOS tunnel process state', () => {
   });
 
   test('retains only the newest completed tunnel logs', () => {
-    for (let index = 1; index <= 7; index++) {
-      const owner = index.toString(16).padStart(32, '0');
+    const retiredOwners = [OWNER_1, OWNER_2, OWNER_3];
+    for (const [index, owner] of retiredOwners.entries()) {
       const paths = tunnelProcessPaths(INSTANCE_ID, owner, root);
       fs.mkdirSync(paths.directory, { recursive: true });
       fs.writeFileSync(paths.log, owner);
-      const modified = new Date(Date.now() + index * 1000);
+      const modified = new Date(Date.now() + (index + 1) * 1000);
       fs.utimesSync(paths.log, modified, modified);
     }
+    const oldestPaths = tunnelProcessPaths(INSTANCE_ID, OWNER_1, root);
+    fs.writeFileSync(`${oldestPaths.log}.1`, 'rotated');
+    const activeOwner = '4'.repeat(32);
+    const active = makeState({ owner: activeOwner, pid: process.pid });
+    expect(claimTunnelProcess(active, root)).toBe(true);
+    fs.writeFileSync(tunnelProcessPaths(INSTANCE_ID, activeOwner, root).log, 'active');
 
     pruneTunnelLogs(INSTANCE_ID, root, 2);
     const directory = tunnelProcessPaths(INSTANCE_ID, OWNER_1, root).directory;
-    expect(fs.readdirSync(directory).filter((entry) => entry.endsWith('.log'))).toHaveLength(2);
+    expect(
+      fs.readdirSync(directory).filter((entry) => entry.endsWith('.log')).sort(),
+    ).toEqual(
+      [`${OWNER_2}.log`, `${OWNER_3}.log`, `${activeOwner}.log`].sort(),
+    );
+    expect(fs.existsSync(`${oldestPaths.log}.1`)).toBe(false);
   });
 
   function makeReadyState(overrides: Partial<IosTunnelProcessState> = {}): IosTunnelProcessState {

--- a/packages/cli/src/lib/ios-tunnel-process.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.ts
@@ -1,10 +1,10 @@
 import { execFileSync } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
+import net from 'net';
 import os from 'os';
 import path from 'path';
 import type { Ios } from '@limrun/api';
-import { validateTunnelV2Routes } from '@limrun/api/tunnel-v2';
 
 export const IOS_TUNNELS_ROOT = path.join(os.homedir(), '.lim', 'tunnels');
 const OWNER_PATTERN = /^[0-9a-f]{32}$/;
@@ -20,6 +20,12 @@ export interface IosTunnelProcessState {
   tunnelId?: string;
   bindings?: NonNullable<Ios.TunnelStatus['active']>['bindings'];
 }
+
+export type ReadyIosTunnelProcessState = IosTunnelProcessState & {
+  status: 'ready';
+  tunnelId: string;
+  bindings: NonNullable<Ios.TunnelStatus['active']>['bindings'];
+};
 
 export interface IosTunnelProcessPaths {
   directory: string;
@@ -51,6 +57,76 @@ export function parseTunnelRoute(value: string): Ios.TunnelOptions['routes'][num
     throw new Error(`Invalid route port in "${value}"; expected 1-65535`);
   }
   return { host, port };
+}
+
+export function newTunnelOwner(): string {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+export function formatTunnelRoute(route: Ios.TunnelOptions['routes'][number]): string {
+  const host = route.host.includes(':') ? `[${route.host}]` : route.host;
+  return `${host}:${route.port}`;
+}
+
+export function buildTunnelServeArgs(options: {
+  scriptPath: string;
+  instanceId: string;
+  owner: string;
+  routes: Ios.TunnelOptions['routes'];
+}): string[] {
+  assertOwner(options.owner);
+  return [
+    options.scriptPath,
+    'ios',
+    'tunnel',
+    '--serve',
+    '--no-create',
+    '--id',
+    options.instanceId,
+    `--tunnel-owner=${options.owner}`,
+    ...options.routes.flatMap((route) => ['--route', formatTunnelRoute(route)]),
+  ];
+}
+
+export function tunnelChildEnvironment(
+  apiKey: string | undefined,
+  environment: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return {
+    ...environment,
+    ...(apiKey ? { LIM_API_KEY: apiKey } : {}),
+  };
+}
+
+export async function waitForTunnelProcessReady(options: {
+  load: () => IosTunnelProcessState | undefined;
+  isAlive: () => boolean;
+  sleep: (milliseconds: number) => Promise<void>;
+  now?: () => number;
+  timeoutMs?: number;
+  pollMs?: number;
+}): Promise<
+  { outcome: 'ready'; state: ReadyIosTunnelProcessState } | { outcome: 'exited' } | { outcome: 'timeout' }
+> {
+  const now = options.now ?? Date.now;
+  const deadline = now() + (options.timeoutMs ?? 30_000);
+  function loadReadyState(): ReadyIosTunnelProcessState | undefined {
+    const state = options.load();
+    if (state?.status !== 'ready' || !state.tunnelId || !state.bindings) {
+      return undefined;
+    }
+    return state as ReadyIosTunnelProcessState;
+  }
+
+  while (now() < deadline) {
+    if (!options.isAlive()) return { outcome: 'exited' };
+    const state = loadReadyState();
+    if (state) return { outcome: 'ready', state };
+    await options.sleep(options.pollMs ?? 100);
+  }
+  if (!options.isAlive()) return { outcome: 'exited' };
+  const state = loadReadyState();
+  return state ? { outcome: 'ready', state } : { outcome: 'timeout' };
 }
 
 function tunnelProcessDirectory(instanceId: string, root: string): string {
@@ -269,6 +345,41 @@ export function capTunnelLog(logPath: string, maxBytes = 5 * 1024 * 1024): boole
   }
 }
 
+function validateStoredRoutes(routes: Ios.TunnelOptions['routes']): Ios.TunnelOptions['routes'] {
+  if (!Array.isArray(routes) || routes.length < 1 || routes.length > 10) {
+    throw new Error('Invalid tunnel routes');
+  }
+  for (const route of routes) {
+    if (
+      typeof route?.host !== 'string' ||
+      route.host.length < 1 ||
+      route.host.length > 254 ||
+      Buffer.byteLength(route.host, 'utf8') !== route.host.length ||
+      route.host.includes('\0') ||
+      !storedRouteHostIsValid(route.host) ||
+      !Number.isInteger(route.port) ||
+      route.port < 1 ||
+      route.port > 65_535
+    ) {
+      throw new Error('Invalid tunnel routes');
+    }
+  }
+  return routes;
+}
+
+function storedRouteHostIsValid(input: string): boolean {
+  let host = input.toLowerCase();
+  if (host.endsWith('.')) host = host.slice(0, -1);
+  if (!host || host.length > 253) return false;
+  if (net.isIP(host) !== 0) return true;
+  const labels = host.split('.');
+  const labelsAreValid = labels.every(
+    (label) => label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label),
+  );
+  const looksLikeAnIpAddress = labels.every((label) => /^\d+$/.test(label) || /^0x[0-9a-f]+$/.test(label));
+  return labelsAreValid && !looksLikeAnIpAddress;
+}
+
 function validateTunnelProcessState(
   state: IosTunnelProcessState,
   instanceId: string,
@@ -279,7 +390,7 @@ function validateTunnelProcessState(
   const age = Date.now() - startedAt;
   let canonicalRoutes: Ios.TunnelOptions['routes'];
   try {
-    canonicalRoutes = validateTunnelV2Routes(state.routes);
+    canonicalRoutes = validateStoredRoutes(state.routes);
   } catch {
     throw new Error('Invalid tunnel process state');
   }

--- a/packages/cli/src/lib/ios-tunnel-process.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.ts
@@ -71,6 +71,12 @@ export function formatTunnelRoute(route: Ios.TunnelOptions['routes'][number]): s
   return `${host}:${route.port}`;
 }
 
+export function formatTunnelDialFailure(failure: NonNullable<Ios.TunnelStatus['lastDialFailure']>): string {
+  const correlationIds = `tunnel ${failure.tunnelId}, connection ${failure.connectionId}, ${failure.routeId}`;
+  const failureDetails = failure.osCode ? `${failure.reason}, ${failure.osCode}` : failure.reason;
+  return `Last dial failure: ${correlationIds} (${failureDetails})`;
+}
+
 export function buildTunnelServeArgs(options: {
   scriptPath: string;
   instanceId: string;

--- a/packages/cli/src/lib/ios-tunnel-process.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.ts
@@ -1,0 +1,375 @@
+import { execFileSync } from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { Ios } from '@limrun/api';
+import { validateTunnelV2Routes } from '@limrun/api/tunnel-v2';
+
+export const IOS_TUNNELS_ROOT = path.join(os.homedir(), '.lim', 'tunnels');
+const OWNER_PATTERN = /^[0-9a-f]{32}$/;
+
+export interface IosTunnelProcessState {
+  owner: string;
+  pid: number;
+  instanceId: string;
+  status: 'starting' | 'ready';
+  routes: Ios.TunnelOptions['routes'];
+  startedAt: string;
+  logPath: string;
+  tunnelId?: string;
+  bindings?: NonNullable<Ios.TunnelStatus['active']>['bindings'];
+}
+
+export interface IosTunnelProcessPaths {
+  directory: string;
+  state: string;
+  log: string;
+}
+
+export function parseTunnelRoute(value: string): Ios.TunnelOptions['routes'][number] {
+  let host: string;
+  let portText: string;
+  if (value.startsWith('[')) {
+    const match = /^\[([^\]]+)\]:(\d+)$/.exec(value);
+    if (!match?.[1] || !match[2]) {
+      throw new Error(`Invalid route "${value}"; use [IPv6]:port`);
+    }
+    host = match[1];
+    portText = match[2];
+  } else {
+    const separator = value.lastIndexOf(':');
+    if (separator <= 0 || value.indexOf(':') !== separator) {
+      throw new Error(`Invalid route "${value}"; use host:port or [IPv6]:port`);
+    }
+    host = value.slice(0, separator);
+    portText = value.slice(separator + 1);
+  }
+
+  const port = Number(portText);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Invalid route port in "${value}"; expected 1-65535`);
+  }
+  return { host, port };
+}
+
+function tunnelProcessDirectory(instanceId: string, root: string): string {
+  const key = crypto.createHash('sha256').update(instanceId).digest('hex').slice(0, 12);
+  return path.join(root, key);
+}
+
+export function tunnelProcessPaths(
+  instanceId: string,
+  owner: string,
+  root = IOS_TUNNELS_ROOT,
+): IosTunnelProcessPaths {
+  assertOwner(owner);
+  const directory = tunnelProcessDirectory(instanceId, root);
+  return {
+    directory,
+    state: path.join(directory, `${owner}.json`),
+    log: path.join(directory, `${owner}.log`),
+  };
+}
+
+export function claimTunnelProcess(state: IosTunnelProcessState, root = IOS_TUNNELS_ROOT): boolean {
+  const paths = tunnelProcessPaths(state.instanceId, state.owner, root);
+  validateTunnelProcessState(state, state.instanceId, paths);
+  fs.mkdirSync(paths.directory, { recursive: true, mode: 0o700 });
+  const temporary = writeTemporaryState(state, paths);
+  try {
+    fs.linkSync(temporary, paths.state);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw error;
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export function updateTunnelProcess(
+  state: IosTunnelProcessState,
+  expectedOwner: string,
+  root = IOS_TUNNELS_ROOT,
+): void {
+  if (state.owner !== expectedOwner) {
+    throw new Error('Tunnel process ownership changed during startup');
+  }
+  const paths = tunnelProcessPaths(state.instanceId, expectedOwner, root);
+  validateTunnelProcessState(state, state.instanceId, paths);
+  const existing = loadTunnelProcess(state.instanceId, expectedOwner, root);
+  if (!existing) {
+    throw new Error('Tunnel process ownership changed during startup');
+  }
+  const temporary = writeTemporaryState(state, paths);
+  try {
+    fs.renameSync(temporary, paths.state);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export function loadTunnelProcess(
+  instanceId: string,
+  owner: string,
+  root = IOS_TUNNELS_ROOT,
+): IosTunnelProcessState | undefined {
+  const paths = tunnelProcessPaths(instanceId, owner, root);
+  try {
+    const state = JSON.parse(fs.readFileSync(paths.state, 'utf8')) as IosTunnelProcessState;
+    validateTunnelProcessState(state, instanceId, paths);
+    return state;
+  } catch {
+    return undefined;
+  }
+}
+
+export function listTunnelProcesses(instanceId: string, root = IOS_TUNNELS_ROOT): IosTunnelProcessState[] {
+  const directory = tunnelProcessDirectory(instanceId, root);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(directory);
+  } catch {
+    return [];
+  }
+  const states: IosTunnelProcessState[] = [];
+  for (const entry of entries) {
+    const match = /^([0-9a-f]{32})\.json$/.exec(entry);
+    if (!match?.[1]) continue;
+    const state = loadTunnelProcess(instanceId, match[1], root);
+    if (state) states.push(state);
+  }
+  return states;
+}
+
+export function clearTunnelProcess(instanceId: string, owner: string, root = IOS_TUNNELS_ROOT): boolean {
+  const paths = tunnelProcessPaths(instanceId, owner, root);
+  const state = loadTunnelProcess(instanceId, owner, root);
+  if (state && state.pid !== process.pid && isTunnelOwnerProcessAlive(state)) {
+    return false;
+  }
+  try {
+    fs.unlinkSync(paths.state);
+    pruneTunnelLogs(instanceId, root);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+export function pruneTunnelLogs(instanceId: string, root = IOS_TUNNELS_ROOT, retain = 5): void {
+  const directory = tunnelProcessDirectory(instanceId, root);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(directory);
+  } catch {
+    return;
+  }
+  const activeOwners = new Set(listTunnelProcesses(instanceId, root).map((state) => state.owner));
+  const retiredLogs: Array<{ owner: string; mtimeMs: number }> = [];
+  for (const entry of entries) {
+    const match = /^([0-9a-f]{32})\.log$/.exec(entry);
+    const owner = match?.[1];
+    if (!owner || activeOwners.has(owner)) continue;
+
+    const logPath = path.join(directory, entry);
+    try {
+      retiredLogs.push({
+        owner,
+        mtimeMs: fs.statSync(logPath).mtimeMs,
+      });
+    } catch {
+      continue;
+    }
+  }
+  retiredLogs.sort((left, right) => right.mtimeMs - left.mtimeMs);
+
+  for (const { owner } of retiredLogs.slice(Math.max(0, retain))) {
+    const logPath = tunnelProcessPaths(instanceId, owner, root).log;
+    fs.rmSync(logPath, { force: true });
+    fs.rmSync(`${logPath}.1`, { force: true });
+  }
+}
+
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export function tunnelProcessStartingLeaseExpired(state: IosTunnelProcessState, now = Date.now()): boolean {
+  return state.status === 'starting' && now - Date.parse(state.startedAt) >= 30_000;
+}
+
+export function isTunnelOwnerProcessAlive(state: IosTunnelProcessState): boolean {
+  if (!isProcessAlive(state.pid)) return false;
+  try {
+    let command: string;
+    if (process.platform === 'win32') {
+      command = execFileSync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${state.pid}").CommandLine`,
+        ],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 2_000,
+        },
+      );
+    } else {
+      command = execFileSync('/bin/ps', ['-ww', '-p', String(state.pid), '-o', 'command='], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 2_000,
+      });
+    }
+
+    const ownerArgument = new RegExp(`(?:^|\\s)--tunnel-owner=${state.owner}(?:\\s|$)`);
+    return ownerArgument.test(command);
+  } catch {
+    return false;
+  }
+}
+
+export function prepareTunnelLog(logPath: string, maxBytes = 5 * 1024 * 1024): number {
+  fs.mkdirSync(path.dirname(logPath), { recursive: true, mode: 0o700 });
+  capTunnelLog(logPath, maxBytes);
+  return fs.openSync(logPath, 'a', 0o600);
+}
+
+export function readTunnelLogTail(logPath: string, lines = 20, maxBytes = 64 * 1024): string {
+  try {
+    const content = readFileSuffix(logPath, maxBytes).toString('utf8').trimEnd();
+    return content ? content.split('\n').slice(-lines).join('\n') : '(log file is empty)';
+  } catch {
+    return '(no log output captured)';
+  }
+}
+
+export function capTunnelLog(logPath: string, maxBytes = 5 * 1024 * 1024): boolean {
+  try {
+    if (fs.statSync(logPath).size <= maxBytes) return false;
+    const suffix = readFileSuffix(logPath, maxBytes);
+    fs.writeFileSync(`${logPath}.1`, suffix, { mode: 0o600 });
+    fs.truncateSync(logPath, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function validateTunnelProcessState(
+  state: IosTunnelProcessState,
+  instanceId: string,
+  paths: IosTunnelProcessPaths,
+): void {
+  const startedAt = typeof state.startedAt === 'string' ? Date.parse(state.startedAt) : Number.NaN;
+  const startedAtValid = Number.isFinite(startedAt) && new Date(startedAt).toISOString() === state.startedAt;
+  const age = Date.now() - startedAt;
+  let canonicalRoutes: Ios.TunnelOptions['routes'];
+  try {
+    canonicalRoutes = validateTunnelV2Routes(state.routes);
+  } catch {
+    throw new Error('Invalid tunnel process state');
+  }
+  const bindingsValid =
+    state.bindings === undefined ||
+    (Array.isArray(state.bindings) &&
+      state.bindings.every(
+        (binding) =>
+          typeof binding?.routeId === 'string' &&
+          binding.routeId.length > 0 &&
+          validHostPort(binding.route) &&
+          validHostPort(binding.endpoint),
+      ));
+  const readyFieldsValid =
+    state.status !== 'ready' ||
+    (state.pid > 0 &&
+      typeof state.tunnelId === 'string' &&
+      state.tunnelId.length > 0 &&
+      Array.isArray(state.bindings) &&
+      state.bindings.length === canonicalRoutes.length &&
+      state.bindings.every((binding, index) => {
+        const route = canonicalRoutes[index];
+        return (
+          route !== undefined &&
+          binding?.routeId === `route-${index + 1}` &&
+          binding?.route?.host === route.host &&
+          binding?.route?.port === route.port
+        );
+      }));
+  const startingFieldsValid =
+    state.status !== 'starting' || (state.tunnelId === undefined && state.bindings === undefined);
+  if (
+    typeof state.owner !== 'string' ||
+    !OWNER_PATTERN.test(state.owner) ||
+    !Number.isInteger(state.pid) ||
+    state.pid < 0 ||
+    state.instanceId !== instanceId ||
+    (state.status !== 'starting' && state.status !== 'ready') ||
+    !startedAtValid ||
+    age < 0 ||
+    state.logPath !== paths.log ||
+    !bindingsValid ||
+    !readyFieldsValid ||
+    !startingFieldsValid
+  ) {
+    throw new Error('Invalid tunnel process state');
+  }
+}
+
+function validHostPort(value: unknown): value is { host: string; port: number } {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { host?: unknown; port?: unknown };
+  return (
+    typeof candidate.host === 'string' &&
+    candidate.host.length > 0 &&
+    typeof candidate.port === 'number' &&
+    Number.isInteger(candidate.port) &&
+    candidate.port >= 1 &&
+    candidate.port <= 65_535
+  );
+}
+
+function writeTemporaryState(state: IosTunnelProcessState, paths: IosTunnelProcessPaths): string {
+  fs.mkdirSync(paths.directory, { recursive: true, mode: 0o700 });
+  const temporary = `${paths.state}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  const descriptor = fs.openSync(temporary, 'wx', 0o600);
+  try {
+    fs.writeFileSync(descriptor, JSON.stringify(state, null, 2), 'utf8');
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return temporary;
+}
+
+function assertOwner(owner: string): void {
+  if (!OWNER_PATTERN.test(owner)) {
+    throw new Error('Invalid tunnel process owner');
+  }
+}
+
+function readFileSuffix(filePath: string, maxBytes: number): Buffer {
+  const descriptor = fs.openSync(filePath, 'r');
+  try {
+    const size = fs.fstatSync(descriptor).size;
+    const length = Math.min(size, maxBytes);
+    const buffer = Buffer.alloc(length);
+    fs.readSync(descriptor, buffer, 0, length, size - length);
+    return buffer;
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}

--- a/packages/cli/src/lib/ios-tunnel-process.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.ts
@@ -27,10 +27,13 @@ export type ReadyIosTunnelProcessState = IosTunnelProcessState & {
   bindings: NonNullable<Ios.TunnelStatus['active']>['bindings'];
 };
 
+export type TunnelOwnerProcessIdentity = 'match' | 'mismatch' | 'missing' | 'unknown';
+
 export interface IosTunnelProcessPaths {
   directory: string;
   state: string;
   log: string;
+  cancelled: string;
 }
 
 export function parseTunnelRoute(value: string): Ios.TunnelOptions['routes'][number] {
@@ -145,16 +148,22 @@ export function tunnelProcessPaths(
     directory,
     state: path.join(directory, `${owner}.json`),
     log: path.join(directory, `${owner}.log`),
+    cancelled: path.join(directory, `${owner}.cancelled`),
   };
 }
 
 export function claimTunnelProcess(state: IosTunnelProcessState, root = IOS_TUNNELS_ROOT): boolean {
   const paths = tunnelProcessPaths(state.instanceId, state.owner, root);
   validateTunnelProcessState(state, state.instanceId, paths);
+  if (fs.existsSync(paths.cancelled)) return false;
   fs.mkdirSync(paths.directory, { recursive: true, mode: 0o700 });
   const temporary = writeTemporaryState(state, paths);
   try {
     fs.linkSync(temporary, paths.state);
+    if (fs.existsSync(paths.cancelled)) {
+      fs.rmSync(paths.state, { force: true });
+      return false;
+    }
     return true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
@@ -175,12 +184,19 @@ export function updateTunnelProcess(
   const paths = tunnelProcessPaths(state.instanceId, expectedOwner, root);
   validateTunnelProcessState(state, state.instanceId, paths);
   const existing = loadTunnelProcess(state.instanceId, expectedOwner, root);
-  if (!existing) {
+  if (!existing || fs.existsSync(paths.cancelled)) {
     throw new Error('Tunnel process ownership changed during startup');
   }
   const temporary = writeTemporaryState(state, paths);
   try {
+    if (fs.existsSync(paths.cancelled)) {
+      throw new Error('Tunnel process ownership changed during startup');
+    }
     fs.renameSync(temporary, paths.state);
+    if (fs.existsSync(paths.cancelled)) {
+      fs.rmSync(paths.state, { force: true });
+      throw new Error('Tunnel process ownership changed during startup');
+    }
   } finally {
     fs.rmSync(temporary, { force: true });
   }
@@ -219,18 +235,36 @@ export function listTunnelProcesses(instanceId: string, root = IOS_TUNNELS_ROOT)
   return states;
 }
 
+export function selectTunnelOwnersForStop(
+  owners: IosTunnelProcessState[],
+  tunnelId: string | undefined,
+): IosTunnelProcessState[] {
+  if (!tunnelId) return owners;
+  return owners.filter((state) => state.status === 'starting' || state.tunnelId === tunnelId);
+}
+
+export function stopTunnelErrorIsNotFound(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith('stopTunnel failed: 404 ');
+}
+
 export function clearTunnelProcess(instanceId: string, owner: string, root = IOS_TUNNELS_ROOT): boolean {
   const paths = tunnelProcessPaths(instanceId, owner, root);
   const state = loadTunnelProcess(instanceId, owner, root);
-  if (state && state.pid !== process.pid && isTunnelOwnerProcessAlive(state)) {
-    return false;
+  if (state && state.pid !== process.pid) {
+    const identity = tunnelOwnerProcessIdentity(state);
+    if (identity === 'match' || identity === 'unknown') return false;
+  }
+  try {
+    fs.writeFileSync(paths.cancelled, '', { flag: 'wx', mode: 0o600 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
   }
   try {
     fs.unlinkSync(paths.state);
     pruneTunnelLogs(instanceId, root);
     return true;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return true;
     throw error;
   }
 }
@@ -284,7 +318,11 @@ export function tunnelProcessStartingLeaseExpired(state: IosTunnelProcessState, 
 }
 
 export function isTunnelOwnerProcessAlive(state: IosTunnelProcessState): boolean {
-  if (!isProcessAlive(state.pid)) return false;
+  return tunnelOwnerProcessIdentity(state) === 'match';
+}
+
+export function tunnelOwnerProcessIdentity(state: IosTunnelProcessState): TunnelOwnerProcessIdentity {
+  if (!isProcessAlive(state.pid)) return 'missing';
   try {
     let command: string;
     if (process.platform === 'win32') {
@@ -311,9 +349,24 @@ export function isTunnelOwnerProcessAlive(state: IosTunnelProcessState): boolean
     }
 
     const ownerArgument = new RegExp(`(?:^|\\s)--tunnel-owner=${state.owner}(?:\\s|$)`);
-    return ownerArgument.test(command);
+    return ownerArgument.test(command) ? 'match' : 'mismatch';
   } catch {
-    return false;
+    return isProcessAlive(state.pid) ? 'unknown' : 'missing';
+  }
+}
+
+export function signalTunnelOwner(
+  state: IosTunnelProcessState,
+  signal: NodeJS.Signals,
+): 'signaled' | TunnelOwnerProcessIdentity {
+  const identity = tunnelOwnerProcessIdentity(state);
+  if (identity !== 'match') return identity;
+  try {
+    process.kill(state.pid, signal);
+    return 'signaled';
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return 'missing';
+    throw error;
   }
 }
 

--- a/packages/cli/src/lib/ios-tunnel-process.ts
+++ b/packages/cli/src/lib/ios-tunnel-process.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, type ChildProcess } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
 import net from 'net';
@@ -319,12 +319,15 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
-export function tunnelProcessStartingLeaseExpired(state: IosTunnelProcessState, now = Date.now()): boolean {
-  return state.status === 'starting' && now - Date.parse(state.startedAt) >= 30_000;
+export function isSpawnedTunnelProcessAlive(
+  child: Pick<ChildProcess, 'exitCode' | 'signalCode'>,
+  pid: number,
+): boolean {
+  return child.exitCode === null && child.signalCode === null && isProcessAlive(pid);
 }
 
-export function isTunnelOwnerProcessAlive(state: IosTunnelProcessState): boolean {
-  return tunnelOwnerProcessIdentity(state) === 'match';
+export function tunnelProcessStartingLeaseExpired(state: IosTunnelProcessState, now = Date.now()): boolean {
+  return state.status === 'starting' && now - Date.parse(state.startedAt) >= 30_000;
 }
 
 export function tunnelOwnerProcessIdentity(state: IosTunnelProcessState): TunnelOwnerProcessIdentity {

--- a/src/internal/tunnel-v2-management.ts
+++ b/src/internal/tunnel-v2-management.ts
@@ -12,6 +12,13 @@ export interface TunnelV2Status {
     tunnelId: string;
     code: string;
   };
+  lastDialFailure?: {
+    tunnelId: string;
+    connectionId: number;
+    routeId: string;
+    reason: string;
+    osCode?: string;
+  };
 }
 
 export async function getTunnelV2Status(apiUrl: string, token: string): Promise<TunnelV2Status> {
@@ -48,6 +55,9 @@ export function decodeTunnelV2Status(value: unknown): TunnelV2Status {
   if (status['lastFailure'] !== undefined) {
     decodedStatus.lastFailure = readTunnelFailure(status['lastFailure']);
   }
+  if (status['lastDialFailure'] !== undefined) {
+    decodedStatus.lastDialFailure = readTunnelDialFailure(status['lastDialFailure']);
+  }
   return decodedStatus;
 }
 
@@ -82,6 +92,30 @@ function readTunnelFailure(value: unknown): NonNullable<TunnelV2Status['lastFail
   return {
     tunnelId: readNonEmptyString(failure, 'tunnelId'),
     code: readNonEmptyString(failure, 'code'),
+  };
+}
+
+function readTunnelDialFailure(value: unknown): NonNullable<TunnelV2Status['lastDialFailure']> {
+  const failure = readRecord(value, 'tunnel dial failure');
+  const connectionId = failure['connectionId'];
+  if (
+    typeof connectionId !== 'number' ||
+    !Number.isInteger(connectionId) ||
+    connectionId < 0 ||
+    connectionId > 0xffff_ffff
+  ) {
+    throw new Error('tunnel dial failure connectionId must be an unsigned 32-bit integer');
+  }
+  const osCode = failure['osCode'];
+  if (osCode !== undefined && typeof osCode !== 'string') {
+    throw new Error('tunnel dial failure osCode must be a string');
+  }
+  return {
+    tunnelId: readNonEmptyString(failure, 'tunnelId'),
+    connectionId,
+    routeId: readNonEmptyString(failure, 'routeId'),
+    reason: readNonEmptyString(failure, 'reason'),
+    ...(osCode === undefined ? {} : { osCode }),
   };
 }
 

--- a/src/internal/tunnel-v2-management.ts
+++ b/src/internal/tunnel-v2-management.ts
@@ -1,0 +1,121 @@
+import type { TunnelV2Binding } from '../tunnel-v2';
+import { nodeProxyTransport } from './proxy-transport';
+import { deriveTunnelManagementURL } from './tunnel-v2-url';
+
+export interface TunnelV2Status {
+  active?: {
+    tunnelId: string;
+    state: 'starting' | 'ready' | 'stopping';
+    bindings: TunnelV2Binding[];
+  };
+  lastFailure?: {
+    tunnelId: string;
+    code: string;
+  };
+}
+
+export async function getTunnelV2Status(apiUrl: string, token: string): Promise<TunnelV2Status> {
+  const response = await nodeProxyTransport.fetch(deriveTunnelManagementURL(apiUrl).toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(`getTunnelStatus failed: ${response.status} ${await response.text()}`);
+  }
+  return decodeTunnelV2Status(await response.json());
+}
+
+export async function stopTunnelV2(apiUrl: string, token: string, tunnelId: string): Promise<void> {
+  if (!tunnelId.trim()) {
+    throw new Error('tunnelId must not be empty');
+  }
+  const url = deriveTunnelManagementURL(apiUrl);
+  url.searchParams.set('tunnelId', tunnelId);
+  const response = await nodeProxyTransport.fetch(url.toString(), {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(`stopTunnel failed: ${response.status} ${await response.text()}`);
+  }
+}
+
+export function decodeTunnelV2Status(value: unknown): TunnelV2Status {
+  const status = readRecord(value, 'tunnel status');
+  const decodedStatus: TunnelV2Status = {};
+  if (status['active'] !== undefined) {
+    decodedStatus.active = readActiveTunnel(status['active']);
+  }
+  if (status['lastFailure'] !== undefined) {
+    decodedStatus.lastFailure = readTunnelFailure(status['lastFailure']);
+  }
+  return decodedStatus;
+}
+
+function readActiveTunnel(value: unknown): NonNullable<TunnelV2Status['active']> {
+  const active = readRecord(value, 'active tunnel');
+  const state = readString(active, 'state');
+  if (state !== 'starting' && state !== 'ready' && state !== 'stopping') {
+    throw new Error(`invalid tunnel state ${state}`);
+  }
+  const bindings = active['bindings'];
+  if (!Array.isArray(bindings)) {
+    throw new Error('tunnel bindings must be an array');
+  }
+  return {
+    tunnelId: readNonEmptyString(active, 'tunnelId'),
+    state,
+    bindings: bindings.map(readBinding),
+  };
+}
+
+function readBinding(value: unknown): TunnelV2Binding {
+  const binding = readRecord(value, 'tunnel binding');
+  return {
+    routeId: readNonEmptyString(binding, 'routeId'),
+    route: readHostPort(binding['route'], 'tunnel route'),
+    endpoint: readHostPort(binding['endpoint'], 'tunnel endpoint'),
+  };
+}
+
+function readTunnelFailure(value: unknown): NonNullable<TunnelV2Status['lastFailure']> {
+  const failure = readRecord(value, 'tunnel failure');
+  return {
+    tunnelId: readNonEmptyString(failure, 'tunnelId'),
+    code: readNonEmptyString(failure, 'code'),
+  };
+}
+
+function readHostPort(value: unknown, name: string): { host: string; port: number } {
+  const hostPort = readRecord(value, name);
+  const port = hostPort['port'];
+  if (typeof port !== 'number' || !Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`${name} port must be an integer between 1 and 65535`);
+  }
+  return {
+    host: readNonEmptyString(hostPort, 'host'),
+    port,
+  };
+}
+
+function readRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string') {
+    throw new Error(`${key} must be a string`);
+  }
+  return value;
+}
+
+function readNonEmptyString(record: Record<string, unknown>, key: string): string {
+  const value = readString(record, key);
+  if (value.length === 0) {
+    throw new Error(`${key} must not be empty`);
+  }
+  return value;
+}

--- a/src/internal/tunnel-v2-url.ts
+++ b/src/internal/tunnel-v2-url.ts
@@ -1,14 +1,20 @@
-export function deriveTunnelV2URL(apiUrl: string): string {
+function deriveTunnelEndpointURL(apiUrl: string, endpoint: 'tunnel-v2' | 'tunnel'): URL {
   const url = new URL(apiUrl);
-  if (url.protocol === 'https:') {
-    url.protocol = 'wss:';
-  } else if (url.protocol === 'http:') {
-    url.protocol = 'ws:';
-  } else {
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new Error(`Unsupported apiUrl protocol for tunnel: ${url.protocol}`);
   }
-  url.pathname = `${url.pathname.replace(/\/+$/, '')}/tunnel`;
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/${endpoint}`;
   url.search = '';
   url.hash = '';
+  return url;
+}
+
+export function deriveTunnelV2URL(apiUrl: string): string {
+  const url = deriveTunnelEndpointURL(apiUrl, 'tunnel-v2');
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.toString();
+}
+
+export function deriveTunnelManagementURL(apiUrl: string): URL {
+  return deriveTunnelEndpointURL(apiUrl, 'tunnel');
 }

--- a/src/internal/tunnel-v2-url.ts
+++ b/src/internal/tunnel-v2-url.ts
@@ -1,0 +1,14 @@
+export function deriveTunnelV2URL(apiUrl: string): string {
+  const url = new URL(apiUrl);
+  if (url.protocol === 'https:') {
+    url.protocol = 'wss:';
+  } else if (url.protocol === 'http:') {
+    url.protocol = 'ws:';
+  } else {
+    throw new Error(`Unsupported apiUrl protocol for tunnel: ${url.protocol}`);
+  }
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/tunnel`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -13,6 +13,7 @@ import { prepareAppBundlePath, watchAppArchive } from './app-archive';
 import { downloadFileToLocalPath } from './internal/download-file';
 import { sleep } from './internal/utils/sleep';
 import { nodeProxyTransport } from './internal/proxy-transport';
+import { getTunnelV2Status, stopTunnelV2, type TunnelV2Status } from './internal/tunnel-v2-management';
 import { deriveTunnelV2URL } from './internal/tunnel-v2-url';
 import {
   startHttpProxy as startLocalHttpProxy,
@@ -65,6 +66,7 @@ export type TunnelOptions = {
   /** Controls tunnel logging verbosity. Defaults to the instance client's log level. */
   logLevel?: LogLevel;
 };
+export type TunnelStatus = TunnelV2Status;
 
 /**
  * Events emitted by a simctl execution
@@ -861,6 +863,12 @@ export type InstanceClient = {
    * instance client does not close the tunnel.
    */
   startTunnel: (options: TunnelOptions) => Promise<Tunnel>;
+
+  /** Get the active destination tunnel and most recent terminal failure. */
+  getTunnelStatus: () => Promise<TunnelStatus>;
+
+  /** Stop the active tunnel only when its ID matches `tunnelId`. */
+  stopTunnel: (tunnelId: string) => Promise<void>;
 
   /**
    * Start a local HTTP proxy to a port exposed by the iOS instance.
@@ -2032,6 +2040,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             softReset,
             startReverseTunnel,
             startTunnel,
+            getTunnelStatus,
+            stopTunnel,
             startHttpProxy,
             startForwardHttpProxy,
             disconnect,
@@ -2797,6 +2807,14 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         routes: tunnelOptions.routes,
         logLevel: tunnelOptions.logLevel ?? logLevel,
       });
+    };
+
+    const getTunnelStatus = async (): Promise<TunnelStatus> => {
+      return getTunnelV2Status(options.apiUrl, options.token);
+    };
+
+    const stopTunnel = async (tunnelId: string): Promise<void> => {
+      await stopTunnelV2(options.apiUrl, options.token, tunnelId);
     };
 
     const startHttpProxy = async (proxyOptions: HttpProxyOptions): Promise<number> => {

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -5,12 +5,15 @@ import fs from 'fs';
 import { WebSocket, Data } from 'ws';
 import { EventEmitter } from 'events';
 import { assertPort, isNonRetryableError, startReverseTcpTunnel, type ReverseTunnel } from './tunnel';
+import { startDestinationTcpTunnel, type DestinationTcpTunnel } from './tunnel-v2-dialer';
+import type { TunnelV2Route } from './tunnel-v2';
 import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './folder-sync';
 import { createIgnoreFn } from './folder-sync-ignore';
 import { prepareAppBundlePath, watchAppArchive } from './app-archive';
 import { downloadFileToLocalPath } from './internal/download-file';
 import { sleep } from './internal/utils/sleep';
 import { nodeProxyTransport } from './internal/proxy-transport';
+import { deriveTunnelV2URL } from './internal/tunnel-v2-url';
 import {
   startHttpProxy as startLocalHttpProxy,
   startForwardHttpProxy as startLocalForwardHttpProxy,
@@ -55,6 +58,13 @@ export function deriveReverseTunnelUrl(apiUrl: string, remotePort: number): stri
 }
 
 export type { ReverseTunnel } from './tunnel';
+export type Tunnel = DestinationTcpTunnel;
+export type TunnelOptions = {
+  /** TCP destinations that the server may ask this client to dial. */
+  routes: TunnelV2Route[];
+  /** Controls tunnel logging verbosity. Defaults to the instance client's log level. */
+  logLevel?: LogLevel;
+};
 
 /**
  * Events emitted by a simctl execution
@@ -842,6 +852,15 @@ export type InstanceClient = {
    * to a user-local client-first TCP service, such as HTTP or WebSocket.
    */
   startReverseTunnel: (options: ReverseTunnelOptions) => Promise<ReverseTunnel>;
+
+  /**
+   * Start a destination-routed tunnel from simulator-facing listener endpoints
+   * to the declared TCP services on this machine.
+   *
+   * The caller owns the returned tunnel and must close it. Disconnecting this
+   * instance client does not close the tunnel.
+   */
+  startTunnel: (options: TunnelOptions) => Promise<Tunnel>;
 
   /**
    * Start a local HTTP proxy to a port exposed by the iOS instance.
@@ -2012,6 +2031,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             discoverStoreKitConfig,
             softReset,
             startReverseTunnel,
+            startTunnel,
             startHttpProxy,
             startForwardHttpProxy,
             disconnect,
@@ -2768,6 +2788,13 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       return startReverseTcpTunnel(remoteURL, options.token, {
         localHost: tunnelOptions.localHost ?? '127.0.0.1',
         localPort,
+        logLevel: tunnelOptions.logLevel ?? logLevel,
+      });
+    };
+
+    const startTunnel = async (tunnelOptions: TunnelOptions): Promise<Tunnel> => {
+      return startDestinationTcpTunnel(deriveTunnelV2URL(options.apiUrl), options.token, {
+        routes: tunnelOptions.routes,
         logLevel: tunnelOptions.logLevel ?? logLevel,
       });
     };

--- a/src/tunnel-v2-dialer.ts
+++ b/src/tunnel-v2-dialer.ts
@@ -1,0 +1,559 @@
+import net from 'net';
+import { WebSocket, type RawData } from 'ws';
+import { nodeProxyTransport } from './internal/proxy-transport';
+import {
+  TUNNEL_V2_CONN_ID_HEADER_BYTES,
+  TUNNEL_V2_VERSION,
+  TunnelV2ProtocolError,
+  assertTunnelV2OpenAllowed,
+  assertTunnelV2Ready,
+  decodeTunnelV2ServerMessage,
+  encodeTunnelV2ClientMessage,
+  validateTunnelV2Routes,
+  type TunnelV2Binding,
+  type TunnelV2ClientMessage,
+  type TunnelV2OpenFailureReason,
+  type TunnelV2Route,
+  type TunnelV2ResetReason,
+  type TunnelV2ServerMessage,
+} from './tunnel-v2';
+import type { LogLevel, TunnelConnectionState, TunnelConnectionStateCallback } from './tunnel';
+
+export interface DestinationTcpTunnel {
+  tunnelId: string;
+  bindings: TunnelV2Binding[];
+  close: () => void;
+  getConnectionState: () => TunnelConnectionState;
+  onConnectionStateChange: (callback: TunnelConnectionStateCallback) => () => void;
+}
+
+export interface DestinationTcpTunnelOptions {
+  routes: TunnelV2Route[];
+  logLevel?: LogLevel;
+  maxConnections?: number;
+  maxPendingBytesPerConnection?: number;
+  maxTotalPendingBytes?: number;
+  maxBufferedBytes?: number;
+  connectTimeoutMs?: number;
+  handshakeTimeoutMs?: number;
+  livenessTimeoutMs?: number;
+}
+
+interface DialConnection {
+  socket: net.Socket;
+  phase: 'connecting' | 'open';
+  connectTimer: NodeJS.Timeout;
+  localInputEnded: boolean;
+  remoteInputEnded: boolean;
+  pendingWriteBytes: number;
+}
+
+export async function startDestinationTcpTunnel(
+  remoteURL: string,
+  token: string,
+  options: DestinationTcpTunnelOptions,
+): Promise<DestinationTcpTunnel> {
+  const routes = validateTunnelV2Routes(options.routes);
+  const logLevel = options.logLevel ?? 'info';
+  const maxConnections = positiveInteger(options.maxConnections ?? 64, 'maxConnections');
+  const maxPendingBytesPerConnection = positiveInteger(
+    options.maxPendingBytesPerConnection ?? 16 * 1024 * 1024,
+    'maxPendingBytesPerConnection',
+  );
+  const maxTotalPendingBytes = positiveInteger(
+    options.maxTotalPendingBytes ?? 16 * 1024 * 1024,
+    'maxTotalPendingBytes',
+  );
+  const maxBufferedBytes = positiveInteger(options.maxBufferedBytes ?? 4 * 1024 * 1024, 'maxBufferedBytes');
+  const connectTimeoutMs = positiveInteger(options.connectTimeoutMs ?? 10_000, 'connectTimeoutMs');
+  const handshakeTimeoutMs = positiveInteger(options.handshakeTimeoutMs ?? 15_000, 'handshakeTimeoutMs');
+  const livenessTimeoutMs = positiveInteger(options.livenessTimeoutMs ?? 90_000, 'livenessTimeoutMs');
+  const pingIntervalMs = Math.min(30_000, Math.max(1, Math.floor(livenessTimeoutMs / 3)));
+  const resumeBelowBufferedBytes = maxBufferedBytes / 4;
+  const hardMaxBufferedBytes = maxBufferedBytes + Math.max(64 * 1024, Math.floor(maxBufferedBytes / 4));
+
+  const logger = {
+    debug: (...args: unknown[]) => {
+      if (logLevel === 'debug') console.log('[DestinationTunnel]', ...args);
+    },
+    info: (...args: unknown[]) => {
+      if (logLevel === 'info' || logLevel === 'debug') console.log('[DestinationTunnel]', ...args);
+    },
+    warn: (...args: unknown[]) => {
+      if (logLevel === 'warn' || logLevel === 'info' || logLevel === 'debug') {
+        console.warn('[DestinationTunnel]', ...args);
+      }
+    },
+    error: (...args: unknown[]) => {
+      if (logLevel !== 'none') console.error('[DestinationTunnel]', ...args);
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const connections = new Map<number, DialConnection>();
+    const recentlyClosed = new Map<number, NodeJS.Timeout>();
+    const stateChangeCallbacks = new Set<TunnelConnectionStateCallback>();
+    const url = new URL(remoteURL);
+    const proxyAgent = nodeProxyTransport.getWebSocketAgent(url.toString());
+    const ws = new WebSocket(url.toString(), {
+      headers: { Authorization: `Bearer ${token}` },
+      ...(proxyAgent ? { agent: proxyAgent } : {}),
+      perMessageDeflate: false,
+    });
+
+    let connectionState: TunnelConnectionState = 'connecting';
+    let pingInterval: NodeJS.Timeout | undefined;
+    let handshakeTimer: NodeJS.Timeout | undefined;
+    let livenessTimer: NodeJS.Timeout | undefined;
+    let tunnelReady = false;
+    let closed = false;
+    let pausedForBackpressure = false;
+    let totalPendingWriteBytes = 0;
+
+    const updateConnectionState = (state: TunnelConnectionState): void => {
+      if (connectionState === state) return;
+      connectionState = state;
+      for (const callback of stateChangeCallbacks) {
+        try {
+          callback(state);
+        } catch (error) {
+          logger.error('Connection state callback failed:', error);
+        }
+      }
+    };
+
+    const getConnectionState = (): TunnelConnectionState => connectionState;
+
+    const onConnectionStateChange = (callback: TunnelConnectionStateCallback): (() => void) => {
+      stateChangeCallbacks.add(callback);
+      return () => stateChangeCallbacks.delete(callback);
+    };
+
+    const markRecentlyClosed = (connId: number): void => {
+      const existingTimer = recentlyClosed.get(connId);
+      if (existingTimer) clearTimeout(existingTimer);
+      const timer = setTimeout(() => recentlyClosed.delete(connId), 30_000);
+      timer.unref();
+      recentlyClosed.set(connId, timer);
+    };
+
+    const removeConnection = (connId: number, destroySocket: boolean): void => {
+      const connection = connections.get(connId);
+      if (!connection) return;
+      connections.delete(connId);
+      clearTimeout(connection.connectTimer);
+      markRecentlyClosed(connId);
+      if (destroySocket && !connection.socket.destroyed) {
+        connection.socket.destroy();
+      }
+    };
+
+    const closeAllConnections = (): void => {
+      for (const connId of Array.from(connections.keys())) {
+        removeConnection(connId, true);
+      }
+      for (const timer of recentlyClosed.values()) {
+        clearTimeout(timer);
+      }
+      recentlyClosed.clear();
+      pausedForBackpressure = false;
+    };
+
+    const close = (): void => {
+      if (closed) return;
+      closed = true;
+      if (pingInterval) {
+        clearInterval(pingInterval);
+        pingInterval = undefined;
+      }
+      if (handshakeTimer) {
+        clearTimeout(handshakeTimer);
+        handshakeTimer = undefined;
+      }
+      if (livenessTimer) {
+        clearTimeout(livenessTimer);
+        livenessTimer = undefined;
+      }
+      closeAllConnections();
+      ws.removeAllListeners('open');
+      ws.removeAllListeners('message');
+      ws.removeAllListeners('ping');
+      ws.removeAllListeners('pong');
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close(1000, 'close');
+      }
+      updateConnectionState('disconnected');
+    };
+
+    const failTransport = (error: Error): void => {
+      if (closed) return;
+      logger.error(error.message);
+      close();
+      if (!tunnelReady) {
+        reject(error);
+      }
+    };
+
+    const pauseForBackpressure = (): void => {
+      if (pausedForBackpressure) return;
+      pausedForBackpressure = true;
+      for (const connection of connections.values()) {
+        if (!connection.socket.destroyed) connection.socket.pause();
+      }
+    };
+
+    const resumeIfDrained = (): void => {
+      if (!pausedForBackpressure || ws.bufferedAmount >= resumeBelowBufferedBytes) return;
+      pausedForBackpressure = false;
+      for (const connection of connections.values()) {
+        if (!connection.socket.destroyed) connection.socket.resume();
+      }
+    };
+
+    const frameQueued = (): void => {
+      if (ws.bufferedAmount > hardMaxBufferedBytes) {
+        failTransport(new Error('destination tunnel WebSocket send buffer exceeded its hard limit'));
+      } else if (!pausedForBackpressure && ws.bufferedAmount > maxBufferedBytes) {
+        pauseForBackpressure();
+      }
+    };
+
+    const frameSent = (error?: Error): void => {
+      if (error) {
+        failTransport(error);
+      } else {
+        resumeIfDrained();
+      }
+    };
+
+    const sendControl = (message: TunnelV2ClientMessage): void => {
+      if (closed || ws.readyState !== WebSocket.OPEN) {
+        failTransport(new Error('destination tunnel WebSocket is not open'));
+        return;
+      }
+      ws.send(encodeTunnelV2ClientMessage(message), frameSent);
+      frameQueued();
+    };
+
+    const sendData = (connId: number, payload: Buffer): void => {
+      if (closed || ws.readyState !== WebSocket.OPEN) {
+        failTransport(new Error('destination tunnel WebSocket closed while sending data'));
+        return;
+      }
+      const frame = Buffer.allocUnsafe(TUNNEL_V2_CONN_ID_HEADER_BYTES + payload.length);
+      frame.writeUInt32BE(connId, 0);
+      payload.copy(frame, TUNNEL_V2_CONN_ID_HEADER_BYTES);
+      ws.send(frame, { binary: true }, frameSent);
+      frameQueued();
+    };
+
+    const sendOpenFailure = (connId: number, reason: TunnelV2OpenFailureReason, osCode?: string): void => {
+      sendControl({
+        type: 'openFail',
+        connId,
+        reason,
+        ...(osCode ? { osCode } : {}),
+      });
+      markRecentlyClosed(connId);
+    };
+
+    const sendReset = (connId: number, reason: TunnelV2ResetReason, osCode?: string): void => {
+      sendControl({
+        type: 'reset',
+        connId,
+        reason,
+        ...(osCode ? { osCode } : {}),
+      });
+    };
+
+    const handleOpen = (message: Extract<TunnelV2ServerMessage, { type: 'open' }>): void => {
+      try {
+        assertTunnelV2OpenAllowed(message, routes);
+      } catch {
+        sendOpenFailure(message.connId, 'route_not_allowed');
+        return;
+      }
+      if (connections.has(message.connId) || recentlyClosed.has(message.connId)) {
+        throw new TunnelV2ProtocolError(`server reused connection ID ${message.connId}`);
+      }
+      if (connections.size >= maxConnections) {
+        sendOpenFailure(message.connId, 'resource_exhausted');
+        return;
+      }
+
+      const socket = net.createConnection({
+        host: message.host,
+        port: message.port,
+        allowHalfOpen: true,
+      });
+      const connectTimer = setTimeout(() => {
+        if (connections.get(message.connId)?.phase !== 'connecting') return;
+        sendOpenFailure(message.connId, 'connection_timed_out', 'ETIMEDOUT');
+        removeConnection(message.connId, true);
+      }, connectTimeoutMs);
+      connectTimer.unref();
+      const connection: DialConnection = {
+        socket,
+        phase: 'connecting',
+        connectTimer,
+        localInputEnded: false,
+        remoteInputEnded: false,
+        pendingWriteBytes: 0,
+      };
+      connections.set(message.connId, connection);
+      if (pausedForBackpressure) {
+        socket.pause();
+      }
+
+      socket.once('connect', () => {
+        if (connections.get(message.connId) !== connection) return;
+        clearTimeout(connectTimer);
+        connection.phase = 'open';
+        sendControl({ type: 'openOk', connId: message.connId });
+        logger.debug(`Connected ${message.connId} to ${message.host}:${message.port}`);
+      });
+
+      socket.on('data', (payload: Buffer) => {
+        if (connections.get(message.connId) !== connection || connection.phase !== 'open') return;
+        sendData(message.connId, payload);
+      });
+
+      socket.once('end', () => {
+        if (connections.get(message.connId) !== connection || connection.phase !== 'open') return;
+        connection.localInputEnded = true;
+        sendControl({ type: 'fin', connId: message.connId });
+      });
+
+      socket.once('error', (error: NodeJS.ErrnoException) => {
+        if (connections.get(message.connId) !== connection) return;
+        if (connection.phase === 'connecting') {
+          sendOpenFailure(message.connId, classifyOpenFailure(error), error.code);
+        } else {
+          sendReset(message.connId, 'connection_error', error.code);
+        }
+        removeConnection(message.connId, true);
+      });
+
+      socket.once('close', () => {
+        if (connections.get(message.connId) !== connection) return;
+        if (connection.phase === 'connecting') {
+          sendOpenFailure(message.connId, 'internal');
+        } else if (!connection.localInputEnded || !connection.remoteInputEnded) {
+          sendReset(message.connId, 'connection_error');
+        }
+        removeConnection(message.connId, false);
+      });
+    };
+
+    const findOpenConnection = (connId: number): DialConnection | undefined => {
+      const connection = connections.get(connId);
+      if (connection?.phase === 'open') return connection;
+      if (connection) {
+        sendReset(connId, 'protocol_error');
+        removeConnection(connId, true);
+      } else if (!recentlyClosed.has(connId)) {
+        sendReset(connId, 'protocol_error');
+        markRecentlyClosed(connId);
+      }
+      return undefined;
+    };
+
+    const handleRemoteFIN = (connId: number): void => {
+      const connection = findOpenConnection(connId);
+      if (!connection) return;
+      if (connection.remoteInputEnded) {
+        sendReset(connId, 'protocol_error');
+        removeConnection(connId, true);
+        return;
+      }
+      connection.remoteInputEnded = true;
+      connection.socket.end();
+    };
+
+    const handleRemoteReset = (connId: number): void => {
+      if (connections.has(connId)) {
+        removeConnection(connId, true);
+      }
+    };
+
+    const handleBinary = (frame: Buffer): void => {
+      if (!tunnelReady) {
+        throw new TunnelV2ProtocolError('received tunnel data before READY');
+      }
+      if (frame.length <= TUNNEL_V2_CONN_ID_HEADER_BYTES) {
+        throw new TunnelV2ProtocolError('tunnel data frame must include a payload');
+      }
+      const connId = frame.readUInt32BE(0);
+      const connection = findOpenConnection(connId);
+      if (!connection) return;
+      if (connection.remoteInputEnded) {
+        sendReset(connId, 'protocol_error');
+        removeConnection(connId, true);
+        return;
+      }
+
+      const payload = frame.subarray(TUNNEL_V2_CONN_ID_HEADER_BYTES);
+      const nextConnectionPendingBytes = connection.pendingWriteBytes + payload.length;
+      const nextTotalPendingBytes = totalPendingWriteBytes + payload.length;
+      if (
+        nextConnectionPendingBytes > maxPendingBytesPerConnection ||
+        nextTotalPendingBytes > maxTotalPendingBytes
+      ) {
+        sendReset(connId, 'resource_exhausted');
+        removeConnection(connId, true);
+        return;
+      }
+
+      connection.pendingWriteBytes = nextConnectionPendingBytes;
+      totalPendingWriteBytes = nextTotalPendingBytes;
+      connection.socket.write(payload, (error?: Error | null) => {
+        connection.pendingWriteBytes -= payload.length;
+        totalPendingWriteBytes -= payload.length;
+        if (error && connections.get(connId) === connection) {
+          const osCode = (error as NodeJS.ErrnoException).code;
+          sendReset(connId, 'connection_error', osCode);
+          removeConnection(connId, true);
+        }
+      });
+    };
+
+    const handleControl = (message: TunnelV2ServerMessage): void => {
+      switch (message.type) {
+        case 'ready':
+          if (tunnelReady) throw new TunnelV2ProtocolError('received duplicate READY');
+          assertTunnelV2Ready(message, routes);
+          tunnelReady = true;
+          if (handshakeTimer) {
+            clearTimeout(handshakeTimer);
+            handshakeTimer = undefined;
+          }
+          armLivenessDeadline();
+          updateConnectionState('connected');
+          logger.info(`Destination tunnel ready with ${message.bindings.length} route(s)`);
+          resolve({
+            tunnelId: message.tunnelId,
+            bindings: message.bindings,
+            close,
+            getConnectionState,
+            onConnectionStateChange,
+          });
+          return;
+        case 'error':
+          throw new Error(`destination tunnel failed: ${message.code}`);
+        case 'open':
+          if (!tunnelReady) throw new TunnelV2ProtocolError('received OPEN before READY');
+          handleOpen(message);
+          return;
+        case 'fin':
+          if (!tunnelReady) throw new TunnelV2ProtocolError('received FIN before READY');
+          handleRemoteFIN(message.connId);
+          return;
+        case 'reset':
+          if (!tunnelReady) throw new TunnelV2ProtocolError('received RESET before READY');
+          handleRemoteReset(message.connId);
+      }
+    };
+
+    const armLivenessDeadline = (): void => {
+      if (!tunnelReady || closed) return;
+      if (livenessTimer) clearTimeout(livenessTimer);
+      livenessTimer = setTimeout(() => {
+        failTransport(new Error(`destination tunnel received no frames for ${livenessTimeoutMs}ms`));
+      }, livenessTimeoutMs);
+      livenessTimer.unref();
+    };
+
+    handshakeTimer = setTimeout(() => {
+      failTransport(new Error(`destination tunnel was not ready within ${handshakeTimeoutMs}ms`));
+    }, handshakeTimeoutMs);
+    handshakeTimer.unref();
+
+    ws.on('open', () => {
+      sendControl({ type: 'start', version: TUNNEL_V2_VERSION, routes });
+      pingInterval = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.ping(undefined, true, frameSent);
+          frameQueued();
+        }
+      }, pingIntervalMs);
+      pingInterval.unref();
+    });
+
+    ws.on('message', (data: RawData, isBinary: boolean) => {
+      try {
+        armLivenessDeadline();
+        if (isBinary) {
+          handleBinary(toBuffer(data));
+        } else {
+          handleControl(decodeTunnelV2ServerMessage(JSON.parse(toBuffer(data).toString('utf8'))));
+        }
+      } catch (error) {
+        failTransport(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+
+    ws.on('ping', armLivenessDeadline);
+    ws.on('pong', armLivenessDeadline);
+
+    ws.once('error', (error: Error) => {
+      failTransport(error);
+    });
+
+    ws.once('close', (code: number, reason: Buffer) => {
+      if (closed) {
+        ws.removeAllListeners();
+        return;
+      }
+      failTransport(
+        new Error(
+          `destination tunnel WebSocket closed: ${code}${reason.length ? ` ${reason.toString()}` : ''}`,
+        ),
+      );
+      ws.removeAllListeners();
+    });
+  });
+}
+
+export function classifyOpenFailure(error: NodeJS.ErrnoException): TunnelV2OpenFailureReason {
+  switch (error.code) {
+    case 'ENOTFOUND':
+      return 'dns_not_found';
+    case 'EAI_AGAIN':
+      return 'dns_temporary_failure';
+    case 'ECONNREFUSED':
+      return 'connection_refused';
+    case 'ECONNRESET':
+      return 'connection_reset';
+    case 'ETIMEDOUT':
+      return 'connection_timed_out';
+    case 'ENETUNREACH':
+    case 'EHOSTUNREACH':
+      return 'unreachable';
+    case 'EACCES':
+    case 'EPERM':
+      return 'permission_denied';
+    case 'EMFILE':
+    case 'ENFILE':
+    case 'ENOBUFS':
+    case 'ENOMEM':
+      return 'resource_exhausted';
+    case 'ECANCELED':
+      return 'cancelled';
+    default:
+      return 'internal';
+  }
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function toBuffer(data: RawData): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (Array.isArray(data)) return Buffer.concat(data);
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  throw new TunnelV2ProtocolError('unsupported WebSocket payload type');
+}

--- a/src/tunnel-v2.ts
+++ b/src/tunnel-v2.ts
@@ -1,0 +1,370 @@
+import net from 'net';
+
+export const TUNNEL_V2_VERSION = 2;
+export const TUNNEL_V2_MAX_ROUTES = 10;
+export const TUNNEL_V2_CONN_ID_HEADER_BYTES = 4;
+
+export interface TunnelV2Route {
+  host: string;
+  port: number;
+}
+
+export interface TunnelV2Endpoint {
+  host: string;
+  port: number;
+}
+
+export interface TunnelV2Binding {
+  routeId: string;
+  route: TunnelV2Route;
+  endpoint: TunnelV2Endpoint;
+}
+
+export type TunnelV2OpenFailureReason =
+  | 'dns_not_found'
+  | 'dns_temporary_failure'
+  | 'connection_refused'
+  | 'connection_reset'
+  | 'connection_timed_out'
+  | 'unreachable'
+  | 'permission_denied'
+  | 'resource_exhausted'
+  | 'route_not_allowed'
+  | 'cancelled'
+  | 'internal'
+  | (string & {});
+
+export type TunnelV2ResetReason =
+  | 'cancelled'
+  | 'connection_error'
+  | 'protocol_error'
+  | 'resource_exhausted'
+  | 'internal'
+  | (string & {});
+
+export type TunnelV2SessionErrorCode =
+  | 'unsupported_version'
+  | 'invalid_message'
+  | 'invalid_route'
+  | 'route_capacity'
+  | 'already_active'
+  | 'listener_unavailable'
+  | 'internal'
+  | (string & {});
+
+export type TunnelV2ClientMessage =
+  | { type: 'start'; version: number; routes: TunnelV2Route[] }
+  | { type: 'openOk'; connId: number }
+  | {
+      type: 'openFail';
+      connId: number;
+      reason: TunnelV2OpenFailureReason;
+      osCode?: string;
+    }
+  | { type: 'fin'; connId: number }
+  | { type: 'reset'; connId: number; reason: TunnelV2ResetReason; osCode?: string };
+
+export type TunnelV2ServerMessage =
+  | { type: 'ready'; version: number; tunnelId: string; bindings: TunnelV2Binding[] }
+  | {
+      type: 'open';
+      connId: number;
+      routeId: string;
+      host: string;
+      port: number;
+      proto: 'tcp';
+    }
+  | { type: 'fin'; connId: number }
+  | { type: 'reset'; connId: number; reason: TunnelV2ResetReason; osCode?: string }
+  | { type: 'error'; code: TunnelV2SessionErrorCode };
+
+export type TunnelV2RouteErrorCode = 'empty' | 'too_many' | 'invalid_host' | 'invalid_port' | 'duplicate';
+
+export class TunnelV2RouteError extends Error {
+  constructor(
+    readonly code: TunnelV2RouteErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'TunnelV2RouteError';
+  }
+}
+
+export class TunnelV2ProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TunnelV2ProtocolError';
+  }
+}
+
+export function validateTunnelV2Routes(routes: readonly TunnelV2Route[]): TunnelV2Route[] {
+  if (routes.length === 0) {
+    throw new TunnelV2RouteError('empty', 'at least one tunnel route is required');
+  }
+  if (routes.length > TUNNEL_V2_MAX_ROUTES) {
+    throw new TunnelV2RouteError('too_many', `at most ${TUNNEL_V2_MAX_ROUTES} tunnel routes are allowed`);
+  }
+
+  const canonicalRoutes: TunnelV2Route[] = [];
+  const seen = new Set<string>();
+  for (const route of routes) {
+    const canonical = canonicalizeTunnelV2Route(route);
+    const key = `${canonical.host}\0${canonical.port}`;
+    if (seen.has(key)) {
+      throw new TunnelV2RouteError('duplicate', `duplicate tunnel route ${canonical.host}:${canonical.port}`);
+    }
+    seen.add(key);
+    canonicalRoutes.push(canonical);
+  }
+  return canonicalRoutes;
+}
+
+export function assertTunnelV2OpenAllowed(
+  message: Extract<TunnelV2ServerMessage, { type: 'open' }>,
+  routes: readonly TunnelV2Route[],
+): void {
+  const index = parseRouteId(message.routeId);
+  const route = routes[index];
+  if (!route || message.host !== route.host || message.port !== route.port || message.proto !== 'tcp') {
+    throw new TunnelV2ProtocolError(
+      `server requested undeclared route ${message.routeId} ${message.host}:${message.port}/${message.proto}`,
+    );
+  }
+}
+
+export function assertTunnelV2Ready(
+  message: Extract<TunnelV2ServerMessage, { type: 'ready' }>,
+  routes: readonly TunnelV2Route[],
+): void {
+  if (message.version !== TUNNEL_V2_VERSION) {
+    throw new TunnelV2ProtocolError(`unsupported tunnel version ${message.version}`);
+  }
+  if (message.bindings.length !== routes.length) {
+    throw new TunnelV2ProtocolError('server returned bindings for a different route set');
+  }
+  for (const [index, binding] of message.bindings.entries()) {
+    const route = routes[index];
+    if (
+      !route ||
+      binding.routeId !== `route-${index + 1}` ||
+      binding.route.host !== route.host ||
+      binding.route.port !== route.port
+    ) {
+      throw new TunnelV2ProtocolError('server returned a binding for an undeclared route');
+    }
+  }
+}
+
+export function encodeTunnelV2ClientMessage(message: TunnelV2ClientMessage): string {
+  const record = readRecord(message, 'tunnel control message');
+  const type = readString(record, 'type');
+
+  switch (type) {
+    case 'start': {
+      const version = readInteger(record, 'version');
+      if (version !== TUNNEL_V2_VERSION) {
+        throw new TunnelV2ProtocolError(`unsupported tunnel version ${version}`);
+      }
+      const routes = validateTunnelV2Routes(readArray(record, 'routes').map(readRoute));
+      return JSON.stringify({ type, version, routes });
+    }
+    case 'openOk':
+    case 'fin':
+      return JSON.stringify({ type, connId: readConnectionId(record) });
+    case 'openFail':
+    case 'reset':
+      return JSON.stringify({
+        type,
+        connId: readConnectionId(record),
+        reason: readString(record, 'reason'),
+        ...readOptionalString(record, 'osCode'),
+      });
+    default:
+      throw new TunnelV2ProtocolError(`unknown tunnel control message type ${type}`);
+  }
+}
+
+export function decodeTunnelV2ServerMessage(value: unknown): TunnelV2ServerMessage {
+  const message = readRecord(value, 'tunnel control message');
+  const type = readString(message, 'type');
+
+  switch (type) {
+    case 'ready':
+      return {
+        type,
+        version: readInteger(message, 'version'),
+        tunnelId: readString(message, 'tunnelId'),
+        bindings: readArray(message, 'bindings').map(readBinding),
+      };
+    case 'open':
+      return {
+        type,
+        connId: readConnectionId(message),
+        routeId: readString(message, 'routeId'),
+        host: readString(message, 'host'),
+        port: readPort(message, 'port'),
+        proto: readTCP(message),
+      };
+    case 'fin':
+      return { type, connId: readConnectionId(message) };
+    case 'reset':
+      return {
+        type,
+        connId: readConnectionId(message),
+        reason: readString(message, 'reason'),
+        ...readOptionalString(message, 'osCode'),
+      };
+    case 'error':
+      return { type, code: readString(message, 'code') };
+    default:
+      throw new TunnelV2ProtocolError(`unknown tunnel control message type ${type}`);
+  }
+}
+
+function canonicalizeTunnelV2Route(route: TunnelV2Route): TunnelV2Route {
+  if (!Number.isInteger(route.port) || route.port < 1 || route.port > 65_535) {
+    throw new TunnelV2RouteError('invalid_port', `invalid tunnel route port ${route.port}`);
+  }
+  const isASCII = Buffer.byteLength(route.host, 'utf8') === route.host.length;
+  if (route.host.length === 0 || !isASCII || route.host.length > 254 || route.host.includes('\0')) {
+    throw new TunnelV2RouteError('invalid_host', `invalid tunnel route host ${route.host}`);
+  }
+
+  let host = route.host.toLowerCase();
+  if (host.endsWith('.')) {
+    host = host.slice(0, -1);
+  }
+  if (host.length === 0 || host.length > 253) {
+    throw new TunnelV2RouteError('invalid_host', `invalid tunnel route host ${route.host}`);
+  }
+
+  const ipVersion = net.isIP(host);
+  if (ipVersion === 4) {
+    return { host, port: route.port };
+  }
+  if (ipVersion === 6) {
+    const hostname = new URL(`http://[${host}]/`).hostname;
+    return { host: canonicalizeIPv6(hostname.slice(1, -1)), port: route.port };
+  }
+
+  const labels = host.split('.');
+  if (
+    labels.some(
+      (label) => label.length === 0 || label.length > 63 || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label),
+    ) ||
+    labels.every((label) => /^\d+$/.test(label) || /^0x[0-9a-f]+$/.test(label))
+  ) {
+    throw new TunnelV2RouteError('invalid_host', `invalid tunnel route host ${route.host}`);
+  }
+  return { host, port: route.port };
+}
+
+function canonicalizeIPv6(host: string): string {
+  const embeddedIPv4 = /^(::(?:ffff:)?)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(host);
+  if (!embeddedIPv4?.[1] || !embeddedIPv4[2] || !embeddedIPv4[3]) {
+    return host;
+  }
+  const high = Number.parseInt(embeddedIPv4[2], 16);
+  const low = Number.parseInt(embeddedIPv4[3], 16);
+  return `${embeddedIPv4[1]}${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+
+function parseRouteId(routeId: string): number {
+  const match = /^route-([1-9]\d*)$/.exec(routeId);
+  if (!match?.[1]) {
+    return -1;
+  }
+  return Number(match[1]) - 1;
+}
+
+function readBinding(value: unknown): TunnelV2Binding {
+  const binding = readRecord(value, 'tunnel binding');
+  return {
+    routeId: readString(binding, 'routeId'),
+    route: readRoute(binding['route']),
+    endpoint: readEndpoint(binding['endpoint']),
+  };
+}
+
+function readRoute(value: unknown): TunnelV2Route {
+  const route = readRecord(value, 'tunnel route');
+  return {
+    host: readString(route, 'host'),
+    port: readPort(route, 'port'),
+  };
+}
+
+function readEndpoint(value: unknown): TunnelV2Endpoint {
+  const endpoint = readRecord(value, 'tunnel endpoint');
+  const host = readString(endpoint, 'host');
+  if (host.length === 0) {
+    throw new TunnelV2ProtocolError('tunnel endpoint host must not be empty');
+  }
+  return { host, port: readPort(endpoint, 'port') };
+}
+
+function readRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TunnelV2ProtocolError(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function readArray(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key];
+  if (!Array.isArray(value)) {
+    throw new TunnelV2ProtocolError(`${key} must be an array`);
+  }
+  return value;
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string') {
+    throw new TunnelV2ProtocolError(`${key} must be a string`);
+  }
+  return value;
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string): { [K in typeof key]?: string } {
+  const value = record[key];
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== 'string') {
+    throw new TunnelV2ProtocolError(`${key} must be a string`);
+  }
+  return { [key]: value };
+}
+
+function readInteger(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (!Number.isInteger(value)) {
+    throw new TunnelV2ProtocolError(`${key} must be an integer`);
+  }
+  return value as number;
+}
+
+function readPort(record: Record<string, unknown>, key: string): number {
+  const value = readInteger(record, key);
+  if (value < 1 || value > 65_535) {
+    throw new TunnelV2ProtocolError(`${key} must be between 1 and 65535`);
+  }
+  return value;
+}
+
+function readConnectionId(record: Record<string, unknown>): number {
+  const value = readInteger(record, 'connId');
+  if (value < 0 || value > 0xffff_ffff) {
+    throw new TunnelV2ProtocolError('connId must be an unsigned 32-bit integer');
+  }
+  return value;
+}
+
+function readTCP(record: Record<string, unknown>): 'tcp' {
+  const value = readString(record, 'proto');
+  if (value !== 'tcp') {
+    throw new TunnelV2ProtocolError(`unsupported tunnel transport ${value}`);
+  }
+  return value;
+}

--- a/tests/tunnel-protocol-v2.fixture.json
+++ b/tests/tunnel-protocol-v2.fixture.json
@@ -1,0 +1,362 @@
+{
+  "contract": {
+    "version": 2,
+    "maxRoutes": 10,
+    "connID": {
+      "jsonType": "integer",
+      "minimum": 0,
+      "maximum": 4294967295,
+      "binaryHeaderBytes": 4,
+      "binaryByteOrder": "big_endian",
+      "invalidJSONValues": [-1, 1.5, 4294967296]
+    },
+    "transports": ["tcp"],
+    "openFailureReasons": [
+      "dns_not_found",
+      "dns_temporary_failure",
+      "connection_refused",
+      "connection_reset",
+      "connection_timed_out",
+      "unreachable",
+      "permission_denied",
+      "resource_exhausted",
+      "route_not_allowed",
+      "cancelled",
+      "internal"
+    ],
+    "resetReasons": ["cancelled", "connection_error", "protocol_error", "resource_exhausted", "internal"],
+    "sessionErrorCodes": [
+      "unsupported_version",
+      "invalid_message",
+      "invalid_route",
+      "route_capacity",
+      "already_active",
+      "listener_unavailable",
+      "internal"
+    ]
+  },
+  "routeCases": [
+    {
+      "input": {
+        "host": "API.Example.COM.",
+        "port": 443
+      },
+      "canonical": {
+        "host": "api.example.com",
+        "port": 443
+      }
+    },
+    {
+      "input": {
+        "host": "localhost",
+        "port": 8000
+      },
+      "canonical": {
+        "host": "localhost",
+        "port": 8000
+      }
+    },
+    {
+      "input": {
+        "host": "127.0.0.1",
+        "port": 8081
+      },
+      "canonical": {
+        "host": "127.0.0.1",
+        "port": 8081
+      }
+    },
+    {
+      "input": {
+        "host": "2001:0DB8:0:0:0:0:0:1",
+        "port": 8443
+      },
+      "canonical": {
+        "host": "2001:db8::1",
+        "port": 8443
+      }
+    },
+    {
+      "input": {
+        "host": "::FFFF:192.0.2.1",
+        "port": 9443
+      },
+      "canonical": {
+        "host": "::ffff:192.0.2.1",
+        "port": 9443
+      }
+    },
+    {
+      "input": {
+        "host": "::192.0.2.1",
+        "port": 10443
+      },
+      "canonical": {
+        "host": "::192.0.2.1",
+        "port": 10443
+      }
+    }
+  ],
+  "invalidRouteSets": [
+    {
+      "name": "empty",
+      "routes": [],
+      "error": "empty"
+    },
+    {
+      "name": "wildcard",
+      "routes": [
+        {
+          "host": "*.example.com",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "embedded NUL",
+      "routes": [
+        {
+          "host": "127.0.0.1\u0000.evil",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "Unicode case folding",
+      "routes": [
+        {
+          "host": "\u212A.example",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "short IPv4",
+      "routes": [
+        {
+          "host": "127.1",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "integer IPv4",
+      "routes": [
+        {
+          "host": "2130706433",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "hex IPv4",
+      "routes": [
+        {
+          "host": "0x7f000001",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "cidr",
+      "routes": [
+        {
+          "host": "10.0.0.0/8",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "bracketed IPv6",
+      "routes": [
+        {
+          "host": "[::1]",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "invalid IPv4",
+      "routes": [
+        {
+          "host": "999.0.0.1",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "non-ASCII",
+      "routes": [
+        {
+          "host": "münchen.example",
+          "port": 443
+        }
+      ],
+      "error": "invalid_host"
+    },
+    {
+      "name": "zero port",
+      "routes": [
+        {
+          "host": "localhost",
+          "port": 0
+        }
+      ],
+      "error": "invalid_port"
+    },
+    {
+      "name": "high port",
+      "routes": [
+        {
+          "host": "localhost",
+          "port": 65536
+        }
+      ],
+      "error": "invalid_port"
+    },
+    {
+      "name": "canonical duplicate",
+      "routes": [
+        {
+          "host": "API.example.com",
+          "port": 443
+        },
+        {
+          "host": "api.example.com.",
+          "port": 443
+        }
+      ],
+      "error": "duplicate"
+    },
+    {
+      "name": "canonical IPv6 duplicate",
+      "routes": [
+        {
+          "host": "2001:db8::1",
+          "port": 443
+        },
+        {
+          "host": "2001:0db8:0:0:0:0:0:1",
+          "port": 443
+        }
+      ],
+      "error": "duplicate"
+    }
+  ],
+  "client": [
+    {
+      "name": "start",
+      "message": {
+        "type": "start",
+        "version": 2,
+        "routes": [
+          {
+            "host": "localhost",
+            "port": 8000
+          },
+          {
+            "host": "127.0.0.1",
+            "port": 8081
+          }
+        ]
+      }
+    },
+    {
+      "name": "openOk",
+      "message": {
+        "type": "openOk",
+        "connId": 4294967295
+      }
+    },
+    {
+      "name": "openFail",
+      "message": {
+        "type": "openFail",
+        "connId": 8,
+        "reason": "connection_refused",
+        "osCode": "ECONNREFUSED"
+      }
+    },
+    {
+      "name": "fin",
+      "message": {
+        "type": "fin",
+        "connId": 9
+      }
+    },
+    {
+      "name": "reset",
+      "message": {
+        "type": "reset",
+        "connId": 10,
+        "reason": "cancelled"
+      }
+    }
+  ],
+  "server": [
+    {
+      "name": "ready",
+      "message": {
+        "type": "ready",
+        "version": 2,
+        "tunnelId": "tunnel-1",
+        "bindings": [
+          {
+            "routeId": "route-1",
+            "route": {
+              "host": "localhost",
+              "port": 8000
+            },
+            "endpoint": {
+              "host": "10.244.0.8",
+              "port": 57090
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "open",
+      "message": {
+        "type": "open",
+        "connId": 7,
+        "routeId": "route-1",
+        "host": "localhost",
+        "port": 8000,
+        "proto": "tcp"
+      }
+    },
+    {
+      "name": "fin",
+      "message": {
+        "type": "fin",
+        "connId": 7
+      }
+    },
+    {
+      "name": "reset",
+      "message": {
+        "type": "reset",
+        "connId": 8,
+        "reason": "connection_error",
+        "osCode": "ECONNRESET"
+      }
+    },
+    {
+      "name": "error",
+      "message": {
+        "type": "error",
+        "code": "route_capacity"
+      }
+    }
+  ]
+}

--- a/tests/tunnel-v2-dialer.test.ts
+++ b/tests/tunnel-v2-dialer.test.ts
@@ -87,7 +87,6 @@ describe('destination tunnel v2 dialer', () => {
     const greetingIndex = events.findIndex(
       (event) => event.kind === 'data' && event.payload.toString() === 'greeting',
     );
-    expect(openIndex).toBeGreaterThanOrEqual(0);
     expect(greetingIndex).toBeGreaterThan(openIndex);
 
     sendData(7, Buffer.from('request'));
@@ -278,7 +277,6 @@ describe('destination tunnel v2 dialer', () => {
   test.each([
     ['ENOTFOUND', 'dns_not_found'],
     ['EAI_AGAIN', 'dns_temporary_failure'],
-    ['ECONNREFUSED', 'connection_refused'],
     ['ECONNRESET', 'connection_reset'],
     ['ETIMEDOUT', 'connection_timed_out'],
     ['ENETUNREACH', 'unreachable'],

--- a/tests/tunnel-v2-dialer.test.ts
+++ b/tests/tunnel-v2-dialer.test.ts
@@ -1,0 +1,436 @@
+import net from 'net';
+import { WebSocketServer, type WebSocket } from 'ws';
+import {
+  classifyOpenFailure,
+  startDestinationTcpTunnel,
+  type DestinationTcpTunnel,
+} from '../src/tunnel-v2-dialer';
+import {
+  TUNNEL_V2_CONN_ID_HEADER_BYTES,
+  TUNNEL_V2_VERSION,
+  type TunnelV2ClientMessage,
+  type TunnelV2Route,
+  type TunnelV2ServerMessage,
+} from '../src/tunnel-v2';
+
+type ClientEvent =
+  | { kind: 'control'; message: TunnelV2ClientMessage }
+  | { kind: 'data'; connId: number; payload: Buffer };
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('destination tunnel v2 dialer', () => {
+  let remoteServer: WebSocketServer;
+  let remoteSocket: WebSocket | undefined;
+  let events: ClientEvent[];
+  let tunnel: DestinationTcpTunnel | undefined;
+  let localServers: net.Server[];
+  let localSockets: Set<net.Socket>;
+
+  beforeEach(async () => {
+    events = [];
+    localServers = [];
+    localSockets = new Set();
+    await startRemoteServer(true);
+  });
+
+  afterEach(async () => {
+    tunnel?.close();
+    tunnel = undefined;
+    jest.restoreAllMocks();
+    for (const socket of localSockets) socket.destroy();
+    await Promise.all(
+      localServers.map(
+        (server) =>
+          new Promise<void>((resolve) => {
+            server.close(() => resolve());
+          }),
+      ),
+    );
+    await closeRemoteServer();
+  });
+
+  test('sends OPEN-OK before server-first data and preserves directional FIN', async () => {
+    let localSocket: net.Socket | undefined;
+    let request = Buffer.alloc(0);
+    const localPort = await listenLocal((socket) => {
+      localSocket = socket;
+      socket.write('greeting');
+      socket.on('data', (data) => {
+        request = Buffer.concat([request, data]);
+      });
+      socket.on('end', () => {
+        socket.end('tail');
+      });
+    });
+    const route = { host: '127.0.0.1', port: localPort };
+    tunnel = await establish([route]);
+
+    sendControl({
+      type: 'open',
+      connId: 7,
+      routeId: 'route-1',
+      host: route.host,
+      port: route.port,
+      proto: 'tcp',
+    });
+    await waitFor(() => hasControl('openOk', 7) && dataFor(7).toString() === 'greeting');
+    const openIndex = events.findIndex(
+      (event) => event.kind === 'control' && event.message.type === 'openOk',
+    );
+    const greetingIndex = events.findIndex(
+      (event) => event.kind === 'data' && event.payload.toString() === 'greeting',
+    );
+    expect(openIndex).toBeGreaterThanOrEqual(0);
+    expect(greetingIndex).toBeGreaterThan(openIndex);
+
+    sendData(7, Buffer.from('request'));
+    await waitFor(() => request.toString() === 'request');
+
+    sendControl({ type: 'fin', connId: 7 });
+    await waitFor(() => dataFor(7).toString() === 'greetingtail' && hasControl('fin', 7));
+    const finIndex = events.findIndex((event) => event.kind === 'control' && event.message.type === 'fin');
+    const dataBeforeFin = Buffer.concat(
+      events
+        .slice(0, finIndex)
+        .filter(
+          (event): event is Extract<ClientEvent, { kind: 'data' }> =>
+            event.kind === 'data' && event.connId === 7,
+        )
+        .map((event) => event.payload),
+    );
+    expect(dataBeforeFin.toString()).toBe('greetingtail');
+    expect(events.slice(finIndex + 1).some((event) => event.kind === 'data' && event.connId === 7)).toBe(
+      false,
+    );
+    await waitFor(() => localSocket?.destroyed === true);
+  });
+
+  test('rejects an OPEN destination outside the declared route without dialing it', async () => {
+    let acceptedConnections = 0;
+    const localPort = await listenLocal(() => {
+      acceptedConnections++;
+    });
+    tunnel = await establish([{ host: '127.0.0.1', port: localPort }]);
+
+    sendControl({
+      type: 'open',
+      connId: 8,
+      routeId: 'route-1',
+      host: 'localhost',
+      port: localPort,
+      proto: 'tcp',
+    });
+    await waitFor(() => hasControl('openFail', 8));
+
+    expect(controlFor('openFail', 8)).toEqual({
+      type: 'openFail',
+      connId: 8,
+      reason: 'route_not_allowed',
+    });
+    expect(acceptedConnections).toBe(0);
+  });
+
+  test('reports a refused local dial with its stable reason and OS code', async () => {
+    const unavailablePort = await reserveThenReleasePort();
+    const route = { host: '127.0.0.1', port: unavailablePort };
+    tunnel = await establish([route]);
+
+    sendControl({
+      type: 'open',
+      connId: 9,
+      routeId: 'route-1',
+      host: route.host,
+      port: route.port,
+      proto: 'tcp',
+    });
+    await waitFor(() => hasControl('openFail', 9));
+
+    expect(controlFor('openFail', 9)).toEqual({
+      type: 'openFail',
+      connId: 9,
+      reason: 'connection_refused',
+      osCode: 'ECONNREFUSED',
+    });
+  });
+
+  test('bounds data queued toward a stalled local connection', async () => {
+    const firstSocket = new net.Socket({ allowHalfOpen: true });
+    const secondSocket = new net.Socket({ allowHalfOpen: true });
+    const firstWriteCallbacks: Array<(error?: Error | null) => void> = [];
+    const secondWriteCallbacks: Array<(error?: Error | null) => void> = [];
+    stubWrites(firstSocket, firstWriteCallbacks);
+    stubWrites(secondSocket, secondWriteCallbacks);
+    const createConnection = jest
+      .spyOn(net, 'createConnection')
+      .mockReturnValueOnce(firstSocket)
+      .mockReturnValueOnce(secondSocket);
+
+    const route = { host: '127.0.0.1', port: 8000 };
+    tunnel = await establish([route], {
+      maxPendingBytesPerConnection: 5,
+      maxTotalPendingBytes: 5,
+    });
+    sendControl({
+      type: 'open',
+      connId: 10,
+      routeId: 'route-1',
+      host: route.host,
+      port: route.port,
+      proto: 'tcp',
+    });
+    await waitFor(() => createConnection.mock.calls.length === 1);
+    firstSocket.emit('connect');
+    await waitFor(() => hasControl('openOk', 10));
+
+    sendData(10, Buffer.from('four'));
+    await waitFor(() => firstWriteCallbacks.length === 1);
+    sendData(10, Buffer.from('xx'));
+    await waitFor(() => hasControl('reset', 10));
+    expect(controlFor('reset', 10)).toEqual({
+      type: 'reset',
+      connId: 10,
+      reason: 'resource_exhausted',
+    });
+
+    firstWriteCallbacks[0]!();
+    sendControl({
+      type: 'open',
+      connId: 11,
+      routeId: 'route-1',
+      host: route.host,
+      port: route.port,
+      proto: 'tcp',
+    });
+    await waitFor(() => createConnection.mock.calls.length === 2);
+    secondSocket.emit('connect');
+    await waitFor(() => hasControl('openOk', 11));
+    sendData(11, Buffer.from('four'));
+    await waitFor(() => secondWriteCallbacks.length === 1);
+    expect(controlFor('reset', 11)).toBeUndefined();
+    secondWriteCallbacks[0]!();
+    sendData(11, Buffer.from('four'));
+    await waitFor(() => secondWriteCallbacks.length === 2);
+    expect(controlFor('reset', 11)).toBeUndefined();
+    secondWriteCallbacks[1]!();
+  });
+
+  test('rejects binary data before READY', async () => {
+    const startup = startDestinationTcpTunnel(remoteURL(), 'test-token', {
+      routes: [{ host: 'localhost', port: 8000 }],
+      logLevel: 'none',
+    });
+    await waitFor(() => hasControl('start'));
+
+    remoteSocket!.send(frame(1, Buffer.from('early')));
+    await expect(startup).rejects.toThrow('received tunnel data before READY');
+  });
+
+  test('fails startup when READY never arrives', async () => {
+    const startup = startDestinationTcpTunnel(remoteURL(), 'test-token', {
+      routes: [{ host: 'localhost', port: 8000 }],
+      logLevel: 'none',
+      handshakeTimeoutMs: 100,
+    });
+    await expect(startup).rejects.toThrow('destination tunnel was not ready within 100ms');
+  });
+
+  test('times out a TCP peer that never completes the WebSocket handshake', async () => {
+    const rawServer = net.createServer((socket) => {
+      localSockets.add(socket);
+      socket.once('close', () => localSockets.delete(socket));
+    });
+    localServers.push(rawServer);
+    await new Promise<void>((resolve) => rawServer.listen(0, '127.0.0.1', resolve));
+    const port = (rawServer.address() as net.AddressInfo).port;
+
+    const startup = startDestinationTcpTunnel(`ws://127.0.0.1:${port}/stalled`, 'test-token', {
+      routes: [{ host: 'localhost', port: 8000 }],
+      logLevel: 'none',
+      handshakeTimeoutMs: 100,
+    });
+    await expect(startup).rejects.toThrow('destination tunnel was not ready within 100ms');
+  });
+
+  test('keeps a healthy idle tunnel alive with pong frames', async () => {
+    tunnel = await establish([{ host: 'localhost', port: 8000 }], {
+      livenessTimeoutMs: 100,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(tunnel.getConnectionState()).toBe('connected');
+  });
+
+  test('disconnects a peer that stops sending all frames', async () => {
+    await closeRemoteServer();
+    await startRemoteServer(false);
+    tunnel = await establish([{ host: 'localhost', port: 8000 }], {
+      livenessTimeoutMs: 100,
+    });
+    await waitFor(() => tunnel?.getConnectionState() === 'disconnected');
+  });
+
+  test.each([
+    ['ENOTFOUND', 'dns_not_found'],
+    ['EAI_AGAIN', 'dns_temporary_failure'],
+    ['ECONNREFUSED', 'connection_refused'],
+    ['ECONNRESET', 'connection_reset'],
+    ['ETIMEDOUT', 'connection_timed_out'],
+    ['ENETUNREACH', 'unreachable'],
+    ['EACCES', 'permission_denied'],
+    ['EMFILE', 'resource_exhausted'],
+    ['ECANCELED', 'cancelled'],
+    ['EUNKNOWN', 'internal'],
+  ])('classifies %s as %s', (code, reason) => {
+    expect(classifyOpenFailure(Object.assign(new Error(code), { code }))).toBe(reason);
+  });
+
+  async function establish(
+    routes: TunnelV2Route[],
+    options: {
+      maxPendingBytesPerConnection?: number;
+      maxTotalPendingBytes?: number;
+      livenessTimeoutMs?: number;
+    } = {},
+  ): Promise<DestinationTcpTunnel> {
+    const startup = startDestinationTcpTunnel(remoteURL(), 'test-token', {
+      routes,
+      logLevel: 'none',
+      ...options,
+    });
+    await waitFor(() => hasControl('start'));
+    expect(controlFor('start')).toEqual({
+      type: 'start',
+      version: TUNNEL_V2_VERSION,
+      routes,
+    });
+    sendControl({
+      type: 'ready',
+      version: TUNNEL_V2_VERSION,
+      tunnelId: 'tunnel-1',
+      bindings: routes.map((route, index) => ({
+        routeId: `route-${index + 1}`,
+        route,
+        endpoint: { host: '10.0.0.8', port: 57090 + index },
+      })),
+    });
+    return startup;
+  }
+
+  async function listenLocal(onConnection: (socket: net.Socket) => void): Promise<number> {
+    const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+      localSockets.add(socket);
+      socket.once('close', () => localSockets.delete(socket));
+      onConnection(socket);
+    });
+    localServers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    return (server.address() as net.AddressInfo).port;
+  }
+
+  async function reserveThenReleasePort(): Promise<number> {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    return port;
+  }
+
+  async function startRemoteServer(autoPong: boolean): Promise<void> {
+    remoteServer = new WebSocketServer({
+      host: '127.0.0.1',
+      port: 0,
+      autoPong,
+    });
+    remoteServer.on('connection', (socket) => {
+      remoteSocket = socket;
+      socket.on('message', (data: Buffer, isBinary: boolean) => {
+        if (isBinary) {
+          events.push({
+            kind: 'data',
+            connId: data.readUInt32BE(0),
+            payload: data.subarray(TUNNEL_V2_CONN_ID_HEADER_BYTES),
+          });
+        } else {
+          events.push({
+            kind: 'control',
+            message: JSON.parse(data.toString('utf8')) as TunnelV2ClientMessage,
+          });
+        }
+      });
+    });
+    await new Promise<void>((resolve) => remoteServer.once('listening', resolve));
+  }
+
+  async function closeRemoteServer(): Promise<void> {
+    remoteSocket?.terminate();
+    remoteSocket = undefined;
+    await new Promise<void>((resolve) => remoteServer.close(() => resolve()));
+  }
+
+  function stubWrites(socket: net.Socket, callbacks: Array<(error?: Error | null) => void>): void {
+    jest.spyOn(socket, 'write').mockImplementation(((
+      _: Uint8Array,
+      callback?: (error?: Error | null) => void,
+    ) => {
+      if (callback) callbacks.push(callback);
+      return false;
+    }) as typeof socket.write);
+  }
+
+  function remoteURL(): string {
+    const address = remoteServer.address() as net.AddressInfo;
+    return `ws://127.0.0.1:${address.port}/tunnel-v2`;
+  }
+
+  function sendControl(message: TunnelV2ServerMessage): void {
+    remoteSocket!.send(JSON.stringify(message));
+  }
+
+  function sendData(connId: number, payload: Buffer): void {
+    remoteSocket!.send(frame(connId, payload));
+  }
+
+  function frame(connId: number, payload: Buffer): Buffer {
+    const header = Buffer.alloc(TUNNEL_V2_CONN_ID_HEADER_BYTES);
+    header.writeUInt32BE(connId, 0);
+    return Buffer.concat([header, payload]);
+  }
+
+  function hasControl(type: TunnelV2ClientMessage['type'], connId?: number): boolean {
+    return controlFor(type, connId) !== undefined;
+  }
+
+  function controlFor(
+    type: TunnelV2ClientMessage['type'],
+    connId?: number,
+  ): TunnelV2ClientMessage | undefined {
+    for (const event of events) {
+      if (event.kind !== 'control') continue;
+      const message = event.message;
+      if (
+        message.type === type &&
+        (connId === undefined || ('connId' in message && message.connId === connId))
+      ) {
+        return message;
+      }
+    }
+    return undefined;
+  }
+
+  function dataFor(connId: number): Buffer {
+    return Buffer.concat(
+      events
+        .filter(
+          (event): event is Extract<ClientEvent, { kind: 'data' }> =>
+            event.kind === 'data' && event.connId === connId,
+        )
+        .map((event) => event.payload),
+    );
+  }
+});

--- a/tests/tunnel-v2-management.test.ts
+++ b/tests/tunnel-v2-management.test.ts
@@ -1,0 +1,135 @@
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { decodeTunnelV2Status, getTunnelV2Status, stopTunnelV2 } from '../src/internal/tunnel-v2-management';
+
+describe('tunnel v2 management', () => {
+  let server: http.Server;
+  let responder: (request: http.IncomingMessage, response: http.ServerResponse) => void;
+
+  beforeEach(async () => {
+    responder = (_, response) => {
+      response.writeHead(500).end('missing test responder');
+    };
+    server = http.createServer((request, response) => responder(request, response));
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('gets and validates status with bearer authentication', async () => {
+    let requestMethod: string | undefined;
+    let requestURL: string | undefined;
+    let authorization: string | undefined;
+    responder = (request, response) => {
+      requestMethod = request.method;
+      requestURL = request.url;
+      authorization = request.headers.authorization;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          active: {
+            tunnelId: 'tunnel-1',
+            state: 'ready',
+            bindings: [
+              {
+                routeId: 'route-1',
+                route: { host: 'localhost', port: 8000 },
+                endpoint: { host: '10.0.0.8', port: 57090 },
+              },
+            ],
+          },
+        }),
+      );
+    };
+
+    await expect(getTunnelV2Status(apiURL(), 'secret')).resolves.toEqual({
+      active: {
+        tunnelId: 'tunnel-1',
+        state: 'ready',
+        bindings: [
+          {
+            routeId: 'route-1',
+            route: { host: 'localhost', port: 8000 },
+            endpoint: { host: '10.0.0.8', port: 57090 },
+          },
+        ],
+      },
+    });
+    expect(requestMethod).toBe('GET');
+    expect(requestURL).toBe('/v1/ios_123/api/tunnel');
+    expect(authorization).toBe('Bearer secret');
+  });
+
+  test('stops by an encoded tunnel ID with bearer authentication', async () => {
+    const tunnelId = 'tunnel /?&';
+    let requestMethod: string | undefined;
+    let requestURL: URL | undefined;
+    let authorization: string | undefined;
+    responder = (request, response) => {
+      requestMethod = request.method;
+      requestURL = new URL(request.url!, 'http://localhost');
+      authorization = request.headers.authorization;
+      response.writeHead(204).end();
+    };
+
+    await stopTunnelV2(apiURL(), 'secret', tunnelId);
+
+    expect(requestMethod).toBe('DELETE');
+    expect(requestURL?.pathname).toBe('/v1/ios_123/api/tunnel');
+    expect(requestURL?.searchParams.get('tunnelId')).toBe(tunnelId);
+    expect(authorization).toBe('Bearer secret');
+  });
+
+  test('surfaces HTTP errors', async () => {
+    responder = (_, response) => {
+      response.writeHead(404).end('missing');
+    };
+
+    await expect(getTunnelV2Status(apiURL(), 'secret')).rejects.toThrow(
+      'getTunnelStatus failed: 404 missing',
+    );
+    await expect(stopTunnelV2(apiURL(), 'secret', 'tunnel-1')).rejects.toThrow(
+      'stopTunnel failed: 404 missing',
+    );
+  });
+
+  test.each([
+    null,
+    { active: null },
+    { active: { tunnelId: 'one', state: 'future', bindings: [] } },
+    {
+      active: {
+        tunnelId: 'one',
+        state: 'ready',
+        bindings: [
+          {
+            routeId: 'route-1',
+            route: { host: 'localhost', port: 0 },
+            endpoint: { host: '10.0.0.8', port: 57090 },
+          },
+        ],
+      },
+    },
+    { lastFailure: { tunnelId: '', code: 'internal' } },
+  ])('rejects malformed status %#', (status) => {
+    expect(() => decodeTunnelV2Status(status)).toThrow();
+  });
+
+  test('rejects an empty stop ID before sending a request', async () => {
+    let requests = 0;
+    responder = (_, response) => {
+      requests++;
+      response.writeHead(204).end();
+    };
+
+    await expect(stopTunnelV2(apiURL(), 'secret', '   ')).rejects.toThrow('tunnelId must not be empty');
+    expect(requests).toBe(0);
+  });
+
+  function apiURL(): string {
+    const address = server.address() as AddressInfo;
+    return `http://127.0.0.1:${address.port}/v1/ios_123/api?old=value#fragment`;
+  }
+});

--- a/tests/tunnel-v2-management.test.ts
+++ b/tests/tunnel-v2-management.test.ts
@@ -19,6 +19,13 @@ describe('tunnel v2 management', () => {
   });
 
   test('gets and validates status with bearer authentication', async () => {
+    const lastDialFailure = {
+      tunnelId: 'tunnel-1',
+      connectionId: 7,
+      routeId: 'route-3',
+      reason: 'connection_refused',
+      osCode: 'ECONNREFUSED',
+    };
     let requestMethod: string | undefined;
     let requestURL: string | undefined;
     let authorization: string | undefined;
@@ -40,6 +47,7 @@ describe('tunnel v2 management', () => {
               },
             ],
           },
+          lastDialFailure,
         }),
       );
     };
@@ -56,6 +64,7 @@ describe('tunnel v2 management', () => {
           },
         ],
       },
+      lastDialFailure,
     });
     expect(requestMethod).toBe('GET');
     expect(requestURL).toBe('/v1/ios_123/api/tunnel');
@@ -113,6 +122,14 @@ describe('tunnel v2 management', () => {
       },
     },
     { lastFailure: { tunnelId: '', code: 'internal' } },
+    {
+      lastDialFailure: {
+        tunnelId: 'one',
+        connectionId: -1,
+        routeId: 'route-1',
+        reason: 'internal',
+      },
+    },
   ])('rejects malformed status %#', (status) => {
     expect(() => decodeTunnelV2Status(status)).toThrow();
   });
@@ -126,6 +143,20 @@ describe('tunnel v2 management', () => {
 
     await expect(stopTunnelV2(apiURL(), 'secret', '   ')).rejects.toThrow('tunnelId must not be empty');
     expect(requests).toBe(0);
+  });
+
+  test('accepts the maximum uint32 connection ID', () => {
+    const connectionId = 0xffff_ffff;
+    expect(
+      decodeTunnelV2Status({
+        lastDialFailure: {
+          tunnelId: 'tunnel-1',
+          connectionId,
+          routeId: 'route-1',
+          reason: 'internal',
+        },
+      }).lastDialFailure?.connectionId,
+    ).toBe(connectionId);
   });
 
   function apiURL(): string {

--- a/tests/tunnel-v2-management.test.ts
+++ b/tests/tunnel-v2-management.test.ts
@@ -21,7 +21,7 @@ describe('tunnel v2 management', () => {
   test('gets and validates status with bearer authentication', async () => {
     const lastDialFailure = {
       tunnelId: 'tunnel-1',
-      connectionId: 7,
+      connectionId: 0xffff_ffff,
       routeId: 'route-3',
       reason: 'connection_refused',
       osCode: 'ECONNREFUSED',
@@ -143,20 +143,6 @@ describe('tunnel v2 management', () => {
 
     await expect(stopTunnelV2(apiURL(), 'secret', '   ')).rejects.toThrow('tunnelId must not be empty');
     expect(requests).toBe(0);
-  });
-
-  test('accepts the maximum uint32 connection ID', () => {
-    const connectionId = 0xffff_ffff;
-    expect(
-      decodeTunnelV2Status({
-        lastDialFailure: {
-          tunnelId: 'tunnel-1',
-          connectionId,
-          routeId: 'route-1',
-          reason: 'internal',
-        },
-      }).lastDialFailure?.connectionId,
-    ).toBe(connectionId);
   });
 
   function apiURL(): string {

--- a/tests/tunnel-v2-url.test.ts
+++ b/tests/tunnel-v2-url.test.ts
@@ -1,0 +1,21 @@
+import { deriveTunnelV2URL } from '../src/internal/tunnel-v2-url';
+
+describe('destination tunnel URL', () => {
+  test('preserves the instance API path', () => {
+    expect(deriveTunnelV2URL('https://node.example/v1/ios_123/api')).toBe(
+      'wss://node.example/v1/ios_123/api/tunnel',
+    );
+  });
+
+  test('clears existing query and hash', () => {
+    expect(deriveTunnelV2URL('http://node.example/v1/ios_123/api?token=old#frag')).toBe(
+      'ws://node.example/v1/ios_123/api/tunnel',
+    );
+  });
+
+  test('rejects unsupported schemes', () => {
+    expect(() => deriveTunnelV2URL('file:///v1/ios_123/api')).toThrow(
+      'Unsupported apiUrl protocol for tunnel: file:',
+    );
+  });
+});

--- a/tests/tunnel-v2-url.test.ts
+++ b/tests/tunnel-v2-url.test.ts
@@ -1,21 +1,27 @@
-import { deriveTunnelV2URL } from '../src/internal/tunnel-v2-url';
+import { deriveTunnelManagementURL, deriveTunnelV2URL } from '../src/internal/tunnel-v2-url';
 
 describe('destination tunnel URL', () => {
   test('preserves the instance API path', () => {
     expect(deriveTunnelV2URL('https://node.example/v1/ios_123/api')).toBe(
-      'wss://node.example/v1/ios_123/api/tunnel',
+      'wss://node.example/v1/ios_123/api/tunnel-v2',
     );
   });
 
   test('clears existing query and hash', () => {
     expect(deriveTunnelV2URL('http://node.example/v1/ios_123/api?token=old#frag')).toBe(
-      'ws://node.example/v1/ios_123/api/tunnel',
+      'ws://node.example/v1/ios_123/api/tunnel-v2',
     );
   });
 
   test('rejects unsupported schemes', () => {
     expect(() => deriveTunnelV2URL('file:///v1/ios_123/api')).toThrow(
       'Unsupported apiUrl protocol for tunnel: file:',
+    );
+  });
+
+  test('derives the management URL separately from the WebSocket', () => {
+    expect(deriveTunnelManagementURL('https://node.example/v1/ios_123/api?token=old#frag').toString()).toBe(
+      'https://node.example/v1/ios_123/api/tunnel',
     );
   });
 });

--- a/tests/tunnel-v2-url.test.ts
+++ b/tests/tunnel-v2-url.test.ts
@@ -1,4 +1,4 @@
-import { deriveTunnelManagementURL, deriveTunnelV2URL } from '../src/internal/tunnel-v2-url';
+import { deriveTunnelV2URL } from '../src/internal/tunnel-v2-url';
 
 describe('destination tunnel URL', () => {
   test('preserves the instance API path', () => {
@@ -16,12 +16,6 @@ describe('destination tunnel URL', () => {
   test('rejects unsupported schemes', () => {
     expect(() => deriveTunnelV2URL('file:///v1/ios_123/api')).toThrow(
       'Unsupported apiUrl protocol for tunnel: file:',
-    );
-  });
-
-  test('derives the management URL separately from the WebSocket', () => {
-    expect(deriveTunnelManagementURL('https://node.example/v1/ios_123/api?token=old#frag').toString()).toBe(
-      'https://node.example/v1/ios_123/api/tunnel',
     );
   });
 });

--- a/tests/tunnel-v2.test.ts
+++ b/tests/tunnel-v2.test.ts
@@ -1,0 +1,159 @@
+import fixture from './tunnel-protocol-v2.fixture.json';
+import {
+  TUNNEL_V2_CONN_ID_HEADER_BYTES,
+  TUNNEL_V2_MAX_ROUTES,
+  TUNNEL_V2_VERSION,
+  TunnelV2ProtocolError,
+  TunnelV2RouteError,
+  assertTunnelV2OpenAllowed,
+  assertTunnelV2Ready,
+  decodeTunnelV2ServerMessage,
+  encodeTunnelV2ClientMessage,
+  validateTunnelV2Routes,
+  type TunnelV2ClientMessage,
+  type TunnelV2Route,
+  type TunnelV2RouteErrorCode,
+  type TunnelV2ServerMessage,
+} from '../src/tunnel-v2';
+
+describe('tunnel v2 wire contract', () => {
+  test('pins protocol constants', () => {
+    expect(TUNNEL_V2_VERSION).toBe(fixture.contract.version);
+    expect(TUNNEL_V2_MAX_ROUTES).toBe(fixture.contract.maxRoutes);
+    expect(TUNNEL_V2_CONN_ID_HEADER_BYTES).toBe(fixture.contract.connID.binaryHeaderBytes);
+    expect(fixture.contract.connID.binaryByteOrder).toBe('big_endian');
+    expect(fixture.contract.transports).toEqual(['tcp']);
+  });
+
+  test('encodes every client fixture', () => {
+    for (const entry of fixture.client) {
+      const encoded = encodeTunnelV2ClientMessage(entry.message as TunnelV2ClientMessage);
+      expect(JSON.parse(encoded)).toEqual(entry.message);
+    }
+  });
+
+  test.each([-1, 1.5, 0x1_0000_0000, Number.NaN, Number.POSITIVE_INFINITY])(
+    'refuses to encode invalid connId %p',
+    (connId) => {
+      expect(() =>
+        encodeTunnelV2ClientMessage({
+          type: 'openOk',
+          connId,
+        }),
+      ).toThrow(TunnelV2ProtocolError);
+    },
+  );
+
+  test('canonicalizes START routes while encoding', () => {
+    const encoded = encodeTunnelV2ClientMessage({
+      type: 'start',
+      version: TUNNEL_V2_VERSION,
+      routes: [{ host: 'API.Example.COM.', port: 443 }],
+    });
+    expect(JSON.parse(encoded)).toEqual({
+      type: 'start',
+      version: TUNNEL_V2_VERSION,
+      routes: [{ host: 'api.example.com', port: 443 }],
+    });
+  });
+
+  test.each(fixture.invalidRouteSets)('refuses to encode invalid START route set $name', ({ routes }) => {
+    expect(() =>
+      encodeTunnelV2ClientMessage({
+        type: 'start',
+        version: TUNNEL_V2_VERSION,
+        routes,
+      }),
+    ).toThrow();
+  });
+
+  test('decodes every server fixture', () => {
+    for (const entry of fixture.server) {
+      expect(decodeTunnelV2ServerMessage(entry.message)).toEqual(entry.message);
+    }
+  });
+
+  test.each(fixture.contract.connID.invalidJSONValues)('rejects invalid connId %p', (connId) => {
+    expect(() =>
+      decodeTunnelV2ServerMessage({
+        type: 'fin',
+        connId,
+      }),
+    ).toThrow(TunnelV2ProtocolError);
+  });
+
+  test('rejects unknown server message types', () => {
+    expect(() => decodeTunnelV2ServerMessage({ type: 'future' })).toThrow(
+      'unknown tunnel control message type future',
+    );
+  });
+
+  test('preserves unknown diagnostic values', () => {
+    expect(
+      decodeTunnelV2ServerMessage({
+        type: 'reset',
+        connId: 1,
+        reason: 'future_reason',
+        osCode: 'EUNKNOWN',
+      }),
+    ).toEqual({
+      type: 'reset',
+      connId: 1,
+      reason: 'future_reason',
+      osCode: 'EUNKNOWN',
+    });
+  });
+});
+
+describe('tunnel v2 route contract', () => {
+  test.each(fixture.routeCases)('canonicalizes $input.host', ({ input, canonical }) => {
+    expect(validateTunnelV2Routes([input])).toEqual([canonical]);
+  });
+
+  test.each(fixture.invalidRouteSets)('rejects $name with $error', ({ routes, error }) => {
+    expect(() => validateTunnelV2Routes(routes)).toThrow(
+      expect.objectContaining<Partial<TunnelV2RouteError>>({
+        code: error as TunnelV2RouteErrorCode,
+      }),
+    );
+  });
+
+  test('accepts exactly the declared OPEN destination', () => {
+    const routes = validateTunnelV2Routes([{ host: 'LOCALHOST.', port: 8000 }]);
+    const open = decodeTunnelV2ServerMessage(fixture.server.find(({ name }) => name === 'open')!.message);
+    expect(open.type).toBe('open');
+    expect(() =>
+      assertTunnelV2OpenAllowed(open as Extract<TunnelV2ServerMessage, { type: 'open' }>, routes),
+    ).not.toThrow();
+  });
+
+  test.each([
+    { routeId: 'route-2', host: 'localhost', port: 8000 },
+    { routeId: 'route-1', host: '127.0.0.1', port: 8000 },
+    { routeId: 'route-1', host: 'localhost', port: 8001 },
+  ])('rejects undeclared OPEN $routeId $host:$port', (requested) => {
+    const routes: TunnelV2Route[] = [{ host: 'localhost', port: 8000 }];
+    expect(() =>
+      assertTunnelV2OpenAllowed(
+        {
+          type: 'open',
+          connId: 1,
+          ...requested,
+          proto: 'tcp',
+        },
+        routes,
+      ),
+    ).toThrow(TunnelV2ProtocolError);
+  });
+
+  test('requires READY bindings to match the original route set', () => {
+    const ready = decodeTunnelV2ServerMessage(fixture.server.find(({ name }) => name === 'ready')!.message);
+    expect(ready.type).toBe('ready');
+    const readyMessage = ready as Extract<TunnelV2ServerMessage, { type: 'ready' }>;
+
+    expect(() => assertTunnelV2Ready(readyMessage, [{ host: 'localhost', port: 8000 }])).not.toThrow();
+    expect(() => assertTunnelV2Ready(readyMessage, [{ host: 'localhost', port: 8001 }])).toThrow(
+      TunnelV2ProtocolError,
+    );
+  });
+});

--- a/tests/tunnel-v2.test.ts
+++ b/tests/tunnel-v2.test.ts
@@ -21,8 +21,6 @@ describe('tunnel v2 wire contract', () => {
     expect(TUNNEL_V2_VERSION).toBe(fixture.contract.version);
     expect(TUNNEL_V2_MAX_ROUTES).toBe(fixture.contract.maxRoutes);
     expect(TUNNEL_V2_CONN_ID_HEADER_BYTES).toBe(fixture.contract.connID.binaryHeaderBytes);
-    expect(fixture.contract.connID.binaryByteOrder).toBe('big_endian');
-    expect(fixture.contract.transports).toEqual(['tcp']);
   });
 
   test('encodes every client fixture', () => {
@@ -32,8 +30,8 @@ describe('tunnel v2 wire contract', () => {
     }
   });
 
-  test.each([-1, 1.5, 0x1_0000_0000, Number.NaN, Number.POSITIVE_INFINITY])(
-    'refuses to encode invalid connId %p',
+  test.each(fixture.contract.connID.invalidJSONValues)(
+    'rejects invalid connId %p at both wire boundaries',
     (connId) => {
       expect(() =>
         encodeTunnelV2ClientMessage({
@@ -41,8 +39,23 @@ describe('tunnel v2 wire contract', () => {
           connId,
         }),
       ).toThrow(TunnelV2ProtocolError);
+      expect(() =>
+        decodeTunnelV2ServerMessage({
+          type: 'fin',
+          connId,
+        }),
+      ).toThrow(TunnelV2ProtocolError);
     },
   );
+
+  test('refuses to encode a non-finite connId', () => {
+    expect(() =>
+      encodeTunnelV2ClientMessage({
+        type: 'openOk',
+        connId: Number.NaN,
+      }),
+    ).toThrow(TunnelV2ProtocolError);
+  });
 
   test('canonicalizes START routes while encoding', () => {
     const encoded = encodeTunnelV2ClientMessage({
@@ -57,29 +70,10 @@ describe('tunnel v2 wire contract', () => {
     });
   });
 
-  test.each(fixture.invalidRouteSets)('refuses to encode invalid START route set $name', ({ routes }) => {
-    expect(() =>
-      encodeTunnelV2ClientMessage({
-        type: 'start',
-        version: TUNNEL_V2_VERSION,
-        routes,
-      }),
-    ).toThrow();
-  });
-
   test('decodes every server fixture', () => {
     for (const entry of fixture.server) {
       expect(decodeTunnelV2ServerMessage(entry.message)).toEqual(entry.message);
     }
-  });
-
-  test.each(fixture.contract.connID.invalidJSONValues)('rejects invalid connId %p', (connId) => {
-    expect(() =>
-      decodeTunnelV2ServerMessage({
-        type: 'fin',
-        connId,
-      }),
-    ).toThrow(TunnelV2ProtocolError);
   });
 
   test('rejects unknown server message types', () => {
@@ -111,11 +105,17 @@ describe('tunnel v2 route contract', () => {
   });
 
   test.each(fixture.invalidRouteSets)('rejects $name with $error', ({ routes, error }) => {
-    expect(() => validateTunnelV2Routes(routes)).toThrow(
-      expect.objectContaining<Partial<TunnelV2RouteError>>({
-        code: error as TunnelV2RouteErrorCode,
+    const expected = expect.objectContaining<Partial<TunnelV2RouteError>>({
+      code: error as TunnelV2RouteErrorCode,
+    });
+    expect(() => validateTunnelV2Routes(routes)).toThrow(expected);
+    expect(() =>
+      encodeTunnelV2ClientMessage({
+        type: 'start',
+        version: TUNNEL_V2_VERSION,
+        routes,
       }),
-    );
+    ).toThrow();
   });
 
   test('accepts exactly the declared OPEN destination', () => {
@@ -147,11 +147,10 @@ describe('tunnel v2 route contract', () => {
   });
 
   test('requires READY bindings to match the original route set', () => {
-    const ready = decodeTunnelV2ServerMessage(fixture.server.find(({ name }) => name === 'ready')!.message);
-    expect(ready.type).toBe('ready');
-    const readyMessage = ready as Extract<TunnelV2ServerMessage, { type: 'ready' }>;
+    const readyMessage = decodeTunnelV2ServerMessage(
+      fixture.server.find(({ name }) => name === 'ready')!.message,
+    ) as Extract<TunnelV2ServerMessage, { type: 'ready' }>;
 
-    expect(() => assertTunnelV2Ready(readyMessage, [{ host: 'localhost', port: 8000 }])).not.toThrow();
     expect(() => assertTunnelV2Ready(readyMessage, [{ host: 'localhost', port: 8001 }])).toThrow(
       TunnelV2ProtocolError,
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New networking surface that dials user-declared local TCP from a remote-driven tunnel; mitigated by strict route allowlisting and hardened detached-process ownership, but still touches auth tokens and local connectivity.
> 
> **Overview**
> Adds **destination-routed tunnels** so a remote iOS simulator can reach exact **local `host:port` services** (not just reverse port forwarding). The SDK introduces tunnel **v2** (WebSocket control + multiplexed TCP), **`startTunnel` / `getTunnelStatus` / `stopTunnel`** on the iOS instance client, and HTTP helpers for tunnel management URLs.
> 
> The CLI exposes **`lim ios tunnel`** with repeatable **`--route`** targets, foreground or **`--detach`** background mode, plus **`tunnel status`** and **`tunnel stop`**. Detached mode uses **`~/.lim/tunnels`** state, owner tokens, PID/command-line verification, log rotation, and coordinated remote + local cleanup.
> 
> Route validation rejects wildcards and ambiguous hosts; the dialer only connects to destinations declared in the tunnel handshake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc4977cb0f2d0c8a354d9ec60b11ba34e7e9e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->