### PR TITLE
feat(ios): list files in simulator containers

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -249,8 +249,9 @@ lim ios simctl -- listapps booted
 lim ios xcrun -- --sdk iphonesimulator --show-sdk-version
 lim ios xcodebuild -- -version
 lim ios push-file ./fixtures/payload.json payload.json
-lim ios pull-file documents/photo.jpeg ./photo.jpeg --bundle-id com.example.app --container-type data
-lim ios delete-file documents/photo.jpeg --bundle-id com.example.app --container-type data
+lim ios ls Documents --bundle-id com.example.app --container-type data
+lim ios pull-file Documents/photo.jpeg ./photo.jpeg --bundle-id com.example.app --container-type data
+lim ios delete-file Documents/photo.jpeg --bundle-id com.example.app --container-type data
 lim ios lsof
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
         "description": "Build Android projects on cloud gradle sandboxes"
       },
       "ios": {
-        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, keychain, record, perform, simctl, cp, xcrun, xcodebuild, lsof, reverse"
+        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, keychain, record, perform, ls, push-file, pull-file, delete-file, simctl, cp, xcrun, xcodebuild, lsof, reverse"
       },
       "session": {
         "description": "Manage persistent background sessions for device interaction: start, status, stop. Sessions are used to execute commands on remote devices without the need to reconnect to the device after each command."

--- a/packages/cli/src/commands/ios/ls.ts
+++ b/packages/cli/src/commands/ios/ls.ts
@@ -1,0 +1,71 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { formatBytes } from '../../lib/bytes';
+import { getIosInstanceClient } from '../../lib/instance-client-factory';
+
+export default class IosLs extends BaseCommand {
+  static summary = 'List files in the iOS simulator or an app container';
+  static description =
+    'List a directory in the simulator staging folder. ' +
+    'With --bundle-id, the path is relative to that app container instead. ' +
+    'Returned paths can be passed directly to ios pull-file, push-file, or delete-file with the same flags.';
+  static examples = [
+    '<%= config.bin %> ios ls',
+    '<%= config.bin %> ios ls Documents --bundle-id com.example.app --container-type data',
+    '<%= config.bin %> ios ls Documents --bundle-id com.example.app --container-type data --json',
+  ];
+
+  static args = {
+    path: Args.string({
+      description: 'Relative directory to list. Defaults to the selected storage root.',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'iOS instance ID to target. Defaults to the last created iOS instance.',
+    }),
+    'bundle-id': Flags.string({
+      description: 'Bundle ID of the installed app whose container should be listed.',
+    }),
+    'container-type': Flags.string({
+      description:
+        "Container to target when --bundle-id is provided: 'app', 'data', or a specific App Group identifier. Defaults to 'app'.",
+      dependsOn: ['bundle-id'],
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(IosLs);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveIosInstance(flags.id);
+      const { client, disconnect } = await getIosInstanceClient(this.client, resolvedInstance);
+      try {
+        const entries = await client.listFiles(
+          args.path,
+          flags['bundle-id'] ?
+            { bundleId: flags['bundle-id'], containerType: flags['container-type'] }
+          : undefined,
+        );
+        if (flags.json) {
+          this.outputJson(entries);
+          return;
+        }
+        this.outputTable(
+          ['Type', 'Size', 'Path'],
+          entries.map((entry) => [
+            entry.isDirectory ? 'directory' : 'file',
+            entry.isDirectory ? '' : formatBytes(entry.size ?? 0),
+            entry.path,
+          ]),
+        );
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/src/ios-client.ts
+++ b/src/ios-client.ts
@@ -270,6 +270,18 @@ export type ContainerTargetOptions = {
   containerType?: string;
 };
 
+/** A file or directory inside the simulator staging folder or an app container. */
+export type IosFileEntry = {
+  /** Entry name within the listed directory. */
+  name: string;
+  /** Entry path relative to the selected storage root; usable with pullFile/pushFile/deleteFile. */
+  path: string;
+  /** Whether the entry is a directory. */
+  isDirectory: boolean;
+  /** File size in bytes. Omitted for directories. */
+  size?: number;
+};
+
 /**
  * Options for playing a video file as the simulated camera feed.
  */
@@ -948,6 +960,17 @@ export type InstanceClient = {
    * @returns A promise that resolves to the file content.
    */
   pullFile: (name: string, opts?: ContainerTargetOptions) => Promise<Buffer>;
+
+  /**
+   * List a directory in the simulator staging folder or an app container.
+   *
+   * Returned paths are relative to the selected storage root and can be passed
+   * directly to `pullFile`, `pushFile`, or `deleteFile` with the same options.
+   *
+   * @param path Relative directory to list. Empty or `.` lists the storage root.
+   * @param opts Optional app container targeting (see `pushFile`).
+   */
+  listFiles: (path?: string, opts?: ContainerTargetOptions) => Promise<IosFileEntry[]>;
 
   /**
    * Delete a file or folder (recursively) on the simulator.
@@ -2023,6 +2046,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             xcodebuild,
             pushFile,
             pullFile,
+            listFiles,
             deleteFile,
             setCameraVideo,
             clearCameraVideo,
@@ -2610,6 +2634,33 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         throw new Error(`Download of '${name}' failed: ${response.status} ${errorBody}`);
       }
       return Buffer.from(await response.arrayBuffer());
+    };
+
+    const listFiles = async (path = '.', opts?: ContainerTargetOptions): Promise<IosFileEntry[]> => {
+      const params = new URLSearchParams();
+      if (path && path !== '.') {
+        params.set('path', path);
+      }
+      if (opts?.bundleId) {
+        params.set('bundleId', opts.bundleId);
+        if (opts.containerType) {
+          params.set('containerType', opts.containerType);
+        }
+      }
+      const query = params.toString();
+      const url = `${options.apiUrl}/files/list${query ? `?${query}` : ''}`;
+      const response = await nodeProxyTransport.fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${options.token}`,
+        },
+      });
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`Listing of '${path}' failed: ${response.status} ${errorBody}`);
+      }
+      const result = (await response.json()) as { entries: IosFileEntry[] };
+      return result.entries;
     };
 
     const deleteFile = async (name: string, opts?: ContainerTargetOptions): Promise<void> => {

--- a/tests/ios-files.test.ts
+++ b/tests/ios-files.test.ts
@@ -124,4 +124,24 @@ describe('iOS file listing', () => {
 
     client.disconnect();
   });
+
+  it('includes the path and server response when listing fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => '{"message":"Directory not found: Documents"}',
+    });
+    const { createInstanceClient } = await import('../src/ios-client');
+    const client = await createInstanceClient({
+      apiUrl: 'https://example.test/v1/ios_123/api',
+      token: 'token',
+      logLevel: 'none',
+    });
+
+    await expect(client.listFiles('Documents')).rejects.toThrow(
+      `Listing of 'Documents' failed: 404 {"message":"Directory not found: Documents"}`,
+    );
+
+    client.disconnect();
+  });
 });

--- a/tests/ios-files.test.ts
+++ b/tests/ios-files.test.ts
@@ -1,0 +1,127 @@
+const mockFetch = jest.fn();
+
+jest.mock('../src/internal/proxy-transport', () => ({
+  nodeProxyTransport: {
+    fetch: (...args: unknown[]) => mockFetch(...args),
+    getWebSocketAgent: () => undefined,
+  },
+}));
+
+jest.mock('ws', () => {
+  const { EventEmitter } = require('events');
+
+  class MockWebSocket extends EventEmitter {
+    static CONNECTING = 0;
+    static OPEN = 1;
+
+    readyState = MockWebSocket.OPEN;
+
+    constructor() {
+      super();
+      process.nextTick(() => this['emit']('open'));
+    }
+
+    send(data: string, callback?: (err?: Error) => void): void {
+      const message = JSON.parse(data);
+      if (message.type === 'deviceInfo') {
+        process.nextTick(() => {
+          this['emit'](
+            'message',
+            Buffer.from(
+              JSON.stringify({
+                type: 'deviceInfoResult',
+                id: message.id,
+                udid: 'test-udid',
+                screenWidth: 390,
+                screenHeight: 844,
+                model: 'iphone',
+              }),
+            ),
+          );
+        });
+      }
+      callback?.();
+    }
+
+    ping(): void {}
+
+    close(): void {
+      this.readyState = 3;
+      this['emit']('close');
+    }
+  }
+
+  return { WebSocket: MockWebSocket };
+});
+
+describe('iOS file listing', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('lists an app data-container directory and returns pull-ready paths', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        entries: [
+          {
+            name: 'video.mov',
+            path: 'Documents/video.mov',
+            isDirectory: false,
+            size: 1234,
+          },
+        ],
+      }),
+    });
+    const { createInstanceClient } = await import('../src/ios-client');
+    const client = await createInstanceClient({
+      apiUrl: 'https://example.test/v1/ios_123/api',
+      token: 'token',
+      logLevel: 'none',
+    });
+
+    await expect(
+      client.listFiles('Documents', {
+        bundleId: 'com.example.app',
+        containerType: 'data',
+      }),
+    ).resolves.toEqual([
+      {
+        name: 'video.mov',
+        path: 'Documents/video.mov',
+        isDirectory: false,
+        size: 1234,
+      },
+    ]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.test/v1/ios_123/api/files/list?path=Documents&bundleId=com.example.app&containerType=data',
+      {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      },
+    );
+
+    client.disconnect();
+  });
+
+  it('lists the staging root without a query string', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ entries: [] }),
+    });
+    const { createInstanceClient } = await import('../src/ios-client');
+    const client = await createInstanceClient({
+      apiUrl: 'https://example.test/v1/ios_123/api',
+      token: 'token',
+      logLevel: 'none',
+    });
+
+    await expect(client.listFiles()).resolves.toEqual([]);
+    expect(mockFetch).toHaveBeenCalledWith('https://example.test/v1/ios_123/api/files/list', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    client.disconnect();
+  });
+});


### PR DESCRIPTION
## Summary
- add `client.listFiles(path?, options?)` to the iOS TypeScript client
- add `lim ios ls [path]` with the same `--bundle-id` / `--container-type` targeting as pull, push, and delete
- output pull-ready relative paths as a table or structured JSON
- document the command in the CLI README

## Test plan
- [x] `yarn test tests/ios-files.test.ts --runInBand`
- [x] `yarn lint` (format, ESLint, package builds, TypeScript, ATTW, publint)
- [x] `cd packages/cli && yarn build`
- [x] `node bin/run.js ios ls --help`

## Dependency
Requires [limrun#647](https://github.com/limrun-inc/limrun/pull/647), which adds `GET /files/list` to limulator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 89ad7c9d5f5a511191bac6b36f2eff9af3b2029d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->