### PR TITLE
cli: add set-instance and LIM_*_INSTANCE_URL/TOKEN for API-key-less instance control

### DIFF
--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -20,6 +20,7 @@ import {
 } from './lib/config';
 import { login } from './lib/auth';
 import { getScopeKey, isGlobalScopeKey, setScopeOverride } from './lib/scope';
+import { envInstanceTarget } from './lib/set-instance';
 import { renderTable } from './lib/formatting';
 import { stopDaemon } from './lib/daemon';
 import { detectInstanceType } from './lib/instance-client-factory';
@@ -95,11 +96,12 @@ export abstract class BaseCommand extends Command {
       const apiKey = flags?.['api-key'] || config.apiKey;
       const baseURL = config.apiEndpoint;
 
-      if (!apiKey) {
-        this.error('Not authenticated. Run `lim login` first, or provide --api-key.');
-      }
-
-      this._client = new Limrun({ apiKey: apiKey as string, baseURL });
+      // Without a key, still hand out a client: instance-credential paths
+      // (createClient with an instance apiUrl + token) never send the
+      // management key, so set-instance and env-pinned targets work keyless.
+      // An actual management call gets a 401 and flows into the existing
+      // AuthenticationError handling, same as an expired key.
+      this._client = new Limrun({ apiKey: (apiKey as string) || 'unauthenticated', baseURL });
     }
     return this._client;
   }
@@ -152,7 +154,7 @@ export abstract class BaseCommand extends Command {
   }
 
   /** ` in this workspace (<key>)`, or empty when resolved to the shared global slot. */
-  private scopeSuffix(): string {
+  protected scopeSuffix(): string {
     const key = getScopeKey();
     return isGlobalScopeKey(key) ? '' : ` in this workspace (${key})`;
   }
@@ -349,6 +351,12 @@ export abstract class BaseCommand extends Command {
       return instance;
     }
 
+    const envTarget = envInstanceTarget('android');
+    if (envTarget) {
+      this._lastResolvedInstanceId = envTarget.id;
+      return envTarget;
+    }
+
     const instance = loadLastAndroidInstance();
     if (instance) {
       this._lastResolvedInstanceId = instance.id;
@@ -368,6 +376,12 @@ export abstract class BaseCommand extends Command {
       const instance = this.iosInstanceFromId(id);
       this._lastResolvedInstanceId = instance.id;
       return instance;
+    }
+
+    const envTarget = envInstanceTarget('ios');
+    if (envTarget) {
+      this._lastResolvedInstanceId = envTarget.id;
+      return envTarget;
     }
 
     const instance = loadLastIosInstance();
@@ -394,6 +408,20 @@ export abstract class BaseCommand extends Command {
       throw new Error(
         'Sessions are for device interaction. Xcode and gradle instances use sync/build instead.',
       );
+    }
+
+    const envIos = envInstanceTarget('ios');
+    if (envIos) {
+      this._lastResolvedExpectedType = 'ios';
+      this._lastResolvedInstanceId = envIos.id;
+      return envIos;
+    }
+
+    const envAndroid = envInstanceTarget('android');
+    if (envAndroid) {
+      this._lastResolvedExpectedType = 'android';
+      this._lastResolvedInstanceId = envAndroid.id;
+      return envAndroid;
     }
 
     const ios = loadLastIosInstance();
@@ -429,6 +457,12 @@ export abstract class BaseCommand extends Command {
       return target;
     }
 
+    const envTarget = envInstanceTarget('xcode');
+    if (envTarget) {
+      this._lastResolvedInstanceId = envTarget.id;
+      return envTarget;
+    }
+
     const target = loadLastXcodeInstance();
     if (target) {
       this._lastResolvedInstanceId = target.id;
@@ -450,6 +484,14 @@ export abstract class BaseCommand extends Command {
       const target = this.xcodeTargetFromId(id);
       this._lastResolvedInstanceId = target.id;
       return target;
+    }
+
+    // An env-pinned target is as explicit as --id: it wins over the cached
+    // last-instance and is never bypassed for a fresh auto-created one.
+    const envTarget = envInstanceTarget('xcode');
+    if (envTarget) {
+      this._lastResolvedInstanceId = envTarget.id;
+      return envTarget;
     }
 
     const target = loadLastXcodeInstance();
@@ -489,6 +531,19 @@ export abstract class BaseCommand extends Command {
       }
       this._lastResolvedInstanceId = target.id;
       return target;
+    }
+
+    // An env-pinned target is as explicit as --id, so it gets the same
+    // attached-simulator requirement instead of a silent fallback.
+    const envTarget = envInstanceTarget('xcode');
+    if (envTarget) {
+      if (!(await this.xcodeTargetHasAttachedSimulator(envTarget, false))) {
+        throw new Error(
+          `--ios requires an Xcode instance with an attached simulator, but the one pinned by LIM_XCODE_INSTANCE_URL (${envTarget.id}) has none. Attach one with: lim xcode attach-simulator`,
+        );
+      }
+      this._lastResolvedInstanceId = envTarget.id;
+      return envTarget;
     }
 
     const target = loadLastXcodeInstance();
@@ -936,6 +991,11 @@ export abstract class BaseCommand extends Command {
       const target = this.gradleTargetFromId(id);
       this._lastResolvedInstanceId = target.id;
       return target;
+    }
+    const envTarget = envInstanceTarget('gradle');
+    if (envTarget) {
+      this._lastResolvedInstanceId = envTarget.id;
+      return envTarget;
     }
     const target = loadLastGradleInstance();
     if (target) {

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -487,9 +487,15 @@ export abstract class BaseCommand extends Command {
     }
 
     // An env-pinned target is as explicit as --id: it wins over the cached
-    // last-instance and is never bypassed for a fresh auto-created one.
+    // last-instance, is never bypassed for a fresh auto-created one, and
+    // rejects creation-time settings the same way --id does.
     const envTarget = envInstanceTarget('xcode');
     if (envTarget) {
+      if (this.autoCreateInactivityTimeout()) {
+        throw new Error(
+          '--inactivity-timeout controls a newly created instance and cannot be combined with an instance pinned by LIM_XCODE_INSTANCE_URL.',
+        );
+      }
       this._lastResolvedInstanceId = envTarget.id;
       return envTarget;
     }
@@ -534,9 +540,15 @@ export abstract class BaseCommand extends Command {
     }
 
     // An env-pinned target is as explicit as --id, so it gets the same
-    // attached-simulator requirement instead of a silent fallback.
+    // attached-simulator requirement instead of a silent fallback, and
+    // rejects creation-time settings the same way --id does.
     const envTarget = envInstanceTarget('xcode');
     if (envTarget) {
+      if (this.autoCreateInactivityTimeout()) {
+        throw new Error(
+          '--inactivity-timeout controls a newly created instance and cannot be combined with an instance pinned by LIM_XCODE_INSTANCE_URL.',
+        );
+      }
       if (!(await this.xcodeTargetHasAttachedSimulator(envTarget, false))) {
         throw new Error(
           `--ios requires an Xcode instance with an attached simulator, but the one pinned by LIM_XCODE_INSTANCE_URL (${envTarget.id}) has none. Attach one with: lim xcode attach-simulator`,
@@ -992,8 +1004,16 @@ export abstract class BaseCommand extends Command {
       this._lastResolvedInstanceId = target.id;
       return target;
     }
+    // An env-pinned target is as explicit as --id: creation-time settings
+    // cannot apply to it, so they error instead of silently auto-creating a
+    // fresh billed instance while the pin is ignored.
     const envTarget = envInstanceTarget('gradle');
     if (envTarget) {
+      if (this.autoCreateInactivityTimeout()) {
+        throw new Error(
+          '--inactivity-timeout controls a newly created instance and cannot be combined with an instance pinned by LIM_GRADLE_INSTANCE_URL.',
+        );
+      }
       this._lastResolvedInstanceId = envTarget.id;
       return envTarget;
     }

--- a/packages/cli/src/commands/android/set-instance.ts
+++ b/packages/cli/src/commands/android/set-instance.ts
@@ -1,0 +1,56 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { setLastInstance } from '../../lib/config';
+import { buildManualInstanceRecord } from '../../lib/set-instance';
+
+export default class AndroidSetInstance extends BaseCommand {
+  static summary = 'Set the Android instance targeted by subsequent commands';
+  static description =
+    'Pin an existing Android instance as the target of subsequent `lim android` commands using only its API URL and token — no LIM_API_KEY needed. ' +
+    'Made for handing a single instance to a sandboxed agent: the creator passes the URL and token from `lim android create --json` (status.apiUrl and status.token). ' +
+    'Pass --adb-websocket-url (status.adbWebSocketUrl) as well if the agent should run `lim android connect`. ' +
+    'To target the instance without persisting anything, export LIM_ANDROID_INSTANCE_URL and LIM_ANDROID_INSTANCE_TOKEN instead; commands pick them up directly.';
+  static examples = [
+    '<%= config.bin %> android set-instance --api-url https://eu-north1.limrun.com/v1/android_.../api --token lim_st_...',
+    '<%= config.bin %> android set-instance --api-url https://.../api --token lim_st_... --adb-websocket-url wss://...',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'api-url': Flags.string({
+      description: "The instance's API URL (status.apiUrl). Can also be set via LIM_ANDROID_INSTANCE_URL.",
+      env: 'LIM_ANDROID_INSTANCE_URL',
+      required: true,
+    }),
+    token: Flags.string({
+      description: "The instance's token (status.token). Can also be set via LIM_ANDROID_INSTANCE_TOKEN.",
+      env: 'LIM_ANDROID_INSTANCE_TOKEN',
+      required: true,
+    }),
+    'adb-websocket-url': Flags.string({
+      description:
+        "The instance's ADB WebSocket URL (status.adbWebSocketUrl), needed only for `lim android connect`. Can also be set via LIM_ANDROID_INSTANCE_ADB_URL.",
+      env: 'LIM_ANDROID_INSTANCE_ADB_URL',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(AndroidSetInstance);
+    this.setParsedFlags(flags);
+
+    const record = buildManualInstanceRecord({
+      type: 'android',
+      apiUrl: flags['api-url'],
+      token: flags.token,
+      ...(flags['adb-websocket-url'] ? { adbWebSocketUrl: flags['adb-websocket-url'] } : {}),
+    });
+    setLastInstance(record);
+
+    if (flags.json) {
+      this.outputJson({ id: record.id, type: record.type, apiUrl: record.apiUrl });
+      return;
+    }
+    this.output(`Set ${record.id} as the target Android instance${this.scopeSuffix()}.`);
+    this.info('Subsequent `lim android` commands will use it without an API key.');
+  }
+}

--- a/packages/cli/src/commands/gradle/set-instance.ts
+++ b/packages/cli/src/commands/gradle/set-instance.ts
@@ -1,0 +1,49 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { setLastInstance } from '../../lib/config';
+import { buildManualInstanceRecord } from '../../lib/set-instance';
+
+export default class GradleSetInstance extends BaseCommand {
+  static summary = 'Set the gradle instance targeted by subsequent commands';
+  static description =
+    'Pin an existing gradle instance as the target of subsequent `lim gradle` commands using only its API URL and token — no LIM_API_KEY needed. ' +
+    'Made for handing a single instance to a sandboxed agent: the creator passes the URL and token from `lim gradle create --json` (status.apiUrl and status.token). ' +
+    'To target the instance without persisting anything, export LIM_GRADLE_INSTANCE_URL and LIM_GRADLE_INSTANCE_TOKEN instead; commands pick them up directly.';
+  static examples = [
+    '<%= config.bin %> gradle set-instance --api-url https://eu-north1.limrun.com/v1/gradle_.../api --token lim_st_...',
+    'LIM_GRADLE_INSTANCE_TOKEN=lim_st_... <%= config.bin %> gradle set-instance --api-url https://.../api',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'api-url': Flags.string({
+      description: "The instance's API URL (status.apiUrl). Can also be set via LIM_GRADLE_INSTANCE_URL.",
+      env: 'LIM_GRADLE_INSTANCE_URL',
+      required: true,
+    }),
+    token: Flags.string({
+      description: "The instance's token (status.token). Can also be set via LIM_GRADLE_INSTANCE_TOKEN.",
+      env: 'LIM_GRADLE_INSTANCE_TOKEN',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(GradleSetInstance);
+    this.setParsedFlags(flags);
+
+    const record = buildManualInstanceRecord({
+      type: 'gradle',
+      apiUrl: flags['api-url'],
+      token: flags.token,
+    });
+    setLastInstance(record);
+
+    if (flags.json) {
+      this.outputJson({ id: record.id, type: record.type, apiUrl: record.apiUrl });
+      return;
+    }
+    this.output(`Set ${record.id} as the target gradle instance${this.scopeSuffix()}.`);
+    this.info('Subsequent `lim gradle` commands will use it without an API key.');
+  }
+}

--- a/packages/cli/src/commands/ios/set-instance.ts
+++ b/packages/cli/src/commands/ios/set-instance.ts
@@ -1,0 +1,49 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { setLastInstance } from '../../lib/config';
+import { buildManualInstanceRecord } from '../../lib/set-instance';
+
+export default class IosSetInstance extends BaseCommand {
+  static summary = 'Set the iOS instance targeted by subsequent commands';
+  static description =
+    'Pin an existing iOS instance as the target of subsequent `lim ios` commands using only its API URL and token — no LIM_API_KEY needed. ' +
+    'Made for handing a single instance to a sandboxed agent: the creator passes the URL and token from `lim ios create --json` (status.apiUrl and status.token). ' +
+    'To target the instance without persisting anything, export LIM_IOS_INSTANCE_URL and LIM_IOS_INSTANCE_TOKEN instead; commands pick them up directly.';
+  static examples = [
+    '<%= config.bin %> ios set-instance --api-url https://eu-north1.limrun.com/v1/ios_.../api --token lim_st_...',
+    'LIM_IOS_INSTANCE_TOKEN=lim_st_... <%= config.bin %> ios set-instance --api-url https://.../api',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'api-url': Flags.string({
+      description: "The instance's API URL (status.apiUrl). Can also be set via LIM_IOS_INSTANCE_URL.",
+      env: 'LIM_IOS_INSTANCE_URL',
+      required: true,
+    }),
+    token: Flags.string({
+      description: "The instance's token (status.token). Can also be set via LIM_IOS_INSTANCE_TOKEN.",
+      env: 'LIM_IOS_INSTANCE_TOKEN',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(IosSetInstance);
+    this.setParsedFlags(flags);
+
+    const record = buildManualInstanceRecord({
+      type: 'ios',
+      apiUrl: flags['api-url'],
+      token: flags.token,
+    });
+    setLastInstance(record);
+
+    if (flags.json) {
+      this.outputJson({ id: record.id, type: record.type, apiUrl: record.apiUrl });
+      return;
+    }
+    this.output(`Set ${record.id} as the target iOS instance${this.scopeSuffix()}.`);
+    this.info('Subsequent `lim ios` commands will use it without an API key.');
+  }
+}

--- a/packages/cli/src/commands/xcode/set-instance.ts
+++ b/packages/cli/src/commands/xcode/set-instance.ts
@@ -1,0 +1,50 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { setLastInstance } from '../../lib/config';
+import { buildManualInstanceRecord } from '../../lib/set-instance';
+
+export default class XcodeSetInstance extends BaseCommand {
+  static summary = 'Set the Xcode instance targeted by subsequent commands';
+  static description =
+    'Pin an existing Xcode instance as the target of subsequent `lim xcode` commands using only its API URL and token — no LIM_API_KEY needed. ' +
+    'Works with a standalone Xcode instance (status.apiUrl and status.token from `lim xcode create --json`) or with the Xcode sandbox of an iOS instance (status.sandbox.xcode.url and status.token from `lim ios create --xcode --json`). ' +
+    'To target the instance without persisting anything, export LIM_XCODE_INSTANCE_URL and LIM_XCODE_INSTANCE_TOKEN instead; commands pick them up directly.';
+  static examples = [
+    '<%= config.bin %> xcode set-instance --api-url https://eu-north1.limrun.com/v1/xcode_.../api --token lim_st_...',
+    '<%= config.bin %> xcode set-instance --api-url https://.../v1/sandbox_.../api --token lim_st_...',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    'api-url': Flags.string({
+      description:
+        "The instance's API URL (status.apiUrl, or status.sandbox.xcode.url of an iOS instance). Can also be set via LIM_XCODE_INSTANCE_URL.",
+      env: 'LIM_XCODE_INSTANCE_URL',
+      required: true,
+    }),
+    token: Flags.string({
+      description: "The instance's token (status.token). Can also be set via LIM_XCODE_INSTANCE_TOKEN.",
+      env: 'LIM_XCODE_INSTANCE_TOKEN',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(XcodeSetInstance);
+    this.setParsedFlags(flags);
+
+    const record = buildManualInstanceRecord({
+      type: 'xcode',
+      apiUrl: flags['api-url'],
+      token: flags.token,
+    });
+    setLastInstance(record);
+
+    if (flags.json) {
+      this.outputJson({ id: record.id, type: record.type, apiUrl: record.apiUrl });
+      return;
+    }
+    this.output(`Set ${record.id} as the target Xcode instance${this.scopeSuffix()}.`);
+    this.info('Subsequent `lim xcode` commands will use it without an API key.');
+  }
+}

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -575,6 +575,29 @@ function saveLastInstance(
   return record;
 }
 
+/**
+ * Persist a caller-built record as the last-used instance of its type in the
+ * current workspace scope. Used by set-instance, where the record comes from
+ * user-supplied credentials instead of an API instance object.
+ */
+export function setLastInstance(
+  record: LastAndroidInstance | LastIosInstance | LastXcodeInstance | LastGradleInstance,
+): void {
+  mutate((file, scopeKey) => {
+    const scope = ensureScope(file, scopeKey);
+    if (record.type === 'android') {
+      scope.android = record;
+    } else if (record.type === 'ios') {
+      scope.ios = record;
+    } else if (record.type === 'gradle') {
+      scope.gradle = record;
+    } else {
+      scope.xcode = record;
+    }
+    scope.lastUsedAt = new Date().toISOString();
+  });
+}
+
 /** Returns the record it persisted, so callers don't rebuild the same shape. */
 export function registerCreatedInstance(
   instanceOrId: InstanceInput,

--- a/packages/cli/src/lib/set-instance.test.ts
+++ b/packages/cli/src/lib/set-instance.test.ts
@@ -1,0 +1,138 @@
+import {
+  buildManualInstanceRecord,
+  envInstanceTarget,
+  instanceIdFromToken,
+  syntheticInstanceId,
+} from './set-instance';
+
+function signedToken(scopes: unknown): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ iss: 'limrun', sub: 'org_01abc', scopes })).toString(
+    'base64url',
+  );
+  return `lim_st_${header}.${payload}.c2lnbmF0dXJl`;
+}
+
+const IOS_TID = 'ios_euna_01m02anjqredzr42pcn8s8jx90';
+const SANDBOX_TID = 'sandbox_euna_01m02anjqredzr42pcn8s8jx90';
+
+describe('instanceIdFromToken', () => {
+  it('extracts the instance id from a matching scope', () => {
+    expect(instanceIdFromToken(signedToken([`ios:${IOS_TID}:all`]), 'ios')).toBe(IOS_TID);
+  });
+
+  it('picks the scope whose resource matches the topic among several', () => {
+    const token = signedToken(['android:android_euna_01abc:all', `ios:${IOS_TID}:all`]);
+    expect(instanceIdFromToken(token, 'ios')).toBe(IOS_TID);
+    expect(instanceIdFromToken(token, 'android')).toBe('android_euna_01abc');
+  });
+
+  it('maps sandbox tids to the xcode topic', () => {
+    expect(instanceIdFromToken(signedToken([`xcode:${SANDBOX_TID}:all`]), 'xcode')).toBe(SANDBOX_TID);
+  });
+
+  it('yields nothing for wildcard scopes', () => {
+    expect(instanceIdFromToken(signedToken(['ios:*:all']), 'ios')).toBeUndefined();
+  });
+
+  it('yields nothing for legacy opaque tokens', () => {
+    expect(instanceIdFromToken('random-opaque-token', 'ios')).toBeUndefined();
+  });
+
+  it('yields nothing for a scope whose id prefix contradicts its resource', () => {
+    expect(instanceIdFromToken(signedToken([`ios:${SANDBOX_TID}:all`]), 'ios')).toBeUndefined();
+  });
+
+  it('survives malformed payloads', () => {
+    expect(instanceIdFromToken('lim_st_not.a.jwt', 'ios')).toBeUndefined();
+    expect(instanceIdFromToken(signedToken('not-an-array'), 'ios')).toBeUndefined();
+  });
+});
+
+describe('syntheticInstanceId', () => {
+  it('is deterministic per apiUrl and carries the type prefix', () => {
+    const a = syntheticInstanceId('ios', 'https://region.limrun.com/v1/x/api');
+    expect(a).toBe(syntheticInstanceId('ios', 'https://region.limrun.com/v1/x/api'));
+    expect(a).toMatch(/^ios_local_[0-9a-f]{12}$/);
+    expect(syntheticInstanceId('ios', 'https://other.limrun.com/v1/y/api')).not.toBe(a);
+  });
+});
+
+describe('buildManualInstanceRecord', () => {
+  it('uses the token id when the token names one', () => {
+    const record = buildManualInstanceRecord({
+      type: 'ios',
+      apiUrl: 'https://region.limrun.com/v1/x/api',
+      token: signedToken([`ios:${IOS_TID}:all`]),
+    });
+    expect(record).toEqual({
+      id: IOS_TID,
+      type: 'ios',
+      apiUrl: 'https://region.limrun.com/v1/x/api',
+      token: signedToken([`ios:${IOS_TID}:all`]),
+    });
+  });
+
+  it('falls back to a synthetic handle for legacy tokens', () => {
+    const record = buildManualInstanceRecord({
+      type: 'gradle',
+      apiUrl: 'https://region.limrun.com/v1/x/api',
+      token: 'opaque',
+    });
+    expect(record.id).toMatch(/^gradle_local_[0-9a-f]{12}$/);
+    expect(record.type).toBe('gradle');
+  });
+
+  it('keeps the ADB websocket URL on android records', () => {
+    const record = buildManualInstanceRecord({
+      type: 'android',
+      apiUrl: 'https://region.limrun.com/v1/x/api',
+      token: 'opaque',
+      adbWebSocketUrl: 'wss://region.limrun.com/adb',
+    });
+    expect(record).toMatchObject({ type: 'android', adbWebSocketUrl: 'wss://region.limrun.com/adb' });
+  });
+});
+
+describe('envInstanceTarget', () => {
+  const VARS = [
+    'LIM_IOS_INSTANCE_URL',
+    'LIM_IOS_INSTANCE_TOKEN',
+    'LIM_ANDROID_INSTANCE_URL',
+    'LIM_ANDROID_INSTANCE_TOKEN',
+    'LIM_ANDROID_INSTANCE_ADB_URL',
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const name of VARS) {
+      saved[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of VARS) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+  });
+
+  it('returns null unless both URL and token are set', () => {
+    expect(envInstanceTarget('ios')).toBeNull();
+    process.env['LIM_IOS_INSTANCE_URL'] = 'https://region.limrun.com/v1/x/api';
+    expect(envInstanceTarget('ios')).toBeNull();
+    process.env['LIM_IOS_INSTANCE_TOKEN'] = signedToken([`ios:${IOS_TID}:all`]);
+    expect(envInstanceTarget('ios')).toMatchObject({ id: IOS_TID, type: 'ios' });
+  });
+
+  it('includes the ADB URL for android when set', () => {
+    process.env['LIM_ANDROID_INSTANCE_URL'] = 'https://region.limrun.com/v1/x/api';
+    process.env['LIM_ANDROID_INSTANCE_TOKEN'] = 'opaque';
+    process.env['LIM_ANDROID_INSTANCE_ADB_URL'] = 'wss://region.limrun.com/adb';
+    expect(envInstanceTarget('android')).toMatchObject({
+      type: 'android',
+      adbWebSocketUrl: 'wss://region.limrun.com/adb',
+    });
+  });
+});

--- a/packages/cli/src/lib/set-instance.ts
+++ b/packages/cli/src/lib/set-instance.ts
@@ -1,0 +1,121 @@
+import crypto from 'crypto';
+import {
+  type LastAndroidInstance,
+  type LastGradleInstance,
+  type LastIosInstance,
+  type LastXcodeInstance,
+} from './config';
+import { type InstanceType } from './instance-client-factory';
+
+export type ManualInstanceRecord =
+  | LastAndroidInstance
+  | LastIosInstance
+  | LastXcodeInstance
+  | LastGradleInstance;
+
+const SIGNED_TOKEN_PREFIX = 'lim_st_';
+
+// TID prefixes an instance of each type can carry. Xcode instances appear
+// both standalone (xcode_) and as sandboxes nested in iOS instances (sandbox_).
+const ID_PREFIXES: Record<InstanceType, string[]> = {
+  ios: ['ios'],
+  android: ['android'],
+  xcode: ['xcode', 'sandbox'],
+  gradle: ['gradle'],
+};
+
+/**
+ * The instance id named by a signed token's scopes, if any. Signed tokens are
+ * JWTs whose payload carries scopes shaped <resource>:<instance-tid>:<action>,
+ * so the token itself tells which instance it opens. Decoded without
+ * verification: the id is local bookkeeping, the router does the real check.
+ * Legacy opaque tokens and wildcard scopes yield undefined.
+ */
+export function instanceIdFromToken(token: string, type: InstanceType): string | undefined {
+  if (!token.startsWith(SIGNED_TOKEN_PREFIX)) return undefined;
+  const parts = token.slice(SIGNED_TOKEN_PREFIX.length).split('.');
+  if (parts.length !== 3) return undefined;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (typeof payload !== 'object' || payload === null) return undefined;
+  const scopes = (payload as { scopes?: unknown }).scopes;
+  if (!Array.isArray(scopes)) return undefined;
+  for (const raw of scopes) {
+    if (typeof raw !== 'string') continue;
+    const segments = raw.split(':');
+    if (segments.length !== 3) continue;
+    const [resource, id] = segments;
+    if (resource !== type || !id || id === '*') continue;
+    if (ID_PREFIXES[type].some((prefix) => id.startsWith(`${prefix}_`))) return id;
+  }
+  return undefined;
+}
+
+/**
+ * A deterministic local handle for an instance whose token names no id (legacy
+ * opaque tokens, wildcard scopes). Hashing the apiUrl keeps re-runs idempotent:
+ * the same instance maps to the same record and daemon session. The type
+ * prefix keeps prefix-based dispatch (detectInstanceType) working.
+ */
+export function syntheticInstanceId(type: InstanceType, apiUrl: string): string {
+  const hash = crypto.createHash('sha1').update(apiUrl).digest('hex').slice(0, 12);
+  return `${type}_local_${hash}`;
+}
+
+export interface ManualInstanceInput {
+  type: InstanceType;
+  apiUrl: string;
+  token: string;
+  adbWebSocketUrl?: string;
+}
+
+/**
+ * A last-instance record built from just apiUrl + token, the minimum needed
+ * for direct instance control without a management API key.
+ */
+export function buildManualInstanceRecord(input: ManualInstanceInput): ManualInstanceRecord {
+  const id = instanceIdFromToken(input.token, input.type) ?? syntheticInstanceId(input.type, input.apiUrl);
+  switch (input.type) {
+    case 'android':
+      return {
+        id,
+        type: 'android',
+        apiUrl: input.apiUrl,
+        token: input.token,
+        ...(input.adbWebSocketUrl ? { adbWebSocketUrl: input.adbWebSocketUrl } : {}),
+      };
+    case 'ios':
+      return { id, type: 'ios', apiUrl: input.apiUrl, token: input.token };
+    case 'xcode':
+      return { id, type: 'xcode', apiUrl: input.apiUrl, token: input.token };
+    case 'gradle':
+      return { id, type: 'gradle', apiUrl: input.apiUrl, token: input.token };
+  }
+}
+
+function envVarName(type: InstanceType, suffix: 'URL' | 'TOKEN' | 'ADB_URL'): string {
+  return `LIM_${type.toUpperCase()}_INSTANCE_${suffix}`;
+}
+
+/**
+ * The ambient target pinned by LIM_<TYPE>_INSTANCE_URL + LIM_<TYPE>_INSTANCE_TOKEN,
+ * or null when either is missing. Built in memory and never persisted, so the
+ * environment fully defines the target per process — a parent hands a sandboxed
+ * agent two env vars and every command just works, no set-instance needed.
+ */
+export function envInstanceTarget(type: 'ios'): LastIosInstance | null;
+export function envInstanceTarget(type: 'android'): LastAndroidInstance | null;
+export function envInstanceTarget(type: 'xcode'): LastXcodeInstance | null;
+export function envInstanceTarget(type: 'gradle'): LastGradleInstance | null;
+export function envInstanceTarget(type: InstanceType): ManualInstanceRecord | null;
+export function envInstanceTarget(type: InstanceType): ManualInstanceRecord | null {
+  const apiUrl = process.env[envVarName(type, 'URL')]?.trim();
+  const token = process.env[envVarName(type, 'TOKEN')]?.trim();
+  if (!apiUrl || !token) return null;
+  const adbWebSocketUrl = type === 'android' ? process.env[envVarName(type, 'ADB_URL')]?.trim() : undefined;
+  return buildManualInstanceRecord({ type, apiUrl, token, ...(adbWebSocketUrl ? { adbWebSocketUrl } : {}) });
+}


### PR DESCRIPTION
## Summary
- New `lim {ios,android,xcode,gradle} set-instance --api-url <url> --token <token>` pins an existing instance as the workspace target using only its instance credentials — no `LIM_API_KEY`. Built for handing a single instance to a sandboxed agent: the creator passes `status.apiUrl` and `status.token` from `create --json`. Android optionally takes `--adb-websocket-url` for `lim android connect`.
- Ambient env targets: when `LIM_<TYPE>_INSTANCE_URL` + `LIM_<TYPE>_INSTANCE_TOKEN` are set (`IOS`, `ANDROID`, `XCODE`, `GRADLE`; plus `LIM_ANDROID_INSTANCE_ADB_URL`), every command targets that instance directly with nothing persisted. Precedence: explicit `--id` > env pair > cached last-instance.
- No instance id input anywhere: signed tokens (`lim_st_`) name the instance in their scopes (`<resource>:<tid>:<action>`), so the id is decoded from the token; legacy opaque tokens fall back to a deterministic local handle (`ios_local_<sha1(apiUrl)[:12]>`). No URL-path parsing, so the URL schema stays free to change.
- `BaseCommand.client` no longer errors without an API key; it hands out a sentinel-key client so instance-credential paths work keyless, while real management calls 401 into the existing `AuthenticationError` handling (login, self-heal, deletion unchanged).

## Test plan
- [x] 13 new jest tests for token-scope id extraction, synthetic-handle determinism, and env-pair resolution; full CLI suite 81/81 green
- [x] `./scripts/lint` (prettier, eslint, build, tsc, attw, publint) clean; CLI eslint clean
- [x] Live keyless verification against a real iOS instance in a scratch `HOME` with no `LIM_API_KEY`: env-pinned `ios tap`, `set-instance` + `ios screenshot` (token-derived real id shown), `session start` + fast-path tap through the daemon
- [x] Docs: limrun-inc/docs#29 documents set-instance and the env pairs; limrun-inc/docs#28 updates the connection row for the daemon default
- [ ] Follow-up per repo policy: update `limrun-inc/skills` for the new command and env vars

(The session daemon auto-start work originally described here shipped separately in #320.)

Made with [Cursor](https://cursor.com)


