### PR TITLE
cli: deprecate --region, point to --jurisdiction

### DIFF
--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -15,7 +15,7 @@ export default class AndroidCreate extends BaseCommand {
   static examples = [
     '<%= config.bin %> android create',
     '<%= config.bin %> android create --rm --install ./app.apk',
-    '<%= config.bin %> android create --region us-west --label env=dev',
+    '<%= config.bin %> android create --jurisdiction us --label env=dev',
     '<%= config.bin %> android create --no-connect',
     '<%= config.bin %> android create --daemon=false',
   ];
@@ -43,7 +43,10 @@ export default class AndroidCreate extends BaseCommand {
     'display-name': Flags.string({
       description: 'Human-friendly display name shown in listings and the console',
     }),
-    region: Flags.string({ description: 'Region where the instance should be created, such as us-west' }),
+    region: Flags.string({
+      description:
+        'Deprecated: a region is only a preference and may fall back to other regions when full. Use --jurisdiction to constrain where the instance runs.',
+    }),
     jurisdiction: Flags.string({
       description:
         'Jurisdiction the instance must be created in. Unlike --region, this is a hard constraint: creation fails when no region in the jurisdiction has capacity.',
@@ -84,6 +87,11 @@ export default class AndroidCreate extends BaseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(AndroidCreate);
+    if (flags.region) {
+      this.warn(
+        '--region is deprecated and only a preference; use --jurisdiction to constrain where it runs.',
+      );
+    }
     this.setParsedFlags(flags);
 
     await this.withAuth(async () => {

--- a/packages/cli/src/commands/gradle/create.ts
+++ b/packages/cli/src/commands/gradle/create.ts
@@ -10,7 +10,7 @@ export default class GradleCreate extends BaseCommand {
 
   static examples = [
     '<%= config.bin %> gradle create',
-    '<%= config.bin %> gradle create --region eu',
+    '<%= config.bin %> gradle create --jurisdiction eu',
     '<%= config.bin %> gradle create --label env=dev --display-name ci-builder',
   ];
 
@@ -19,7 +19,10 @@ export default class GradleCreate extends BaseCommand {
     'display-name': Flags.string({
       description: 'Human-friendly display name shown in listings and the console',
     }),
-    region: Flags.string({ description: 'Region where the sandbox should be created, such as us-west' }),
+    region: Flags.string({
+      description:
+        'Deprecated: a region is only a preference and may fall back to other regions when full. Use --jurisdiction to constrain where the sandbox runs.',
+    }),
     jurisdiction: Flags.string({
       description:
         'Jurisdiction the sandbox must be created in. Unlike --region, this is a hard constraint: creation fails when no region in the jurisdiction has capacity.',
@@ -41,6 +44,11 @@ export default class GradleCreate extends BaseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(GradleCreate);
+    if (flags.region) {
+      this.warn(
+        '--region is deprecated and only a preference; use --jurisdiction to constrain where it runs.',
+      );
+    }
     this.setParsedFlags(flags);
 
     await this.withAuth(async () => {

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -19,7 +19,7 @@ export default class IosCreate extends BaseCommand {
   static examples = [
     '<%= config.bin %> ios create',
     '<%= config.bin %> ios create --rm --model ipad',
-    '<%= config.bin %> ios create --region us-west --install-asset my-app.ipa',
+    '<%= config.bin %> ios create --jurisdiction us --install-asset my-app.ipa',
     '<%= config.bin %> ios create --keychain keychain/login.tar.gz --encryption-key-stdin < keychain.key',
     '<%= config.bin %> ios create --keychain-url https://example.t3.storage.dev/... --encryption-key <key>',
     '<%= config.bin %> ios create --install ./MyApp.ipa',
@@ -43,7 +43,10 @@ export default class IosCreate extends BaseCommand {
     'display-name': Flags.string({
       description: 'Human-friendly display name shown in listings and the console',
     }),
-    region: Flags.string({ description: 'Region where the instance should be created, such as us-west' }),
+    region: Flags.string({
+      description:
+        'Deprecated: a region is only a preference and may fall back to other regions when full. Use --jurisdiction to constrain where the instance runs.',
+    }),
     jurisdiction: Flags.string({
       description:
         'Jurisdiction the instance must be created in. Unlike --region, this is a hard constraint: creation fails when no region in the jurisdiction has capacity.',
@@ -115,6 +118,11 @@ export default class IosCreate extends BaseCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(IosCreate);
+    if (flags.region) {
+      this.warn(
+        '--region is deprecated and only a preference; use --jurisdiction to constrain where it runs.',
+      );
+    }
     this.setParsedFlags(flags);
     if (flags.attach && flags.xcode) {
       this.error('Use either --attach or --xcode, not both.');

--- a/packages/cli/src/commands/xcode/create.ts
+++ b/packages/cli/src/commands/xcode/create.ts
@@ -18,7 +18,7 @@ export default class XcodeCreate extends BaseCommand {
     '<%= config.bin %> xcode create',
     '<%= config.bin %> xcode create --ios',
     '<%= config.bin %> xcode create --attach --simulator-id <ios-instance-ID>',
-    '<%= config.bin %> xcode create --rm --region us-west',
+    '<%= config.bin %> xcode create --rm --jurisdiction us',
     '<%= config.bin %> xcode create --label env=dev --display-name ci-builder',
     '<%= config.bin %> xcode create --cache-restore-keys "myapp-features,myapp-main"',
     '<%= config.bin %> xcode create --cache-key myapp-pr51 --cache-paths "Pods,.build"',
@@ -33,7 +33,10 @@ export default class XcodeCreate extends BaseCommand {
     'display-name': Flags.string({
       description: 'Human-friendly display name shown in listings and the console',
     }),
-    region: Flags.string({ description: 'Region where the sandbox should be created, such as us-west' }),
+    region: Flags.string({
+      description:
+        'Deprecated: a region is only a preference and may fall back to other regions when full. Use --jurisdiction to constrain where the sandbox runs.',
+    }),
     jurisdiction: Flags.string({
       description:
         'Jurisdiction the sandbox must be created in. Unlike --region, this is a hard constraint: creation fails when no region in the jurisdiction has capacity.',
@@ -68,6 +71,11 @@ export default class XcodeCreate extends BaseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(XcodeCreate);
+    if (flags.region) {
+      this.warn(
+        '--region is deprecated and only a preference; use --jurisdiction to constrain where it runs.',
+      );
+    }
     this.setParsedFlags(flags);
     if (flags.attach && flags.ios) {
       this.error('Use either --attach or --ios, not both.');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI-only deprecation messaging and help/examples; create API payloads and placement logic are unchanged, so risk is limited to user confusion if they ignore the warning.
> 
> **Overview**
> **Deprecates `--region` on instance create commands** (`android`, `ios`, `xcode`, `gradle`) in favor of **`--jurisdiction`**, without removing `--region` or changing how create requests are built.
> 
> The **`--region` help text** now states it is deprecated, that it is only a **preference** (with possible fallback when regions are full), and that **`--jurisdiction`** is the hard constraint (`us` / `eu` / `as`). **Examples** are updated to show `--jurisdiction` instead of values like `--region us-west`.
> 
> When users still pass **`--region`**, the CLI emits a **warning** to use `--jurisdiction` instead. **`--jurisdiction`** behavior and existing mapping of both flags into create `spec` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4042b384961d0411d2f88093cd0bffc29cfae5b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->