### PR TITLE
lim run: offer only the native sample and auto-open the simulator

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,7 +52,7 @@ The CLI stores configuration in `~/.lim/config.yaml`. This file is compatible wi
 lim run
 ```
 
-`lim run` is the fastest way to get started with Limrun. Run it inside a clear iOS or Expo project root to install the Limrun agent skills for that project and get the next prompt for your coding agent. Run it anywhere else to clone a sample app (Swift, Expo 56, or Bazel — picked interactively, Swift by default), build it on Limrun, and print a cloud simulator URL.
+`lim run` is the fastest way to get started with Limrun. Run it inside a clear iOS or Expo project root to install the Limrun agent skills for that project and get the next prompt for your coding agent. Run it anywhere else to clone the Swift sample app (`limrun-inc/sample-native-app`), build it on Limrun, and print a cloud simulator URL.
 
 ## Global Flags
 
@@ -124,7 +124,7 @@ lim run
 
 - In a clear native iOS project, it installs the Limrun iOS/Xcode skill into `.agents/skills/` and `.claude/skills/`.
 - In a clear Expo project, it installs the Limrun iOS/Xcode and Expo skills into `.agents/skills/` and `.claude/skills/`.
-- In any other directory, it asks which sample project you want to run — Swift (`limrun-inc/sample-native-app`), Expo 56 (`limrun-inc/sample-expo56-app`), or Bazel (`limrun-inc/sample-native-bazel-app`) — clones it, builds it with a Limrun iOS simulator + Xcode sandbox, and prints a simulator URL. Non-interactive sessions default to the Swift sample.
+- In any other directory, it clones the Swift sample app (`limrun-inc/sample-native-app`), builds it with a Limrun iOS simulator + Xcode sandbox, and prints a simulator URL.
 
 After setup, open your coding agent in the project and ask it to build and run the app with Limrun. For manual agent setup, use `lim skills install`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,7 +52,7 @@ The CLI stores configuration in `~/.lim/config.yaml`. This file is compatible wi
 lim run
 ```
 
-`lim run` is the fastest way to get started with Limrun. Run it inside a clear iOS or Expo project root to install the Limrun agent skills for that project and get the next prompt for your coding agent. Run it anywhere else to clone the Swift sample app (`limrun-inc/sample-native-app`), build it on Limrun, and print a cloud simulator URL.
+`lim run` is the fastest way to get started with Limrun. Run it inside a clear iOS or Expo project root to install the Limrun agent skills for that project and get the next prompt for your coding agent. Run it anywhere else to clone the Swift sample app (`limrun-inc/sample-native-app`), build it on Limrun, and open a cloud simulator in your browser.
 
 ## Global Flags
 
@@ -125,6 +125,8 @@ lim run
 - In a clear native iOS project, it installs the Limrun iOS/Xcode skill into `.agents/skills/` and `.claude/skills/`.
 - In a clear Expo project, it installs the Limrun iOS/Xcode and Expo skills into `.agents/skills/` and `.claude/skills/`.
 - In any other directory, it clones the Swift sample app (`limrun-inc/sample-native-app`), builds it with a Limrun iOS simulator + Xcode sandbox, and prints a simulator URL.
+
+Once the app is running, the simulator stream URL is opened in your browser automatically (like `lim ios create`); pass `--no-open` to only print the URL.
 
 After setup, open your coding agent in the project and ask it to build and run the app with Limrun. For manual agent setup, use `lim skills install`.
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -13,7 +13,6 @@ import {
   ensureSampleRepo,
   installProjectSkills,
   SAMPLE_APPS,
-  type SampleKind,
   type SkillInstallResult,
 } from '../lib/onboarding';
 import { captureTelemetry, telemetryErrorCategory, type TelemetryProperties } from '../lib/telemetry';
@@ -33,7 +32,6 @@ type RunFailureStage =
   | 'access_check'
   | 'skills_install'
   | 'env_setup'
-  | 'sample_selection'
   | 'sample_setup'
   | 'instance_create'
   | 'sync'
@@ -244,34 +242,9 @@ export default class Run extends BaseCommand {
     await check();
   }
 
-  private async promptSampleKind(): Promise<SampleKind> {
-    if (this.shouldSuppressInfo() || !process.stdin.isTTY || !process.stderr.isTTY) {
-      return DEFAULT_SAMPLE_KIND;
-    }
-    const response = await prompts(
-      {
-        type: 'select',
-        name: 'kind',
-        message: 'Which sample project do you want to run?',
-        choices: Object.values(SAMPLE_APPS).map((sample) => ({
-          title: sample.displayName,
-          value: sample.kind,
-        })),
-        initial: 0,
-      },
-      {
-        onCancel: () => {
-          this.error('Cancelled.');
-        },
-      },
-    );
-    return response.kind as SampleKind;
-  }
-
   private async runSampleFlow(apiKey: string, allowAuthRetry: boolean): Promise<void> {
     const cwd = process.cwd();
-    this.runFailureStage = 'sample_selection';
-    const sampleApp = SAMPLE_APPS[await this.promptSampleKind()];
+    const sampleApp = SAMPLE_APPS[DEFAULT_SAMPLE_KIND];
     this.runFailureStage = 'access_check';
     await this.reporter.withProgress('Checking Limrun access', () => this.validateAuth(allowAuthRetry));
     this.runFailureStage = 'sample_setup';
@@ -292,7 +265,7 @@ export default class Run extends BaseCommand {
         name: 'lim-go-sample',
         repo: sampleApp.dir,
       },
-      progressLabel: buildProgressLabel(sampleApp.kind === 'expo56' ? 'expo' : 'native-ios'),
+      progressLabel: buildProgressLabel('native-ios'),
       failureLabel: 'Sample build failed',
       recoveryPath: sample.path,
       recoveryFromDir: cwd,

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,7 +1,9 @@
 import os from 'os';
 import path from 'path';
 import prompts from 'prompts';
+import { Flags } from '@oclif/core';
 import { BaseCommand } from '../base-command';
+import { openInBrowser } from '../lib/browser';
 import { ProgressReporter } from '../lib/progress';
 import { readConfig, registerCreatedInstance } from '../lib/config';
 import { detectProject, type ProjectDetection } from '../lib/project-detection';
@@ -53,12 +55,21 @@ export default class Run extends BaseCommand {
     'api-key': BaseCommand.baseFlags['api-key'],
     quiet: BaseCommand.baseFlags.quiet,
   } as unknown as typeof BaseCommand.baseFlags;
+  static flags = {
+    open: Flags.boolean({
+      description:
+        'Open the simulator stream URL in your browser once the app is running. Use --no-open to skip.',
+      default: true,
+      allowNo: true,
+    }),
+  };
   static hiddenAliases = ['go'];
   static summary = 'Get started with Limrun';
   static description = 'Prepare your app for Limrun, or launch a working sample in a cloud simulator.';
   static examples = ['<%= config.bin %> run'];
   private reporter = new ProgressReporter(() => this.shouldSuppressInfo());
   private runFailureStage: RunFailureStage = 'initialization';
+  private openStream = true;
 
   async run(): Promise<void> {
     const startedAt = Date.now();
@@ -69,6 +80,7 @@ export default class Run extends BaseCommand {
       const { flags } = await this.parse(Run);
       this.setParsedFlags(flags);
       quiet = Boolean(flags.quiet);
+      this.openStream = flags.open !== false;
 
       this.runFailureStage = 'project_detection';
       const detection = detectProject(process.cwd());
@@ -174,9 +186,7 @@ export default class Run extends BaseCommand {
       recoveryFromDir: process.cwd(),
     });
 
-    this.output('');
-    this.output('✨ Click here to see your app:');
-    this.output(streamUrl);
+    await this.outputStreamUrl(streamUrl);
     this.outputNextSteps(projectRoot, 'Make a change and rebuild with Limrun skills.');
   }
 
@@ -271,9 +281,7 @@ export default class Run extends BaseCommand {
       recoveryFromDir: cwd,
     });
 
-    this.output('');
-    this.output('✨ Click here to see your app:');
-    this.output(streamUrl);
+    await this.outputStreamUrl(streamUrl);
     this.outputNextSteps(sample.path, samplePrompt());
   }
 
@@ -355,6 +363,17 @@ export default class Run extends BaseCommand {
         this.outputProjectRecovery(recoveryPath, recoveryFromDir);
       }
       throw err;
+    }
+  }
+
+  private async outputStreamUrl(streamUrl: string): Promise<void> {
+    this.output('');
+    this.output('✨ Click here to see your app:');
+    this.output(streamUrl);
+    if (this.openStream && !this.shouldSuppressInfo()) {
+      if (await openInBrowser(streamUrl)) {
+        this.info('Opened the stream in your browser.');
+      }
     }
   }
 

--- a/packages/cli/src/lib/onboarding.ts
+++ b/packages/cli/src/lib/onboarding.ts
@@ -24,7 +24,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-export type SampleKind = 'swift' | 'expo56' | 'bazel';
+export type SampleKind = 'swift';
 
 export interface SampleApp {
   kind: SampleKind;
@@ -39,18 +39,6 @@ export const SAMPLE_APPS: Record<SampleKind, SampleApp> = {
     displayName: 'Swift (native iOS)',
     repo: 'https://github.com/limrun-inc/sample-native-app',
     dir: 'sample-native-app',
-  },
-  expo56: {
-    kind: 'expo56',
-    displayName: 'Expo 56 (React Native)',
-    repo: 'https://github.com/limrun-inc/sample-expo56-app',
-    dir: 'sample-expo56-app',
-  },
-  bazel: {
-    kind: 'bazel',
-    displayName: 'Bazel (native iOS)',
-    repo: 'https://github.com/limrun-inc/sample-native-bazel-app',
-    dir: 'sample-native-bazel-app',
   },
 };
 

--- a/tests/cli-onboarding.test.ts
+++ b/tests/cli-onboarding.test.ts
@@ -10,6 +10,7 @@ import {
   ensureProjectEnvApiKey,
   installProjectSkills,
   SAMPLE_APPS,
+  type SampleApp,
 } from '../packages/cli/src/lib/onboarding';
 import type { LoadedRemoteSkills } from '../packages/cli/src/lib/remote-skills';
 
@@ -347,31 +348,6 @@ describe('lim run sample repo handling', () => {
     }
   });
 
-  test.each(['expo56', 'bazel'] as const)('clones the %s sample into its own directory', async (kind) => {
-    const root = makeTempDir();
-    const calls: Array<{ args: string[]; cwd?: string }> = [];
-    try {
-      const sample = await ensureSampleRepo({
-        cwd: root,
-        sample: SAMPLE_APPS[kind],
-        git: async (args, cwd) => {
-          calls.push(cwd === undefined ? { args } : { args, cwd });
-          return '';
-        },
-      });
-
-      expect(sample).toEqual({ path: path.join(root, SAMPLE_APPS[kind].dir), reused: false });
-      expect(calls).toEqual([
-        {
-          args: ['clone', '--depth', '1', SAMPLE_APPS[kind].repo, SAMPLE_APPS[kind].dir],
-          cwd: root,
-        },
-      ]);
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
   test('reuses existing sample dir only when origin matches', async () => {
     const root = makeTempDir();
     try {
@@ -404,21 +380,27 @@ describe('lim run sample repo handling', () => {
 
   test('verifies the reused checkout against the selected sample repository', async () => {
     const root = makeTempDir();
+    const otherSample: SampleApp = {
+      kind: 'swift',
+      displayName: 'Other sample',
+      repo: 'https://github.com/limrun-inc/other-sample-app',
+      dir: 'other-sample-app',
+    };
     try {
-      fs.mkdirSync(path.join(root, SAMPLE_APPS.expo56.dir), { recursive: true });
+      fs.mkdirSync(path.join(root, otherSample.dir), { recursive: true });
 
       await expect(
         ensureSampleRepo({
           cwd: root,
-          sample: SAMPLE_APPS.expo56,
-          git: async () => `${SAMPLE_APPS.expo56.repo}.git`,
+          sample: otherSample,
+          git: async () => `${otherSample.repo}.git`,
         }),
-      ).resolves.toEqual({ path: path.join(root, SAMPLE_APPS.expo56.dir), reused: true });
+      ).resolves.toEqual({ path: path.join(root, otherSample.dir), reused: true });
 
       await expect(
         ensureSampleRepo({
           cwd: root,
-          sample: SAMPLE_APPS.expo56,
+          sample: otherSample,
           git: async () => SAMPLE_APPS.swift.repo,
         }),
       ).rejects.toThrow('already exists with origin');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two changes to `lim run`:

1. It now offers only the Swift native sample app (`limrun-inc/sample-native-app`) as the demo. Previously it prompted users to pick between three samples (Swift native, Expo 56, Bazel).
2. Once the app is built and running, it opens the simulator stream URL in the browser automatically, matching the behavior of `lim ios create` / `lim android create`. A new `--open` flag (default true, `--no-open` to skip) controls this, and the browser is not opened in `--quiet` mode.

## Changes

- `packages/cli/src/lib/onboarding.ts`: removed the `expo56` and `bazel` entries from `SAMPLE_APPS`, narrowing `SampleKind` to `'swift'`.
- `packages/cli/src/commands/run.ts`:
  - Removed the "Which sample project do you want to run?" prompt (`promptSampleKind`) and its `sample_selection` telemetry failure stage, since there is only one sample now.
  - Added the `--[no-]open` flag and a shared `outputStreamUrl` helper that prints the stream URL and best-effort opens it via `openInBrowser` (same helper the create commands use) in both the existing-project and sample flows.
- `tests/cli-onboarding.test.ts`: removed the Expo/Bazel clone tests and reworked the reused-checkout verification test to use a local `SampleApp` fixture so the `sample` parameter coverage is preserved.
- `packages/cli/README.md`: updated the `lim run` docs for the single sample and the automatic browser open.

## Verification

- `./scripts/lint` passes (prettier, eslint, build, type checks, publint).
- `yarn jest tests/cli-onboarding.test.ts` passes (18 tests).
- `node bin/dev.js run --help` shows the new `--[no-]open` flag.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01bae-cf24-7240-84c5-bd2414dba1a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01bae-cf24-7240-84c5-bd2414dba1a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

