### PR TITLE
cli: release 0.28.0 (--scroll-search, --no-require-focus)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.46.11",
+    "@limrun/api": "^0.46.12",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@^0.46.11":
-  version "0.46.11"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.11.tgz#b421f9a2084e1f455a5e6d855ea91f860b4d9f2b"
-  integrity sha512-vSXSOnTTNsQQtbWB3T04KE2x7B6H1OlBjkO2rF8K/cSMUqYPT3x8UgcI1Kl4X9uBJgfVWT7BJBA0EWedpAxIUQ==
+"@limrun/api@^0.46.12":
+  version "0.46.12"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.46.12.tgz#de7e92f6811fe6a99e0b52cf1985ac890ebe0d68"
+  integrity sha512-V0hS8v63HkpmlFY+8eTivggnv1HaKXbVmFCN9G73SlsejcX69Wolzwccavs3+ljFKK7yY4JJz6cKnnuDSwKCQQ==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency and version metadata only; no application logic changes in the diff.
> 
> **Overview**
> **Release-only version bump** for the published `lim` package: **0.27.2 → 0.28.0**, with `@limrun/api` updated from **^0.46.11** to **^0.46.12** and the lockfile refreshed accordingly.
> 
> There are **no CLI source changes** in this diff; the release title documents user-facing iOS automation options delivered via the new API version—**`--scroll-search`** on `ios tap-element` (client-side paging for virtualized lists) and **`--no-require-focus`** on `ios type` (typing without requiring an accessibility focus scan).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2093a722df724b0d6356d350dd2a1eba185ee656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->