### PR TITLE
cli: let xcode attach-simulator run without an API key

### DIFF
--- a/packages/cli/src/commands/xcode/attach-simulator.ts
+++ b/packages/cli/src/commands/xcode/attach-simulator.ts
@@ -6,17 +6,21 @@ import { formatSimulatorAttachResult, simulatorAttachJson } from '../../lib/simu
 export default class XcodeAttachSimulator extends BaseCommand {
   static summary = 'Attach an iOS simulator to an Xcode instance';
   static description =
-    'Attach an existing iOS simulator to an Xcode sandbox so future builds can auto-install on that simulator.';
+    'Attach an existing iOS simulator to an Xcode sandbox so future builds can auto-install on that simulator. ' +
+    'When the simulator is omitted, the LIM_IOS_INSTANCE_URL/LIM_IOS_INSTANCE_TOKEN pair or the last used ' +
+    'simulator is attached; if its credentials are known locally, no API key is needed.';
 
   static examples = [
+    '<%= config.bin %> xcode attach-simulator',
     '<%= config.bin %> xcode attach-simulator <ios-instance-ID>',
     '<%= config.bin %> xcode attach-simulator <ios-instance-ID> --id <xcode-instance-ID>',
   ];
 
   static args = {
     simulatorId: Args.string({
-      description: 'iOS simulator instance ID to attach',
-      required: true,
+      description:
+        'iOS simulator instance ID to attach. Defaults to the environment-pinned or last used simulator.',
+      required: false,
     }),
   };
 
@@ -40,19 +44,30 @@ export default class XcodeAttachSimulator extends BaseCommand {
     await this.withAuth(async () => {
       const xcodeTarget = await this.resolveXcodeTarget(flags.id);
       const xcodeInstanceId = xcodeTarget.id;
-      const simulator = await this.client.iosInstances.get(args.simulatorId);
+      const resolved = this.resolveIosInstance(args.simulatorId);
       const xcodeClient = await this.resolveXcodeClient(xcodeTarget);
 
-      this.info(`Attaching simulator ${args.simulatorId} to Xcode target ${xcodeInstanceId}...`);
-      const result = await xcodeClient.attachSimulator(simulator);
-      registerCreatedInstance(simulator);
+      // The attach itself is a call to the Xcode instance carrying the
+      // simulator's apiUrl and token. Only fetch from the management API
+      // when those credentials are not already known locally.
+      let attachInput: Parameters<typeof xcodeClient.attachSimulator>[0];
+      if (resolved.apiUrl && resolved.token) {
+        attachInput = { apiUrl: resolved.apiUrl, token: resolved.token };
+      } else {
+        const simulator = await this.client.iosInstances.get(resolved.id);
+        registerCreatedInstance(simulator);
+        attachInput = simulator;
+      }
+
+      this.info(`Attaching simulator ${resolved.id} to Xcode target ${xcodeInstanceId}...`);
+      const result = await xcodeClient.attachSimulator(attachInput);
 
       if (flags.json) {
-        this.outputJson(simulatorAttachJson(simulator.metadata.id, xcodeInstanceId, result));
+        this.outputJson(simulatorAttachJson(resolved.id, xcodeInstanceId, result));
       } else if (this.isQuietEnabled()) {
-        this.output(simulator.metadata.id);
+        this.output(resolved.id);
       } else {
-        this.output(formatSimulatorAttachResult(simulator.metadata.id, xcodeInstanceId, result));
+        this.output(formatSimulatorAttachResult(resolved.id, xcodeInstanceId, result));
       }
     });
   }


### PR DESCRIPTION
## Summary
- `lim xcode attach-simulator` no longer needs `LIM_API_KEY` when the simulator's credentials are known locally. The attach operation was always a call to the Xcode instance's own API carrying the simulator's `apiUrl` and `token`; the management lookup existed only to translate an instance ID into that pair.
- The simulator now resolves with the same precedence as every other iOS command: explicit ID argument, then the `LIM_IOS_INSTANCE_URL`/`LIM_IOS_INSTANCE_TOKEN` pair, then the cached last-used record. When the resolved record carries credentials, the attach goes straight to the Xcode instance; otherwise the management API lookup happens as before.
- The simulator ID argument is now optional. A sandboxed agent holding one pinned simulator and one pinned Xcode sandbox attaches them with a bare `lim xcode attach-simulator`.

Follow-up to #319, which introduced the env pins and keyless instance control.

## Test plan
Verified live against production:
- Keyless (scratch HOME, no `LIM_API_KEY`, both env pairs set): `lim xcode attach-simulator` with no arguments attached the pinned simulator to the pinned sandbox, a subsequent keyless `lim xcode build` auto-installed the app onto it in 355ms, and keyless `lim ios list-apps` showed the installed bundle.
- Keyed fallback (explicit IDs, no local credential cache): the management lookup path still works and correctly reported the simulator as already attached with the latest build installed.
- Full CLI test suite passes; repo `./scripts/lint` is clean.

Made with [Cursor](https://cursor.com)