### PR TITLE
feat(cli): add ios attach-xcode command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -137,6 +137,7 @@ lim ios create          # Create a new iOS instance
 lim ios list            # List all ready iOS instances
 lim ios get <ID>        # Get details of a specific instance
 lim ios delete <ID>     # Delete an instance
+lim ios attach-xcode    # Attach an Xcode target to the simulator
 lim ios info            # Get device info from a running instance
 ```
 
@@ -254,6 +255,20 @@ lim ios pull-file Documents/photo.jpeg ./photo.jpeg --bundle-id com.example.app 
 lim ios delete-file Documents/photo.jpeg --bundle-id com.example.app --container-type data
 lim ios lsof
 ```
+
+#### Xcode Attachment
+
+Attach an existing Xcode target so future simulator builds are installed automatically:
+
+```bash
+# Attach the last used Xcode target to the last used iOS simulator
+lim ios attach-xcode
+
+# Select the Xcode target and simulator explicitly
+lim ios attach-xcode sandbox_def456 --id ios_abc123
+```
+
+This is the iOS-oriented equivalent of `lim xcode attach-simulator ios_abc123 --id sandbox_def456`.
 
 #### App Management (iOS only)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
         "description": "Build Android projects on cloud gradle sandboxes"
       },
       "ios": {
-        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, keychain, record, perform, ls, push-file, pull-file, delete-file, simctl, cp, xcrun, xcodebuild, lsof, reverse"
+        "description": "Execute any task on remote iOS Simulators: create, list, get, delete, attach-xcode, info, list-apps, launch-app, terminate-app, app-log, syslog, sync, screenshot, tap, tap-element, element-tree, type, press-key, toggle-keyboard, scroll, open-url, install-app, keychain, record, perform, ls, push-file, pull-file, delete-file, simctl, cp, xcrun, xcodebuild, lsof, reverse"
       },
       "session": {
         "description": "Manage persistent background sessions for device interaction: start, status, stop. Sessions are used to execute commands on remote devices without the need to reconnect to the device after each command."

--- a/packages/cli/src/commands/ios/attach-xcode.ts
+++ b/packages/cli/src/commands/ios/attach-xcode.ts
@@ -1,0 +1,69 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { registerCreatedInstance } from '../../lib/config';
+import { formatSimulatorAttachResult, simulatorAttachJson } from '../../lib/simulator-attach';
+
+export default class IosAttachXcode extends BaseCommand {
+  static summary = 'Attach an Xcode instance to an iOS simulator';
+  static description =
+    'Attach an Xcode sandbox to an existing iOS simulator so future builds can auto-install on that simulator. ' +
+    'When the Xcode target is omitted, the LIM_XCODE_INSTANCE_URL/LIM_XCODE_INSTANCE_TOKEN pair or the last used ' +
+    'Xcode-capable target is attached; if the simulator credentials are known locally, no API key is needed.';
+
+  static examples = [
+    '<%= config.bin %> ios attach-xcode',
+    '<%= config.bin %> ios attach-xcode <xcode-instance-ID>',
+    '<%= config.bin %> ios attach-xcode <xcode-instance-ID> --id <ios-instance-ID>',
+  ];
+
+  static args = {
+    xcodeId: Args.string({
+      description: 'Xcode target to attach. Defaults to the environment-pinned or last used Xcode target.',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    create: Flags.boolean({
+      hidden: true,
+      default: false,
+      allowNo: true,
+    }),
+    id: Flags.string({
+      description: 'iOS simulator instance ID to attach. Defaults to the last used iOS simulator.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(IosAttachXcode);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const simulator = this.resolveIosInstance(flags.id);
+      const xcodeTarget = await this.resolveXcodeTarget(args.xcodeId);
+      const xcodeInstanceId = xcodeTarget.id;
+      const xcodeClient = await this.resolveXcodeClient(xcodeTarget);
+
+      let attachInput: Parameters<typeof xcodeClient.attachSimulator>[0];
+      if (simulator.apiUrl && simulator.token) {
+        attachInput = { apiUrl: simulator.apiUrl, token: simulator.token };
+      } else {
+        const instance = await this.client.iosInstances.get(simulator.id);
+        registerCreatedInstance(instance);
+        attachInput = instance;
+      }
+
+      this.info(`Attaching Xcode target ${xcodeInstanceId} to simulator ${simulator.id}...`);
+      const result = await xcodeClient.attachSimulator(attachInput);
+
+      if (flags.json) {
+        this.outputJson(simulatorAttachJson(simulator.id, xcodeInstanceId, result));
+      } else if (this.isQuietEnabled()) {
+        this.output(xcodeInstanceId);
+      } else {
+        this.output(formatSimulatorAttachResult(simulator.id, xcodeInstanceId, result));
+      }
+    });
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `lim ios attach-xcode` as the iOS-oriented counterpart to `lim xcode attach-simulator`
- support cached/environment-pinned targets, explicit instance IDs, JSON output, and quiet output
- document the command in CLI help metadata and the package README

## Testing
- `./scripts/lint`
- `yarn --cwd packages/cli build`
- `yarn --cwd packages/cli test --runInBand`
- `node packages/cli/bin/run.js ios attach-xcode --help`
- `node packages/cli/bin/run.js ios --help`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1277f7e-7a6a-4689-bd01-0d681da40a81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1277f7e-7a6a-4689-bd01-0d681da40a81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

