### PR TITLE
feat(cli): add --artifact-name to pin the built .app bundle filename

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -64,6 +64,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./app.mobileprovision --provisioning-profile ./widgets.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
+    '<%= config.bin %> xcode build ./MyProject --scheme "MyApp Dev" --upload myapp-dev-build --upload-product-name MyApp-dev',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
     '<%= config.bin %> xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
     '<%= config.bin %> xcode build ./MyProject --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun',
@@ -133,6 +134,10 @@ export default class XcodeBuild extends BaseCommand {
         'Relative path from the synced workspace root to the Expo app directory. Use for monorepos or ambiguous React Native workspaces.',
     }),
     upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
+    'upload-product-name': Flags.string({
+      description:
+        'Product name of the built app without the .app extension, e.g. MyApp-dev when the artifact is MyApp-dev.app. The server takes the artifact from <name>.app in the built products directory verbatim, skipping product-name discovery. Use when the scheme name differs from PRODUCT_NAME and the artifact is not found after a successful build.',
+    }),
     'upload-option': Flags.string({
       multiple: true,
       dependsOn: ['upload'],
@@ -289,6 +294,16 @@ export default class XcodeBuild extends BaseCommand {
       if (flags.sdk) settings.sdk = flags.sdk;
       if (flags.ios && !flags.sdk) settings.sdk = 'iphonesimulator';
       if (flags.configuration) settings.configuration = flags.configuration;
+      if (flags['upload-product-name']) {
+        const productName = flags['upload-product-name'];
+        if (productName.endsWith('.app')) {
+          this.error('--upload-product-name takes the product name without the .app extension.');
+        }
+        if (productName.includes('/') || productName === '.' || productName === '..') {
+          this.error('--upload-product-name must be a plain filename without path separators.');
+        }
+        settings.productName = productName;
+      }
 
       const options: XcodeBuildOptions = {};
       if (flags['git-init']) {

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -64,7 +64,7 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./app.mobileprovision --provisioning-profile ./widgets.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
     '<%= config.bin %> xcode build --signed-upload-url <url>',
-    '<%= config.bin %> xcode build ./MyProject --scheme "MyApp Dev" --upload myapp-dev-build --upload-product-name MyApp-dev',
+    '<%= config.bin %> xcode build ./MyProject --scheme "MyApp Dev" --upload myapp-dev-build --artifact-name MyApp-dev.app',
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
     '<%= config.bin %> xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
     '<%= config.bin %> xcode build ./MyProject --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun',
@@ -134,9 +134,9 @@ export default class XcodeBuild extends BaseCommand {
         'Relative path from the synced workspace root to the Expo app directory. Use for monorepos or ambiguous React Native workspaces.',
     }),
     upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
-    'upload-product-name': Flags.string({
+    'artifact-name': Flags.string({
       description:
-        'Product name of the built app without the .app extension, e.g. MyApp-dev when the artifact is MyApp-dev.app. The server takes the artifact from <name>.app in the built products directory verbatim, skipping product-name discovery. Use when the scheme name differs from PRODUCT_NAME and the artifact is not found after a successful build.',
+        'Full filename of the built app bundle including the .app extension, e.g. MyApp-dev.app. The server takes the artifact from this name in the built products directory verbatim, skipping artifact discovery. Use when the scheme name differs from the product name and the artifact is not found after a successful build.',
     }),
     'upload-option': Flags.string({
       multiple: true,
@@ -294,15 +294,15 @@ export default class XcodeBuild extends BaseCommand {
       if (flags.sdk) settings.sdk = flags.sdk;
       if (flags.ios && !flags.sdk) settings.sdk = 'iphonesimulator';
       if (flags.configuration) settings.configuration = flags.configuration;
-      if (flags['upload-product-name']) {
-        const productName = flags['upload-product-name'];
-        if (productName.endsWith('.app')) {
-          this.error('--upload-product-name takes the product name without the .app extension.');
+      if (flags['artifact-name']) {
+        const artifactName = flags['artifact-name'];
+        if (!artifactName.endsWith('.app') || artifactName === '.app') {
+          this.error('--artifact-name takes the full bundle filename ending in .app, e.g. MyApp-dev.app.');
         }
-        if (productName.includes('/') || productName === '.' || productName === '..') {
-          this.error('--upload-product-name must be a plain filename without path separators.');
+        if (artifactName.includes('/')) {
+          this.error('--artifact-name must be a plain filename without path separators.');
         }
-        settings.productName = productName;
+        settings.artifactName = artifactName;
       }
 
       const options: XcodeBuildOptions = {};

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -50,7 +50,7 @@ export type XcodeBuildExecRequest = {
     scheme?: string;
     sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos';
     configuration?: 'Debug' | 'Release';
-    productName?: string;
+    artifactName?: string;
   };
   xcodegen?: {
     spec?: string;

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -50,6 +50,7 @@ export type XcodeBuildExecRequest = {
     scheme?: string;
     sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos';
     configuration?: 'Debug' | 'Release';
+    productName?: string;
   };
   xcodegen?: {
     spec?: string;

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -106,14 +106,13 @@ export type XcodeProjectConfig = {
    */
   configuration?: 'Debug' | 'Release';
   /**
-   * Product name of the built app without the .app extension (e.g.
-   * "MyApp-dev" when the artifact is MyApp-dev.app). When set, limbuild
-   * takes the artifact from `<productName>.app` in the built products
-   * directory verbatim, skipping product-name discovery. Use when the
-   * scheme name differs from PRODUCT_NAME and discovery picks the wrong
-   * bundle.
+   * Full filename of the built app bundle, including the .app extension
+   * (e.g. "MyApp-dev.app"). When set, limbuild takes the artifact from
+   * this name in the built products directory verbatim, skipping artifact
+   * discovery. Use when the scheme name differs from the product name and
+   * discovery picks the wrong bundle.
    */
-  productName?: string;
+  artifactName?: string;
 };
 
 export type XcodeGenConfig = {

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -105,6 +105,15 @@ export type XcodeProjectConfig = {
    * Debug for native Xcode builds and Release for React Native / Expo builds.
    */
   configuration?: 'Debug' | 'Release';
+  /**
+   * Product name of the built app without the .app extension (e.g.
+   * "MyApp-dev" when the artifact is MyApp-dev.app). When set, limbuild
+   * takes the artifact from `<productName>.app` in the built products
+   * directory verbatim, skipping product-name discovery. Use when the
+   * scheme name differs from PRODUCT_NAME and discovery picks the wrong
+   * bundle.
+   */
+  productName?: string;
 };
 
 export type XcodeGenConfig = {


### PR DESCRIPTION
## Summary

- Adds `artifactName` to `XcodeProjectConfig` and the exec wire type, passed through to limbuild's new `xcodebuild.artifactName` field (limrun-inc/limrun#679): the server takes the artifact from this full bundle filename (including `.app`) in the built products directory verbatim, skipping artifact discovery.
- Adds `lim xcode build --artifact-name MyApp-dev.app` with client-side validation (must end in `.app`, no path separators) for projects whose scheme name differs from the product name. Older limbuild servers ignore the field silently, like `assetId`.

## Test plan

- [x] `./scripts/lint` (root SDK)
- [x] `yarn build` and `yarn test` in `packages/cli` (92 tests)