### PR TITLE
ci: keep PostHog key through the publish rebuild

### DIFF
--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -9,6 +9,11 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Job-level so the key survives the rebuild that `npm publish` triggers
+    # through prepublishOnly; a step-level env on Build alone gets clobbered.
+    env:
+      LIM_POSTHOG_PROJECT_KEY: ${{ secrets.LIMRUN_POSTHOG_PROJECT_KEY }}
+      LIM_POSTHOG_HOST: ${{ vars.LIMRUN_POSTHOG_HOST || 'https://l.limrun.com' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,9 +39,6 @@ jobs:
       - name: Build
         working-directory: packages/cli
         run: yarn build
-        env:
-          LIM_POSTHOG_PROJECT_KEY: ${{ secrets.LIMRUN_POSTHOG_PROJECT_KEY }}
-          LIM_POSTHOG_HOST: ${{ vars.LIMRUN_POSTHOG_HOST || 'https://l.limrun.com' }}
 
       # Authenticates via the npm trusted publisher configured for this
       # workflow (OIDC); a configured token would take precedence and fail.


### PR DESCRIPTION
## Summary
- Every published `lim` CLI shipped with an empty PostHog project key, silently no-oping all client-side telemetry (`cli_auth_started/failed`, `skills_install_*`, `cli_run_*`, `build_requested` — zero events in 30 days of production data). Verified `lim@0.28.6` from npm contains `DEFAULT_POSTHOG_PROJECT_KEY = ''`.
- Root cause: the Build step injected `LIM_POSTHOG_PROJECT_KEY`, but `npm publish` reruns the build via `prepublishOnly` → `npm run build` → `prebuild`, regenerating `telemetry-config.ts` without the step-level env and clobbering the keyed dist.
- Fix: hoist the env to the job level so the publish-time rebuild keeps the key. The `LIMRUN_POSTHOG_PROJECT_KEY` repo secret is already set.

## Test plan
- [x] `./scripts/lint` passes
- [ ] After merge: dispatch "Publish lim CLI" and verify the published tarball's `dist/lib/telemetry-config.js` contains the key
- [ ] Confirm `cli_auth_started` events appear in PostHog after the release

Made with [Cursor](https://cursor.com)