### PR TITLE
fix(cli): attach a simulator to the recorded Xcode target instead of recreating

### DIFF
--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -541,7 +541,7 @@ export abstract class BaseCommand extends Command {
     const id = this._overrideInstanceId ?? providedId;
     if (id) {
       const target = this.xcodeTargetFromId(id);
-      if (target.type === 'xcode' && !(await this.xcodeTargetHasAttachedSimulator(target, false))) {
+      if (target.type === 'xcode' && !(await this.xcodeTargetHasAttachedSimulator(target))) {
         throw new Error(
           `--ios requires an iOS-backed Xcode target or an Xcode instance with an attached simulator, got ${id}`,
         );
@@ -560,7 +560,7 @@ export abstract class BaseCommand extends Command {
           '--inactivity-timeout controls a newly created instance and cannot be combined with an instance pinned by LIM_XCODE_INSTANCE_URL.',
         );
       }
-      if (!(await this.xcodeTargetHasAttachedSimulator(envTarget, false))) {
+      if (!(await this.xcodeTargetHasAttachedSimulator(envTarget))) {
         throw new Error(
           `--ios requires an Xcode instance with an attached simulator, but the one pinned by LIM_XCODE_INSTANCE_URL (${envTarget.id}) has none. Attach one with: lim xcode attach-simulator`,
         );
@@ -575,13 +575,29 @@ export abstract class BaseCommand extends Command {
       this._lastResolvedInstanceId = target.id;
       return target;
     }
-    if (
-      target?.type === 'xcode' &&
-      !forceFresh &&
-      (await this.xcodeTargetHasAttachedSimulator(target, true))
-    ) {
-      this._lastResolvedInstanceId = target.id;
-      return target;
+    // The recorded Xcode target wins even when it has no simulator yet:
+    // attach one instead of abandoning it for a fresh sandbox, so a prior
+    // `lim xcode sync` or `lim xcode create` keeps all commands pointed at
+    // the same instance. Only a dead target falls through to creation.
+    if (target?.type === 'xcode' && !forceFresh) {
+      try {
+        const xcodeClient = await this.resolveXcodeClient(target);
+        const status = await xcodeClient.getSimulator();
+        if (!status.attached) {
+          // attachNewSimulator deletes the simulator itself when the attach fails.
+          const { simulator } = await xcodeClient.attachNewSimulator();
+          this._instancesCreatedThisRun.add(simulator.metadata.id);
+          saveLastCreatedInstance(simulator);
+          this.info(`Attached new simulator ${simulator.metadata.id} to Xcode target ${target.id}.`);
+        }
+        this._lastResolvedInstanceId = target.id;
+        return target;
+      } catch (err) {
+        if (!(err instanceof NotFoundError) && !this.isCachedXcodeClientNotFound(err)) {
+          throw err;
+        }
+        clearLastInstanceId(target.id);
+      }
     }
 
     if (!this.shouldAutoCreateOnNotFound()) {
@@ -597,21 +613,10 @@ export abstract class BaseCommand extends Command {
     return replacement;
   }
 
-  private async xcodeTargetHasAttachedSimulator(
-    target: LastXcodeInstance,
-    clearIfMissing: boolean,
-  ): Promise<boolean> {
-    try {
-      const xcodeClient = await this.resolveXcodeClient(target);
-      const status = await xcodeClient.getSimulator();
-      return status.attached;
-    } catch (err) {
-      if (clearIfMissing && (err instanceof NotFoundError || this.isCachedXcodeClientNotFound(err))) {
-        clearLastInstanceId(target.id);
-        return false;
-      }
-      throw err;
-    }
+  private async xcodeTargetHasAttachedSimulator(target: LastXcodeInstance): Promise<boolean> {
+    const xcodeClient = await this.resolveXcodeClient(target);
+    const status = await xcodeClient.getSimulator();
+    return status.attached;
   }
 
   private isCachedXcodeClientNotFound(err: unknown): err is Error {


### PR DESCRIPTION
## Summary
- `lim xcode build --ios` after `lim xcode sync` used to abandon the synced standalone sandbox and create a second, simulator-backed one, leaving the first to idle out.
- The recorded Xcode target now wins for all `lim xcode` operations: a live sandbox without a simulator gets one attached in place; only a dead target (404) clears the record and falls through to creating a fresh instance.
- `xcodeTargetHasAttachedSimulator` lost its `clearIfMissing` parameter since that logic moved into the resolution path.

## Test plan
- [x] Verified live: fresh cache, `lim xcode sync` auto-created a sandbox, `lim xcode build --ios` attached a simulator to that same sandbox and installed the build; no second sandbox created.
- [x] Second `lim xcode build --ios` reused the sandbox and attached simulator without creating anything.
- [x] Full test suite passes (603 tests), build and prettier clean.

Made with [Cursor](https://cursor.com)