### PR TITLE
cli: auto-start the session daemon and route the first command through it

### DIFF
--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -23,7 +23,7 @@ import { getScopeKey, isGlobalScopeKey, setScopeOverride } from './lib/scope';
 import { envInstanceTarget } from './lib/set-instance';
 import { renderTable } from './lib/formatting';
 import { stopDaemon } from './lib/daemon';
-import { detectInstanceType } from './lib/instance-client-factory';
+import { detectInstanceType, setSessionAutoStart } from './lib/instance-client-factory';
 import { deleteCreatedInstance } from './lib/instance-cleanup';
 import { defaultSleep as sleep } from '@limrun/api';
 import {
@@ -85,6 +85,13 @@ export abstract class BaseCommand extends Command {
         'Workspace used to resolve the most recent instance when no ID is given. Defaults to the current git repo/worktree (or a `lim set-workspace-dir` assignment), so parallel agents in separate worktrees stay isolated automatically. Can also be set via LIM_WORKSPACE.',
       env: 'LIM_WORKSPACE',
     }),
+    daemon: Flags.boolean({
+      description:
+        'Route device commands through a background WebSocket daemon, starting it on first use, so repeated commands reuse the connection (~50ms instead of a fresh handshake). Disable with --no-daemon or LIM_DAEMON=false.',
+      default: true,
+      allowNo: true,
+      env: 'LIM_DAEMON',
+    }),
   };
 
   private _client?: Limrun;
@@ -130,6 +137,10 @@ export abstract class BaseCommand extends Command {
     if (typeof workspace === 'string' && workspace.trim()) {
       setScopeOverride(workspace.trim());
     }
+    setSessionAutoStart({
+      enabled: flags['daemon'] !== false,
+      silent: Boolean(flags['json']) || Boolean(flags['quiet']),
+    });
     this.captureCommandIntent(flags);
   }
 

--- a/packages/cli/src/commands/android/element-tree.ts
+++ b/packages/cli/src/commands/android/element-tree.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -36,7 +36,7 @@ export default class AndroidElementTree extends BaseCommand {
         this.error('android element-tree only supports Android instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         const tree = await sendSessionCommand(id, 'element-tree');
         if (flags.json) {
           this.outputJson(tree);

--- a/packages/cli/src/commands/android/find-element.ts
+++ b/packages/cli/src/commands/android/find-element.ts
@@ -3,7 +3,7 @@ import { BaseCommand } from '../../base-command';
 import { androidSelectorFlags, buildAndroidSelector } from '../../lib/android-selector';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -63,7 +63,7 @@ export default class AndroidFindElement extends BaseCommand {
       }
 
       let result: FindElementResult;
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         result = (await sendSessionCommand(id, 'find-element', [selector, flags.limit])) as FindElementResult;
       } else {
         const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/android/install-app.ts
+++ b/packages/cli/src/commands/android/install-app.ts
@@ -4,7 +4,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -62,7 +62,7 @@ export default class AndroidInstallApp extends BaseCommand {
         downloadUrl = asset.signedDownloadUrl;
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'install-app', [downloadUrl]);
         this.log('App sent to instance');
         return;

--- a/packages/cli/src/commands/android/open-url.ts
+++ b/packages/cli/src/commands/android/open-url.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -40,7 +40,7 @@ export default class AndroidOpenUrl extends BaseCommand {
         this.error('android open-url only supports Android instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'open-url', [args.url]);
       } else {
         const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/android/press-key.ts
+++ b/packages/cli/src/commands/android/press-key.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -42,7 +42,7 @@ export default class AndroidPressKey extends BaseCommand {
         this.error('android press-key only supports Android instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'press-key', [args.key, flags.modifier]);
       } else {
         const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/android/record.ts
+++ b/packages/cli/src/commands/android/record.ts
@@ -3,7 +3,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -60,7 +60,7 @@ export default class AndroidRecord extends BaseCommand {
       }
 
       if (args.action === 'start') {
-        if (hasActiveSession(id)) {
+        if (await ensureDaemonSession(resolvedInstance)) {
           await sendSessionCommand(id, 'start-recording', [flags.quality]);
         } else {
           const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
@@ -80,7 +80,7 @@ export default class AndroidRecord extends BaseCommand {
         presignedUrl: flags['presigned-url'],
       };
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'stop-recording', [saveTo]);
         this.log(`Recording saved to ${outputPath}`);
         if (flags['presigned-url']) {

--- a/packages/cli/src/commands/android/screenshot.ts
+++ b/packages/cli/src/commands/android/screenshot.ts
@@ -4,7 +4,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -44,7 +44,7 @@ export default class AndroidScreenshot extends BaseCommand {
       }
 
       let screenshot: any;
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         screenshot = await sendSessionCommand(id, 'screenshot');
       } else {
         const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/android/scroll.ts
+++ b/packages/cli/src/commands/android/scroll.ts
@@ -3,7 +3,7 @@ import { BaseCommand } from '../../base-command';
 import { androidTargetFlags, buildAndroidTarget } from '../../lib/android-selector';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -51,7 +51,7 @@ export default class AndroidScroll extends BaseCommand {
 
       const target = buildAndroidTarget(flags);
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         if (target) {
           await sendSessionCommand(id, 'scroll', [target, args.direction, flags.amount]);
         } else {

--- a/packages/cli/src/commands/android/set-wifi-bandwidth.ts
+++ b/packages/cli/src/commands/android/set-wifi-bandwidth.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -54,7 +54,7 @@ export default class AndroidSetWifiBandwidth extends BaseCommand {
       const resolvedInstance = this.resolveAndroidInstance(flags.id);
       const id = resolvedInstance.id;
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'set-wifi-bandwidth', [bandwidth]);
       } else {
         const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/android/tap-element.ts
+++ b/packages/cli/src/commands/android/tap-element.ts
@@ -3,7 +3,7 @@ import { BaseCommand } from '../../base-command';
 import { androidSelectorFlags, buildAndroidSelector } from '../../lib/android-selector';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -46,7 +46,7 @@ export default class AndroidTapElement extends BaseCommand {
         );
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         const result = await sendSessionCommand(id, 'tap-element', [selector]);
         if (flags.json) this.outputJson(result);
         else this.log('Element tapped');

--- a/packages/cli/src/commands/android/tap.ts
+++ b/packages/cli/src/commands/android/tap.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -44,7 +44,7 @@ export default class AndroidTap extends BaseCommand {
         this.error('android tap only supports Android instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'tap', [args.x, args.y]);
       } else {
         const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/android/type.ts
+++ b/packages/cli/src/commands/android/type.ts
@@ -3,7 +3,7 @@ import { BaseCommand } from '../../base-command';
 import { androidTargetFlags, buildAndroidTarget } from '../../lib/android-selector';
 import {
   getAndroidInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -43,7 +43,7 @@ export default class AndroidType extends BaseCommand {
 
       const target = buildAndroidTarget(flags);
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'type', [target, args.text]);
       } else {
         const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/app-log.ts
+++ b/packages/cli/src/commands/ios/app-log.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -49,7 +49,7 @@ export default class IosAppLog extends BaseCommand {
       const id = resolvedInstance.id;
 
       if (!flags.follow) {
-        if (hasActiveSession(id)) {
+        if (await ensureDaemonSession(resolvedInstance)) {
           const output = await sendSessionCommand(id, 'app-log-tail', [args.bundleId, flags.tail]);
           this.log(String(output));
         } else {

--- a/packages/cli/src/commands/ios/element-tree.ts
+++ b/packages/cli/src/commands/ios/element-tree.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -36,7 +36,7 @@ export default class IosElementTree extends BaseCommand {
         this.error('ios element-tree only supports iOS instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         const tree = await sendSessionCommand(id, 'element-tree');
         if (flags.json) {
           this.outputJson(tree);

--- a/packages/cli/src/commands/ios/info.ts
+++ b/packages/cli/src/commands/ios/info.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -47,7 +47,7 @@ export default class IosInfo extends BaseCommand {
       const id = resolvedInstance.id;
 
       let info: DeviceInfo;
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         info = (await sendSessionCommand(id, 'device-info')) as DeviceInfo;
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/install-app.ts
+++ b/packages/cli/src/commands/ios/install-app.ts
@@ -6,7 +6,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -105,7 +105,7 @@ export default class IosInstallApp extends BaseCommand {
         };
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         const result = await sendSessionCommand(id, 'install-app', [downloadUrl, installOptions]);
         if (flags.json) {
           this.outputJson(result);

--- a/packages/cli/src/commands/ios/launch-app.ts
+++ b/packages/cli/src/commands/ios/launch-app.ts
@@ -3,7 +3,7 @@ import type { Ios } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 import {
@@ -84,7 +84,7 @@ export default class IosLaunchApp extends BaseCommand {
       });
 
       if (flags.detach) {
-        if (hasActiveSession(id)) {
+        if (await ensureDaemonSession(resolvedInstance)) {
           await sendSessionCommand(id, 'launch-app', [args.bundleId, launchArgument]);
         } else {
           const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/list-apps.ts
+++ b/packages/cli/src/commands/ios/list-apps.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -34,7 +34,7 @@ export default class IosListApps extends BaseCommand {
       const id = resolvedInstance.id;
       let apps: any[];
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         apps = (await sendSessionCommand(id, 'list-apps')) as any[];
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/open-url.ts
+++ b/packages/cli/src/commands/ios/open-url.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -40,7 +40,7 @@ export default class IosOpenUrl extends BaseCommand {
         this.error('ios open-url only supports iOS instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'open-url', [args.url]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/perform.ts
+++ b/packages/cli/src/commands/ios/perform.ts
@@ -4,7 +4,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -249,7 +249,7 @@ YAML example:
       const ipcTimeoutMs = timeoutMs + IPC_TIMEOUT_BUFFER_MS;
 
       let result: PerformActionsResult;
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         result = (await sendSessionCommand(
           id,
           'perform-actions',

--- a/packages/cli/src/commands/ios/press-key.ts
+++ b/packages/cli/src/commands/ios/press-key.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -42,7 +42,7 @@ export default class IosPressKey extends BaseCommand {
         this.error('ios press-key only supports iOS instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'press-key', [args.key, flags.modifier]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/record.ts
+++ b/packages/cli/src/commands/ios/record.ts
@@ -3,7 +3,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -61,7 +61,7 @@ export default class IosRecord extends BaseCommand {
       }
 
       if (args.action === 'start') {
-        if (hasActiveSession(id)) {
+        if (await ensureDaemonSession(resolvedInstance)) {
           await sendSessionCommand(id, 'start-recording', [flags.quality]);
         } else {
           const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
@@ -81,7 +81,7 @@ export default class IosRecord extends BaseCommand {
         presignedUrl: flags['presigned-url'],
       };
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'stop-recording', [saveTo]);
         this.log(`Recording saved to ${outputPath}`);
         if (flags['presigned-url']) {

--- a/packages/cli/src/commands/ios/screenshot.ts
+++ b/packages/cli/src/commands/ios/screenshot.ts
@@ -4,7 +4,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -43,7 +43,7 @@ export default class IosScreenshot extends BaseCommand {
       }
 
       let screenshot: any;
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         screenshot = await sendSessionCommand(id, 'screenshot');
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/scroll.ts
+++ b/packages/cli/src/commands/ios/scroll.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 import { parsePointFlag } from '../../lib/parse-point';
@@ -60,7 +60,7 @@ export default class IosScroll extends BaseCommand {
       const scrollOptions =
         momentum === undefined && coordinate === undefined ? undefined : { momentum, coordinate };
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'scroll', [args.direction, flags.amount, scrollOptions]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/set-text.ts
+++ b/packages/cli/src/commands/ios/set-text.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -88,7 +88,7 @@ export default class IosSetText extends BaseCommand {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const id = resolvedInstance.id;
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         const result = await sendSessionCommand(id, 'set-text', [args.text, target]);
         if (flags.json) this.outputJson(result);
         else this.log('Text set');

--- a/packages/cli/src/commands/ios/swipe.ts
+++ b/packages/cli/src/commands/ios/swipe.ts
@@ -4,7 +4,7 @@ import { BaseCommand } from '../../base-command';
 import { parsePointFlag } from '../../lib/parse-point';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -56,7 +56,7 @@ export default class IosSwipe extends BaseCommand {
       // gets a buffer on top, so the real error surfaces before the socket
       // times out.
       const timeoutMs = flags.duration + IPC_TIMEOUT_BUFFER_MS;
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         try {
           await sendSessionCommand(
             id,

--- a/packages/cli/src/commands/ios/tap-element.ts
+++ b/packages/cli/src/commands/ios/tap-element.ts
@@ -3,7 +3,7 @@ import { Ios } from '@limrun/api';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -86,7 +86,7 @@ export default class IosTapElement extends BaseCommand {
         activate: flags.activate as Ios.TapElementActivation | undefined,
         scrollSearch: flags['scroll-search'],
       };
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         // timeoutMs is the SDK's total budget for the call (scroll search
         // included); the IPC socket must not give up first.
         const ipcTimeoutMs = Ios.TAP_ELEMENT_TIMEOUT_MS + 15_000;

--- a/packages/cli/src/commands/ios/tap.ts
+++ b/packages/cli/src/commands/ios/tap.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -44,7 +44,7 @@ export default class IosTap extends BaseCommand {
         this.error('ios tap only supports iOS instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'tap', [args.x, args.y]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/terminate-app.ts
+++ b/packages/cli/src/commands/ios/terminate-app.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -37,7 +37,7 @@ export default class IosTerminateApp extends BaseCommand {
     await this.withAuth(async () => {
       const resolvedInstance = this.resolveIosInstance(flags.id);
       const id = resolvedInstance.id;
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'terminate-app', [args.bundleId]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/toggle-keyboard.ts
+++ b/packages/cli/src/commands/ios/toggle-keyboard.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -33,7 +33,7 @@ export default class IosToggleKeyboard extends BaseCommand {
         this.error('ios toggle-keyboard only supports iOS instances');
       }
 
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'toggle-keyboard');
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/ios/type.ts
+++ b/packages/cli/src/commands/ios/type.ts
@@ -2,7 +2,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
 import {
   getIosInstanceClient,
-  hasActiveSession,
+  ensureDaemonSession,
   sendSessionCommand,
 } from '../../lib/instance-client-factory';
 
@@ -52,7 +52,7 @@ export default class IosType extends BaseCommand {
       // The SDK sends requireFocus on the wire only when false, so the
       // default flag value keeps legacy payloads byte-identical.
       const options = { requireFocus: flags['require-focus'] };
-      if (hasActiveSession(id)) {
+      if (await ensureDaemonSession(resolvedInstance)) {
         await sendSessionCommand(id, 'type', [args.text, flags.enter, options]);
       } else {
         const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);

--- a/packages/cli/src/commands/session/start.ts
+++ b/packages/cli/src/commands/session/start.ts
@@ -1,9 +1,6 @@
-import { spawn } from 'child_process';
-import fs from 'fs';
-import path from 'path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command';
-import { isDaemonRunning, saveState, socketPath, type SessionState } from '../../lib/daemon';
+import { isDaemonRunning, spawnSessionDaemon, type SessionState } from '../../lib/daemon';
 import { saveInstanceCache } from '../../lib/config';
 
 export default class SessionStart extends BaseCommand {
@@ -99,39 +96,7 @@ export default class SessionStart extends BaseCommand {
         adbUrl,
         token,
       };
-      saveState(id, state);
-
-      // Spawn daemon with the instance ID as env var
-      const daemonScript = path.join(__dirname, '..', '..', 'lib', 'daemon.js');
-      const child = spawn(process.execPath, [daemonScript], {
-        detached: true,
-        stdio: 'ignore',
-        env: { ...process.env, LIM_DAEMON_INSTANCE_ID: id },
-      });
-      child.unref();
-
-      // Wait for daemon to be ready
-      const sock = socketPath(id);
-      const startTime = Date.now();
-      const timeout = 15000;
-
-      await new Promise<void>((resolve, reject) => {
-        child.on('error', reject);
-
-        const check = () => {
-          if (fs.existsSync(sock)) {
-            resolve();
-            return;
-          }
-          if (Date.now() - startTime > timeout) {
-            reject(new Error('Daemon failed to start within 15 seconds'));
-            return;
-          }
-          setTimeout(check, 100);
-        };
-
-        setTimeout(check, 100);
-      });
+      await spawnSessionDaemon(state);
 
       this.log(`Session started for ${id} (${type})`);
     });

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -176,10 +176,7 @@ function acquireSpawnLock(lock: string): boolean {
  * Concurrent callers are single-flighted through a lock file: only one spawns,
  * the rest wait for the same daemon. Rejects if it is not ready within waitMs.
  */
-export async function spawnSessionDaemon(
-  state: SessionState,
-  opts: { waitMs?: number } = {},
-): Promise<void> {
+export async function spawnSessionDaemon(state: SessionState, opts: { waitMs?: number } = {}): Promise<void> {
   const id = state.instanceId;
   saveState(id, state);
 

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -2,6 +2,7 @@ import net from 'net';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { spawn } from 'child_process';
 import { createInstanceClient, Ios, type InstanceClient } from '@limrun/api';
 import { type InstanceType } from './instance-client-factory';
 
@@ -11,7 +12,9 @@ import { type InstanceType } from './instance-client-factory';
 import crypto from 'crypto';
 
 const SESSIONS_ROOT = path.join(os.homedir(), '.lim', 'sessions');
-const KEEPALIVE_INTERVAL_MS = 60 * 1000;
+/** How often the daemon checks whether it has been idle long enough to exit. */
+const IDLE_CHECK_INTERVAL_MS = 60 * 1000;
+/** The daemon exits after this long without a command, so idle daemons don't accumulate. */
 const INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 
 export { SESSIONS_ROOT };
@@ -126,6 +129,49 @@ export function stopDaemon(instanceId: string): void {
 }
 
 /**
+ * Spawn a detached daemon process for the instance and wait until its socket
+ * is accepting connections. Saves the session state first so the daemon can
+ * read the credentials. Rejects if the daemon does not come up within waitMs.
+ */
+export async function spawnSessionDaemon(
+  state: SessionState,
+  opts: { waitMs?: number } = {},
+): Promise<void> {
+  const id = state.instanceId;
+  saveState(id, state);
+
+  const daemonScript = path.join(__dirname, 'daemon.js');
+  const child = spawn(process.execPath, [daemonScript], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, LIM_DAEMON_INSTANCE_ID: id },
+  });
+  child.unref();
+
+  const sock = socketPath(id);
+  const startTime = Date.now();
+  const timeout = opts.waitMs ?? 15000;
+
+  await new Promise<void>((resolve, reject) => {
+    child.on('error', reject);
+
+    const check = () => {
+      if (fs.existsSync(sock)) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startTime > timeout) {
+        reject(new Error(`Daemon failed to start within ${Math.round(timeout / 1000)} seconds`));
+        return;
+      }
+      setTimeout(check, 100);
+    };
+
+    setTimeout(check, 100);
+  });
+}
+
+/**
  * List all instance IDs that have an active daemon running.
  */
 export function listActiveSessions(): { instanceId: string; pid: number }[] {
@@ -206,7 +252,7 @@ export function startDaemonServer(): void {
   let instanceClient: (InstanceClient | Ios.InstanceClient) | null = null;
   let instanceType: InstanceType | null = null;
   let lastCommandAt = Date.now();
-  let keepAliveInterval: NodeJS.Timeout | undefined;
+  let idleCheckInterval: NodeJS.Timeout | undefined;
 
   async function getClient(): Promise<{ type: InstanceType; client: InstanceClient | Ios.InstanceClient }> {
     if (instanceClient && instanceType) {
@@ -244,26 +290,18 @@ export function startDaemonServer(): void {
     }
   }
 
-  function sendClientKeepAlive(client: InstanceClient | Ios.InstanceClient): void {
-    const maybeClient = client as { keepAlive?: () => void };
-    maybeClient.keepAlive?.();
-  }
-
-  function startKeepAliveLoop(): void {
-    if (keepAliveInterval) {
-      clearInterval(keepAliveInterval);
+  // The daemon deliberately sends no instance keep-alives: it must not extend
+  // the instance's inactivityTimeout beyond what actual commands do. It only
+  // exits itself once it has been idle long enough.
+  function startIdleExitLoop(): void {
+    if (idleCheckInterval) {
+      clearInterval(idleCheckInterval);
     }
-    keepAliveInterval = setInterval(() => {
-      if (!instanceClient) {
-        return;
-      }
+    idleCheckInterval = setInterval(() => {
       if (Date.now() - lastCommandAt > INACTIVITY_TIMEOUT_MS) {
-        return;
+        shutdown();
       }
-      try {
-        sendClientKeepAlive(instanceClient);
-      } catch {}
-    }, KEEPALIVE_INTERVAL_MS);
+    }, IDLE_CHECK_INTERVAL_MS);
   }
 
   function send(socket: net.Socket, resp: DaemonResponse): void {
@@ -505,9 +543,9 @@ export function startDaemonServer(): void {
   });
 
   function cleanup(): void {
-    if (keepAliveInterval) {
-      clearInterval(keepAliveInterval);
-      keepAliveInterval = undefined;
+    if (idleCheckInterval) {
+      clearInterval(idleCheckInterval);
+      idleCheckInterval = undefined;
     }
     try {
       fs.unlinkSync(sock);
@@ -532,7 +570,7 @@ export function startDaemonServer(): void {
   });
 
   server.listen(sock, () => {
-    startKeepAliveLoop();
+    startIdleExitLoop();
     fs.writeFileSync(pid, String(process.pid), { mode: 0o600 });
     try {
       fs.chmodSync(sock, 0o600);

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -131,6 +131,20 @@ export function stopDaemon(instanceId: string): void {
 /** A spawn lock older than this is from a crashed process and can be taken over. */
 const SPAWN_LOCK_STALE_MS = 20 * 1000;
 
+/** A lock is stale when its holder process is dead, or by age if unreadable. */
+function isSpawnLockStale(lock: string): boolean {
+  const holder = parseInt(fs.readFileSync(lock, 'utf-8').trim(), 10);
+  if (!isNaN(holder)) {
+    try {
+      process.kill(holder, 0);
+      return false;
+    } catch {
+      return true;
+    }
+  }
+  return Date.now() - fs.statSync(lock).mtimeMs > SPAWN_LOCK_STALE_MS;
+}
+
 /**
  * Take the per-instance spawn lock so only one CLI process starts a daemon.
  * Returns false when another live process holds it; that process's daemon
@@ -143,7 +157,7 @@ function acquireSpawnLock(lock: string): boolean {
       return true;
     } catch {
       try {
-        if (Date.now() - fs.statSync(lock).mtimeMs <= SPAWN_LOCK_STALE_MS) return false;
+        if (!isSpawnLockStale(lock)) return false;
         fs.unlinkSync(lock);
       } catch {
         return false;
@@ -196,6 +210,12 @@ export async function spawnSessionDaemon(
           resolve();
           return;
         }
+        // The lock holder released without a daemon coming up; fail now
+        // instead of waiting out the full timeout.
+        if (!ownsLock && !fs.existsSync(lock)) {
+          reject(new Error('Daemon spawned by a concurrent command failed to start'));
+          return;
+        }
         if (Date.now() - startTime > timeout) {
           reject(new Error(`Daemon failed to start within ${Math.round(timeout / 1000)} seconds`));
           return;
@@ -205,6 +225,13 @@ export async function spawnSessionDaemon(
 
       setTimeout(check, 100);
     });
+  } catch (err) {
+    // Don't leave a half-started daemon behind: after the lock is released
+    // it could race a follow-up spawn on the socket and pid files.
+    try {
+      child?.kill();
+    } catch {}
+    throw err;
   } finally {
     if (ownsLock) {
       try {

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -128,10 +128,39 @@ export function stopDaemon(instanceId: string): void {
   clearSession(instanceId);
 }
 
+/** A spawn lock older than this is from a crashed process and can be taken over. */
+const SPAWN_LOCK_STALE_MS = 20 * 1000;
+
 /**
- * Spawn a detached daemon process for the instance and wait until its socket
- * is accepting connections. Saves the session state first so the daemon can
- * read the credentials. Rejects if the daemon does not come up within waitMs.
+ * Take the per-instance spawn lock so only one CLI process starts a daemon.
+ * Returns false when another live process holds it; that process's daemon
+ * serves us too, we just wait for it to become ready.
+ */
+function acquireSpawnLock(lock: string): boolean {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      fs.writeFileSync(lock, String(process.pid), { flag: 'wx', mode: 0o600 });
+      return true;
+    } catch {
+      try {
+        if (Date.now() - fs.statSync(lock).mtimeMs <= SPAWN_LOCK_STALE_MS) return false;
+        fs.unlinkSync(lock);
+      } catch {
+        return false;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Spawn a detached daemon process for the instance and wait until it is ready.
+ * Ready means the socket exists and the daemon has written its live pid; the
+ * socket alone is not enough because a stale file or the window before the
+ * pid write would make sendCommand fail its liveness check.
+ * Saves the session state first so the daemon can read the credentials.
+ * Concurrent callers are single-flighted through a lock file: only one spawns,
+ * the rest wait for the same daemon. Rejects if it is not ready within waitMs.
  */
 export async function spawnSessionDaemon(
   state: SessionState,
@@ -140,35 +169,49 @@ export async function spawnSessionDaemon(
   const id = state.instanceId;
   saveState(id, state);
 
-  const daemonScript = path.join(__dirname, 'daemon.js');
-  const child = spawn(process.execPath, [daemonScript], {
-    detached: true,
-    stdio: 'ignore',
-    env: { ...process.env, LIM_DAEMON_INSTANCE_ID: id },
-  });
-  child.unref();
+  const lock = path.join(sessionDir(id), 'spawn.lock');
+  const ownsLock = acquireSpawnLock(lock);
+
+  let child: ReturnType<typeof spawn> | undefined;
+  if (ownsLock) {
+    const daemonScript = path.join(__dirname, 'daemon.js');
+    child = spawn(process.execPath, [daemonScript], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, LIM_DAEMON_INSTANCE_ID: id },
+    });
+    child.unref();
+  }
 
   const sock = socketPath(id);
   const startTime = Date.now();
   const timeout = opts.waitMs ?? 15000;
 
-  await new Promise<void>((resolve, reject) => {
-    child.on('error', reject);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      child?.on('error', reject);
 
-    const check = () => {
-      if (fs.existsSync(sock)) {
-        resolve();
-        return;
-      }
-      if (Date.now() - startTime > timeout) {
-        reject(new Error(`Daemon failed to start within ${Math.round(timeout / 1000)} seconds`));
-        return;
-      }
+      const check = () => {
+        if (fs.existsSync(sock) && isDaemonRunning(id)) {
+          resolve();
+          return;
+        }
+        if (Date.now() - startTime > timeout) {
+          reject(new Error(`Daemon failed to start within ${Math.round(timeout / 1000)} seconds`));
+          return;
+        }
+        setTimeout(check, 100);
+      };
+
       setTimeout(check, 100);
-    };
-
-    setTimeout(check, 100);
-  });
+    });
+  } finally {
+    if (ownsLock) {
+      try {
+        fs.unlinkSync(lock);
+      } catch {}
+    }
+  }
 }
 
 /**
@@ -241,6 +284,12 @@ export function startDaemonServer(): void {
   const dir = sessionDir(instanceId);
   const sock = socketPath(instanceId);
   const pid = pidFile(instanceId);
+
+  // Another live daemon already serves this instance. Exit instead of
+  // unlinking its socket and overwriting its pid file.
+  if (isDaemonRunning(instanceId)) {
+    process.exit(0);
+  }
 
   ensureDir(dir);
 
@@ -547,6 +596,13 @@ export function startDaemonServer(): void {
       clearInterval(idleCheckInterval);
       idleCheckInterval = undefined;
     }
+    // Only remove files this process owns. If the pid file names another
+    // process, a newer daemon took over and these are its files now.
+    let owner: string | undefined;
+    try {
+      owner = fs.readFileSync(pid, 'utf-8').trim();
+    } catch {}
+    if (owner !== String(process.pid)) return;
     try {
       fs.unlinkSync(sock);
     } catch {}

--- a/packages/cli/src/lib/instance-client-factory.test.ts
+++ b/packages/cli/src/lib/instance-client-factory.test.ts
@@ -1,0 +1,94 @@
+import { ensureDaemonSession, setSessionAutoStart } from './instance-client-factory';
+import { isSessionActive } from './daemon-client';
+import { type LastAndroidInstance, type LastIosInstance } from './config';
+
+jest.mock('./daemon-client', () => ({
+  isSessionActive: jest.fn(),
+  sendCommand: jest.fn(),
+}));
+
+const isSessionActiveMock = isSessionActive as jest.Mock;
+
+const IOS_TARGET: LastIosInstance = {
+  id: 'ios_euna_01m02anjqredzr42pcn8s8jx90',
+  type: 'ios',
+  apiUrl: 'https://region.limrun.com/v1/ios_x/api',
+  token: 'lim_st_token',
+};
+
+const ANDROID_TARGET: LastAndroidInstance = {
+  id: 'android_euna_01m02anjqredzr42pcn8s8jx90',
+  type: 'android',
+  apiUrl: 'https://region.limrun.com/v1/android_x/api',
+  token: 'lim_st_token',
+  adbWebSocketUrl: 'wss://region.limrun.com/v1/android_x/adb',
+};
+
+describe('ensureDaemonSession', () => {
+  let spawnFn: jest.Mock;
+  let stderr: jest.SpyInstance;
+
+  beforeEach(() => {
+    isSessionActiveMock.mockReset();
+    isSessionActiveMock.mockReturnValue(false);
+    spawnFn = jest.fn().mockResolvedValue(undefined);
+    stderr = jest.spyOn(console, 'error').mockImplementation(() => {});
+    setSessionAutoStart({ enabled: true, silent: false });
+  });
+
+  afterEach(() => {
+    stderr.mockRestore();
+    setSessionAutoStart({ enabled: true, silent: false });
+  });
+
+  it('uses the existing session without spawning', async () => {
+    isSessionActiveMock.mockReturnValue(true);
+    await expect(ensureDaemonSession(IOS_TARGET, spawnFn)).resolves.toBe(true);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('does not spawn when auto-start is disabled', async () => {
+    setSessionAutoStart({ enabled: false });
+    await expect(ensureDaemonSession(IOS_TARGET, spawnFn)).resolves.toBe(false);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('does not spawn when credentials are not known yet', async () => {
+    const idOnly: LastIosInstance = { id: IOS_TARGET.id, type: 'ios' };
+    await expect(ensureDaemonSession(idOnly, spawnFn)).resolves.toBe(false);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('spawns with the target credentials and announces on stderr', async () => {
+    await expect(ensureDaemonSession(IOS_TARGET, spawnFn)).resolves.toBe(true);
+    expect(spawnFn).toHaveBeenCalledWith({
+      instanceId: IOS_TARGET.id,
+      instanceType: 'ios',
+      apiUrl: IOS_TARGET.apiUrl,
+      adbUrl: undefined,
+      token: IOS_TARGET.token,
+    });
+    expect(stderr).toHaveBeenCalledWith(`WebSocket daemon started for ${IOS_TARGET.id}.`);
+  });
+
+  it('passes the adb url for android targets', async () => {
+    await expect(ensureDaemonSession(ANDROID_TARGET, spawnFn)).resolves.toBe(true);
+    expect(spawnFn).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceType: 'android', adbUrl: ANDROID_TARGET.adbWebSocketUrl }),
+    );
+  });
+
+  it('stays quiet when silent', async () => {
+    setSessionAutoStart({ enabled: true, silent: true });
+    await expect(ensureDaemonSession(IOS_TARGET, spawnFn)).resolves.toBe(true);
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('falls back to direct connection when the spawn fails', async () => {
+    spawnFn.mockRejectedValue(new Error('boom'));
+    await expect(ensureDaemonSession(IOS_TARGET, spawnFn)).resolves.toBe(false);
+    expect(stderr).toHaveBeenCalledWith(
+      `Could not start WebSocket daemon for ${IOS_TARGET.id} (boom); connecting directly.`,
+    );
+  });
+});

--- a/packages/cli/src/lib/instance-client-factory.ts
+++ b/packages/cli/src/lib/instance-client-factory.ts
@@ -1,5 +1,6 @@
 import Limrun, { createInstanceClient, Ios, type InstanceClient } from '@limrun/api';
 import { isSessionActive, sendCommand } from './daemon-client';
+import { spawnSessionDaemon } from './daemon';
 import { saveInstanceCache, type LastAndroidInstance, type LastIosInstance } from './config';
 
 export type InstanceType = 'android' | 'ios' | 'xcode' | 'gradle';
@@ -31,11 +32,51 @@ export function detectInstanceType(id: string): InstanceType {
   );
 }
 
+let sessionAutoStart = { enabled: true, silent: false };
+
+/** Configure daemon auto-start for this invocation; wired from the --daemon and --json flags. */
+export function setSessionAutoStart(config: { enabled: boolean; silent?: boolean }): void {
+  sessionAutoStart = { enabled: config.enabled, silent: config.silent ?? false };
+}
+
+/** Injectable for tests. */
+type SpawnFn = typeof spawnSessionDaemon;
+
 /**
- * Check if a daemon session is active for the given instance ID.
+ * Ensure a daemon session exists for the target so the command can use the
+ * ~50ms Unix-socket path, starting one if needed. Returns false when the
+ * command should fall back to a direct WebSocket instead: auto-start disabled,
+ * credentials not known yet (the direct path fetches and caches them, so the
+ * next command auto-starts), or the daemon failed to start.
  */
-export function hasActiveSession(id: string): boolean {
-  return isSessionActive(id);
+export async function ensureDaemonSession(
+  target: LastAndroidInstance | LastIosInstance,
+  spawnFn: SpawnFn = spawnSessionDaemon,
+): Promise<boolean> {
+  if (isSessionActive(target.id)) return true;
+  if (!sessionAutoStart.enabled) return false;
+  if (!target.apiUrl || !target.token) return false;
+
+  try {
+    await spawnFn({
+      instanceId: target.id,
+      instanceType: target.type,
+      apiUrl: target.apiUrl,
+      adbUrl: target.type === 'android' ? target.adbWebSocketUrl : undefined,
+      token: target.token,
+    });
+  } catch (err) {
+    if (!sessionAutoStart.silent) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Could not start WebSocket daemon for ${target.id} (${message}); connecting directly.`);
+    }
+    return false;
+  }
+
+  if (!sessionAutoStart.silent) {
+    console.error(`WebSocket daemon started for ${target.id}.`);
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Device commands now auto-start the per-instance session daemon on first use and route that first call through it; every call after daemon boot takes the ~50ms Unix-socket path instead of a fresh WebSocket handshake per invocation. `WebSocket daemon started for <id>.` goes to stderr, suppressed under `--json`/`--quiet`.
- Opt out with `--no-daemon` per command or `LIM_DAEMON=false` per environment (e.g. CI). When credentials are not known yet (id-only target that needs a management `get`), the command runs direct and the next one auto-starts from the freshly cached credentials.
- No lifetime/billing impact: the daemon no longer sends instance keep-alives, so `inactivityTimeout` is driven only by real commands, with or without a daemon. **Behavior change:** a manual `lim session start` no longer keeps the instance alive while idle.
- Target switching stays safe by construction: the session is looked up by resolved instance id, so new env vars or a new `set-instance` route to a new daemon. Idle daemons now self-exit after 30 minutes instead of lingering forever.

Follow-up to #319; works keyless with `set-instance` and the `LIM_<TYPE>_INSTANCE_URL`/`TOKEN` env pairs shipped there. limrun-inc/docs#28 updates the docs comparison row for the new connection default.

## Test plan
- [x] 7 new jest tests for `ensureDaemonSession` gating (active session, disabled, missing credentials, spawn payload, silent mode, spawn-failure fallback); full CLI suite 88/88 green, eslint clean
- [x] Live keyless verification with env pins: first `ios element-tree` prints the stderr notice and answers through the daemon (2.4s), second `ios tap` takes the fast path (0.5s, silent); `--json` produces zero stderr while still starting the daemon; `--no-daemon` and `LIM_DAEMON=false` leave no session behind
- [x] Idle self-exit verified with a locally shortened timeout: daemon exits and cleans its session files after the idle window

## Review fixes

- Spawn readiness now waits for the live pid file in addition to the socket, closing the window (and the stale-socket case) where `ensureDaemonSession` returned true but `sendCommand`'s liveness check failed the first command.
- Concurrent CLI processes single-flight daemon spawning through a `spawn.lock` file; a daemon that finds a live peer exits instead of unlinking its socket and overwriting its pid file, and `cleanup()` only removes session files whose pid file names the exiting process.
- Follow-up round: on wait timeout the lock owner kills its half-started child before releasing the lock (no socket/pid race with the next spawn); a spawn lock is stale the moment its holder process is dead rather than after a 20s age fallback; and waiters whose lock holder released without a daemon coming up fail fast to the direct path instead of stalling the full 15s.
- Verified live against a production iOS instance: a planted stale `s.sock` no longer breaks the first command, four parallel keyless commands from a clean state produce exactly one daemon (the old build reproducibly produced two), and a manually started second daemon exits immediately leaving the first session intact.

Made with [Cursor](https://cursor.com)
