### PR TITLE
ios: client-side scroll search for tap-element, --no-require-focus for blind typing

### DIFF
--- a/packages/cli/src/commands/ios/tap-element.ts
+++ b/packages/cli/src/commands/ios/tap-element.ts
@@ -50,6 +50,13 @@ export default class IosTapElement extends BaseCommand {
         'How to activate the element: `touch` (default) scrolls it into view and taps with a real touch; `ax` performs an accessibility press without touch events.',
       options: ['touch', 'ax'],
     }),
+    'scroll-search': Flags.boolean({
+      description:
+        'Page the screen client-side to find elements absent from the accessibility tree (virtualized lists ' +
+        'materialize rows only on scroll). Without this, a selector matching nothing fails fast; elements ' +
+        'already in the tree are scrolled into view automatically.',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -59,9 +66,6 @@ export default class IosTapElement extends BaseCommand {
     await this.withAuth(async () => {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const id = resolvedInstance.id;
-      if (false) {
-        this.error('ios tap-element only supports iOS instances');
-      }
 
       const selector: Record<string, string> = {};
       if (flags['ax-unique-id']) selector.AXUniqueId = flags['ax-unique-id'];
@@ -78,17 +82,15 @@ export default class IosTapElement extends BaseCommand {
         );
       }
 
-      const options: Ios.TapElementOptions | undefined =
-        flags.activate ? { activate: flags.activate as Ios.TapElementActivation } : undefined;
+      const options: Ios.TapElementOptions = {
+        activate: flags.activate as Ios.TapElementActivation | undefined,
+        scrollSearch: flags['scroll-search'],
+      };
       if (hasActiveSession(id)) {
-        // tapElement can scroll-scan for up to 90s; the IPC socket must not
-        // give up first.
-        const result = await sendSessionCommand(
-          id,
-          'tap-element',
-          [selector, options],
-          Ios.TAP_ELEMENT_TIMEOUT_MS + 15_000,
-        );
+        // timeoutMs is the SDK's total budget for the call (scroll search
+        // included); the IPC socket must not give up first.
+        const ipcTimeoutMs = Ios.TAP_ELEMENT_TIMEOUT_MS + 15_000;
+        const result = await sendSessionCommand(id, 'tap-element', [selector, options], ipcTimeoutMs);
         if (flags.json) this.outputJson(result);
         else this.log('Element tapped');
         return;

--- a/packages/cli/src/commands/ios/type.ts
+++ b/packages/cli/src/commands/ios/type.ts
@@ -11,11 +11,13 @@ export default class IosType extends BaseCommand {
   static description =
     'Type text into the currently focused input field as real key events, so the app sees genuine keystrokes ' +
     'and text delegates fire. Fails when no field is focused. For fast text entry without key events, use ' +
-    '`ios set-text`. Use `--enter` to submit the field after typing.';
+    '`ios set-text`. Use `--enter` to submit the field after typing. Use `--no-require-focus` to type blind ' +
+    'when the field was focused by other means (e.g. a coordinate tap) and the accessibility focus scan is unreliable.';
   static examples = [
     '<%= config.bin %> ios type "Hello World"',
     '<%= config.bin %> ios type "Hello World" --id <instance-ID>',
     '<%= config.bin %> ios type "search query" --enter',
+    '<%= config.bin %> ios type "Hello" --no-require-focus',
   ];
 
   static args = {
@@ -31,6 +33,12 @@ export default class IosType extends BaseCommand {
       description: 'Press Enter after typing.',
       default: false,
     }),
+    'require-focus': Flags.boolean({
+      description:
+        'Require a focused input field before typing (`--no-require-focus` types blind for fields focused by other means).',
+      default: true,
+      allowNo: true,
+    }),
   };
 
   async run(): Promise<void> {
@@ -40,16 +48,16 @@ export default class IosType extends BaseCommand {
     await this.withAuth(async () => {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const id = resolvedInstance.id;
-      if (false) {
-        this.error('ios type only supports iOS instances');
-      }
 
+      // The SDK sends requireFocus on the wire only when false, so the
+      // default flag value keeps legacy payloads byte-identical.
+      const options = { requireFocus: flags['require-focus'] };
       if (hasActiveSession(id)) {
-        await sendSessionCommand(id, 'type', [args.text, flags.enter]);
+        await sendSessionCommand(id, 'type', [args.text, flags.enter, options]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
         try {
-          await client.typeText(args.text, flags.enter);
+          await client.typeText(args.text, flags.enter, options);
         } finally {
           disconnect();
         }

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -335,7 +335,7 @@ export function startDaemonServer(): void {
 
         case 'type':
           if (type === 'ios') {
-            await (client as any).typeText(args[0], args[1]);
+            await (client as any).typeText(args[0], args[1], args[2]);
             result = { typed: true };
           } else {
             const target = typeof args[0] === 'string' || args[0] === undefined ? undefined : args[0];

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -9,6 +9,7 @@ import { type SyncFolderResult, type FolderSyncOptions, syncFolder } from './fol
 import { createIgnoreFn } from './folder-sync-ignore';
 import { prepareAppBundlePath, watchAppArchive } from './app-archive';
 import { downloadFileToLocalPath } from './internal/download-file';
+import { sleep } from './internal/utils/sleep';
 import { nodeProxyTransport } from './internal/proxy-transport';
 import {
   startHttpProxy as startLocalHttpProxy,
@@ -186,11 +187,29 @@ export type TapElementActivation = 'touch' | 'ax';
 export type TapElementOptions = {
   activate?: TapElementActivation;
   /**
-   * Request timeout in milliseconds, default 90 seconds. The server scrolls
-   * to find off-screen elements, and that can take well over 30s on busy
-   * screens.
+   * Search for elements absent from the accessibility tree by paging the
+   * screen and retrying, client-side. The server fails absent selectors
+   * fast: virtualized lists materialize rows only on scroll, so whether a
+   * miss is worth paging for is the caller's call. Elements already in the
+   * tree are scrolled into view by the server without this option.
+   */
+  scrollSearch?: boolean;
+  /**
+   * Timeout in milliseconds, default 90 seconds. The server scrolls
+   * elements it can see into view, and that can take well over 30s on busy
+   * screens. With scrollSearch this is the total budget for the whole
+   * search, not per attempt.
    */
   timeoutMs?: number;
+};
+
+export type TypeTextOptions = {
+  /**
+   * When false, skip the server's focused-field check and type blind. For
+   * callers that focus fields by other means (e.g. vision-driven taps)
+   * where the accessibility focus scan is unreliable. Default true.
+   */
+  requireFocus?: boolean;
 };
 
 export type ElementResult = {
@@ -566,13 +585,14 @@ export type InstanceClient = {
 
   /**
    * Type text into the focused field as real key events, so the app's text
-   * delegates fire. Fails when no field is focused. Typing costs ~20ms per
-   * character; use setElementValue for long strings that do not need key
-   * events.
+   * delegates fire. Fails when no field is focused unless
+   * `options.requireFocus` is false. Typing costs ~20ms per character; use
+   * setElementValue for long strings that do not need key events.
    * @param text The text to type
    * @param pressEnter If true, press Enter after typing
+   * @param options Typing options (requireFocus)
    */
-  typeText: (text: string, pressEnter?: boolean) => Promise<void>;
+  typeText: (text: string, pressEnter?: boolean, options?: TypeTextOptions) => Promise<void>;
 
   /**
    * Press a key on the keyboard, optionally with modifiers
@@ -2055,7 +2075,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       return sendRequest<void>('tap', { x, y, screenWidth, screenHeight });
     };
 
-    const tapElement = (
+    const tapElementOnce = (
       selector: AccessibilitySelector,
       options?: TapElementOptions,
     ): Promise<TapElementResult> => {
@@ -2065,6 +2085,70 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         undefined,
         options?.timeoutMs ?? TAP_ELEMENT_TIMEOUT_MS,
       );
+    };
+
+    // The server fails absent selectors fast with a typed error whose phrase
+    // the e2e suite pins. The other two phrases are pre-fail-fast servers:
+    // their touch path reports a miss after its own sweep ("was not found on
+    // screen"), and their ax path reports "not found for selector".
+    const isAbsentSelectorError = (error: unknown): boolean => {
+      const message = error instanceof Error ? error.message : String(error);
+      return /matched nothing in the accessibility tree|was not found on screen after scrolling|Accessibility element not found for selector/.test(
+        message,
+      );
+    };
+
+    const tapElement = async (
+      selector: AccessibilitySelector,
+      options?: TapElementOptions,
+    ): Promise<TapElementResult> => {
+      if (!options?.scrollSearch) {
+        return tapElementOnce(selector, options);
+      }
+      // Client-side scroll search: page down, then back up past the start,
+      // retrying per page. Each attempt costs one server tree read; the
+      // budget and cancellation live here, not on the server. timeoutMs is
+      // the TOTAL budget for the search; each attempt gets what remains.
+      // Mirrors the server's in-tree scroll-into-view paging scheme
+      // (limsimulator+interaction.swift scrollScanForMatch: 3 down/6 up,
+      // 0.6 page, 0.85/0.15 drag start); tune both together.
+      if (!cachedDeviceInfo) {
+        throw new Error('Device info not available yet; wait for client connection to be established.');
+      }
+      const deadline = Date.now() + (options.timeoutMs ?? TAP_ELEMENT_TIMEOUT_MS);
+      const attempt = () =>
+        tapElementOnce(selector, { ...options, timeoutMs: Math.max(1, deadline - Date.now()) });
+      let lastError: unknown;
+      try {
+        return await attempt();
+      } catch (error) {
+        if (!isAbsentSelectorError(error)) throw error;
+        lastError = error;
+      }
+      // No coordinate: deviceInfo reports portrait dimensions only, so an
+      // anchored drag lands in the wrong place in landscape. The server
+      // starts center-screen in rotated space, which halves the effective
+      // page but stays correct in every orientation.
+      const pagePixels = Math.round(cachedDeviceInfo.screenHeight * 0.6);
+      for (const [direction, count] of [
+        ['down', 3],
+        ['up', 6],
+      ] as const) {
+        for (let page = 0; page < count; page += 1) {
+          if (Date.now() >= deadline) break;
+          await scroll(direction, pagePixels);
+          // Let lazily-materializing cells appear before re-reading.
+          await sleep(300);
+          try {
+            return await attempt();
+          } catch (error) {
+            if (!isAbsentSelectorError(error)) throw error;
+            lastError = error;
+          }
+        }
+      }
+      const message = lastError instanceof Error ? lastError.message : String(lastError);
+      throw new Error(`${message} (after client-side scroll search)`);
     };
 
     const incrementElement = (selector: AccessibilitySelector): Promise<ElementResult> => {
@@ -2087,8 +2171,10 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       });
     };
 
-    const typeText = (text: string, pressEnter?: boolean): Promise<void> => {
-      return sendRequest<void>('typeText', { text, pressEnter });
+    const typeText = (text: string, pressEnter?: boolean, options?: TypeTextOptions): Promise<void> => {
+      // Sent only when false so legacy payloads stay byte-identical.
+      const requireFocus = options?.requireFocus === false ? false : undefined;
+      return sendRequest<void>('typeText', { text, pressEnter, requireFocus });
     };
 
     const pressKey = (key: string, modifiers?: string[]): Promise<void> => {

--- a/tests/ios-input.test.ts
+++ b/tests/ios-input.test.ts
@@ -1,4 +1,7 @@
 const sentMessages: Record<string, unknown>[] = [];
+// When > 0, tapElement replies with the server's fail-fast "matched nothing"
+// error and decrements; the client-side scroll search retries against this.
+let tapElementMissesRemaining = 0;
 
 jest.mock('ws', () => {
   const { EventEmitter } = require('events');
@@ -52,17 +55,28 @@ jest.mock('ws', () => {
           this['emit']('message', Buffer.from(JSON.stringify({ type: 'typeTextResult', id: message.id })));
         });
       } else if (message.type === 'tapElement') {
+        const miss = tapElementMissesRemaining > 0;
+        if (miss) tapElementMissesRemaining -= 1;
         process.nextTick(() => {
           this['emit'](
             'message',
             Buffer.from(
-              JSON.stringify({
-                type: 'tapElementResult',
-                id: message.id,
-                elementLabel: 'Submit',
-                elementType: 'Button',
-                method: message.activate ?? 'touch',
-              }),
+              JSON.stringify(
+                miss ?
+                  {
+                    type: 'tapElementResult',
+                    id: message.id,
+                    error:
+                      'Element for selector matched nothing in the accessibility tree. Fix the selector...',
+                  }
+                : {
+                    type: 'tapElementResult',
+                    id: message.id,
+                    elementLabel: 'Submit',
+                    elementType: 'Button',
+                    method: message.activate ?? 'touch',
+                  },
+              ),
             ),
           );
         });
@@ -98,6 +112,7 @@ async function connect() {
 describe('iOS input serialization', () => {
   beforeEach(() => {
     sentMessages.length = 0;
+    tapElementMissesRemaining = 0;
   });
 
   it('serializes typeText with its original payload shape', async () => {
@@ -108,6 +123,21 @@ describe('iOS input serialization', () => {
     expect(sent).toMatchObject({ type: 'typeText', text: 'hello', pressEnter: true });
     expect(sent).not.toHaveProperty('strategy');
     expect(sent).not.toHaveProperty('requireFocus');
+
+    client.disconnect();
+  });
+
+  it('sends requireFocus only when explicitly false', async () => {
+    const client = await connect();
+
+    await client.typeText('hello', false, { requireFocus: false });
+    expect(sentMessages.find((message) => message['type'] === 'typeText')).toMatchObject({
+      requireFocus: false,
+    });
+
+    sentMessages.length = 0;
+    await client.typeText('hello', false, { requireFocus: true });
+    expect(sentMessages.find((message) => message['type'] === 'typeText')).not.toHaveProperty('requireFocus');
 
     client.disconnect();
   });
@@ -143,6 +173,62 @@ describe('iOS input serialization', () => {
       activate: 'ax',
     });
     expect(ax.method).toBe('ax');
+
+    client.disconnect();
+  });
+
+  it('rejects an absent selector immediately without scrollSearch', async () => {
+    const client = await connect();
+    tapElementMissesRemaining = 99;
+
+    await expect(client.tapElement({ AXLabel: 'Ghost' })).rejects.toThrow(/matched nothing/);
+    expect(sentMessages.filter((message) => message['type'] === 'scroll')).toHaveLength(0);
+
+    client.disconnect();
+  });
+
+  it('scroll-searches an absent selector client-side until it materializes', async () => {
+    const client = await connect();
+    // First attempt + two paged attempts miss; the third page hits.
+    tapElementMissesRemaining = 3;
+
+    const result = await client.tapElement({ AXLabel: 'Row 900' }, { scrollSearch: true });
+    expect(result.elementLabel).toBe('Submit');
+
+    const scrolls = sentMessages.filter((message) => message['type'] === 'scroll');
+    const attempts = sentMessages.filter((message) => message['type'] === 'tapElement');
+    expect(scrolls).toHaveLength(3);
+    expect(attempts).toHaveLength(4);
+    // Page size derives from the device info the client caches on connect.
+    expect(scrolls[0]).toMatchObject({ direction: 'down', pixels: Math.round(844 * 0.6) });
+
+    client.disconnect();
+  });
+
+  it('gives up scroll search after the page budget and says so', async () => {
+    const client = await connect();
+    tapElementMissesRemaining = 99;
+
+    await expect(client.tapElement({ AXLabel: 'Ghost' }, { scrollSearch: true })).rejects.toThrow(
+      /after client-side scroll search/,
+    );
+    // 3 pages down, 6 back up; one attempt before paging plus one per page.
+    expect(sentMessages.filter((message) => message['type'] === 'scroll')).toHaveLength(9);
+    expect(sentMessages.filter((message) => message['type'] === 'tapElement')).toHaveLength(10);
+
+    client.disconnect();
+  }, 15_000);
+
+  it('stops scroll search when the total timeoutMs budget runs out', async () => {
+    const client = await connect();
+    tapElementMissesRemaining = 99;
+
+    // The budget covers the first attempt plus roughly one 300ms page; the
+    // remaining pages must be skipped instead of running the full sweep.
+    await expect(
+      client.tapElement({ AXLabel: 'Ghost' }, { scrollSearch: true, timeoutMs: 400 }),
+    ).rejects.toThrow(/after client-side scroll search/);
+    expect(sentMessages.filter((message) => message['type'] === 'scroll').length).toBeLessThan(5);
 
     client.disconnect();
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core iOS automation paths (element tap retries with many scrolls/timeouts and typing without focus checks), which can cause longer runs or typing into the wrong field if misused; behavior is opt-in and default paths stay the same.
> 
> **Overview**
> **`tapElement`** can opt into **client-side scroll search** (`scrollSearch` / CLI `--scroll-search`) when a selector misses because the node is not in the accessibility tree yet (e.g. virtualized lists). The SDK pages the screen (3 scrolls down, 6 up, ~60% of screen height per page, 300ms settle), retries `tapElement` on each page, and honors **`timeoutMs` as one total budget** for the whole search. Without the flag, absent selectors still fail fast with no scrolls.
> 
> **`typeText`** accepts **`requireFocus: false`** (CLI `--no-require-focus`) so the server skips the focused-field check and types anyway; the wire payload only includes `requireFocus` when it is `false` to keep default requests unchanged. Session daemon IPC forwards the new typing options argument.
> 
> Dead `if (false)` guards were removed from the iOS tap-element and type commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5293cdf4864ee87086da012442bf7faadf9b3fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->