### PR TITLE
Add TTL to build-product uploads in xcode and gradle builds

### DIFF
--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -75,7 +75,7 @@ export default class AndroidCreate extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. Defaults to no expiry.',
+        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
     }),
     open: Flags.boolean({
       description:

--- a/packages/cli/src/commands/android/install-app.ts
+++ b/packages/cli/src/commands/android/install-app.ts
@@ -33,7 +33,7 @@ export default class AndroidInstallApp extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
     }),
   };
 

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -25,7 +25,8 @@ export default class AssetPush extends BaseCommand {
     ...BaseCommand.baseFlags,
     name: Flags.string({ char: 'n', description: 'Asset name to store. Defaults to the source filename.' }),
     ttl: Flags.string({
-      description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+      description:
+        'Time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
     }),
     'upload-option': Flags.string({
       multiple: true,

--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -71,6 +71,11 @@ export default class GradleBuild extends BaseCommand {
       options: [...gradleAndroidABIs],
     }),
     upload: Flags.string({ description: 'Upload the resulting APK or AAB as an asset with this name' }),
+    'upload-ttl': Flags.string({
+      dependsOn: ['upload'],
+      description:
+        'TTL of the uploaded asset as a Go duration (e.g. 24h, 30m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+    }),
     'signed-upload-url': Flags.string({
       description: 'Presigned URL to upload the resulting APK or AAB to.',
     }),

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -98,7 +98,7 @@ export default class IosCreate extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. Defaults to no expiry.',
+        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
     }),
     xcode: Flags.boolean({
       description: 'Enable an attached Xcode sandbox for build and sync workflows',

--- a/packages/cli/src/commands/ios/install-app.ts
+++ b/packages/cli/src/commands/ios/install-app.ts
@@ -45,7 +45,7 @@ export default class IosInstallApp extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
     }),
   };
 

--- a/packages/cli/src/commands/ios/keychain/save.ts
+++ b/packages/cli/src/commands/ios/keychain/save.ts
@@ -43,7 +43,8 @@ export default class IosKeychainSave extends BaseCommand {
       description: `Asset name to store the saved keychain under. Defaults to ${DEFAULT_KEYCHAIN_ASSET_NAME}. Prefer the positional <asset-name> argument.`,
     }),
     ttl: Flags.string({
-      description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
+      description:
+        'Time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
     }),
     'encryption-key': Flags.string({
       description:

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -134,6 +134,11 @@ export default class XcodeBuild extends BaseCommand {
         'Relative path from the synced workspace root to the Expo app directory. Use for monorepos or ambiguous React Native workspaces.',
     }),
     upload: Flags.string({ description: 'Upload the resulting build artifact as an asset with this name' }),
+    'upload-ttl': Flags.string({
+      dependsOn: ['upload'],
+      description:
+        'TTL of the uploaded asset as a Go duration (e.g. 24h, 30m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+    }),
     'artifact-name': Flags.string({
       description:
         'Full filename of the built app bundle including the .app extension, e.g. MyApp-dev.app. The server takes the artifact from this name in the built products directory verbatim, skipping artifact discovery. Use when the scheme name differs from the product name and the artifact is not found after a successful build.',
@@ -376,7 +381,11 @@ export default class XcodeBuild extends BaseCommand {
         } catch (err) {
           this.error(err instanceof Error ? err.message : String(err));
         }
-        options.upload = { assetName: flags.upload, ...(uploadOptions && { uploadOptions }) };
+        options.upload = {
+          assetName: flags.upload,
+          ...(flags['upload-ttl'] && { ttl: flags['upload-ttl'] }),
+          ...(uploadOptions && { uploadOptions }),
+        };
       } else if (flags['signed-upload-url']) {
         options.upload = {
           signedUploadUrl: flags['signed-upload-url'],

--- a/packages/cli/src/lib/gradle-build-options.ts
+++ b/packages/cli/src/lib/gradle-build-options.ts
@@ -20,6 +20,7 @@ export interface GradleBuildFlagValues extends WebhookFlagValues {
   'expo-app-dir'?: string;
   abi?: string[];
   upload?: string;
+  'upload-ttl'?: string;
   'signed-upload-url'?: string;
   sign?: boolean;
   'application-id'?: string;
@@ -167,7 +168,10 @@ export function gradleBuildOptionsFromFlags(flags: GradleBuildFlagValues): Gradl
     };
   }
   if (flags.upload) {
-    options.upload = { assetName: flags.upload };
+    options.upload = {
+      assetName: flags.upload,
+      ...(flags['upload-ttl'] && { ttl: flags['upload-ttl'] }),
+    };
   } else if (flags['signed-upload-url']) {
     options.upload = { signedUploadUrl: flags['signed-upload-url'] };
   }

--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -20,8 +20,9 @@ export interface AssetGetOrUploadParams {
 
   /**
    * Optional time-to-live as a Go duration string (e.g. "24h"). When set, the asset is deleted
-   * this long after now; minimum is 1m. Omit for no expiry. On re-upload of an existing asset,
-   * a value updates the expiry while omitting it leaves the current expiry unchanged.
+   * this long after now; minimum is 1m. When omitted, a newly created asset expires 14 days
+   * after now. On re-upload of an existing asset, a value updates the expiry while omitting
+   * it leaves the current expiry unchanged.
    */
   ttl?: string;
 

--- a/src/resources/assets.ts
+++ b/src/resources/assets.ts
@@ -183,9 +183,9 @@ export interface AssetGetOrCreateParams {
 
   /**
    * Optional time-to-live as a Go duration string (e.g. "24h"). When set, the asset
-   * is deleted this long after now; minimum is 1m. Omit for no expiry. On re-upload
-   * of an existing asset, a value updates the expiry while omitting it leaves the
-   * current expiry unchanged.
+   * is deleted this long after now; minimum is 1m. When omitted, a newly created
+   * asset expires 336h (14 days) after now. On re-upload of an existing asset, a
+   * value updates the expiry while omitting it leaves the current expiry unchanged.
    */
   ttl?: string;
 

--- a/src/resources/gradle-instances-helpers.ts
+++ b/src/resources/gradle-instances-helpers.ts
@@ -56,7 +56,19 @@ export type GradleBuildOptions = {
   /** Relative path to the Gradle root when auto-discovery is ambiguous. */
   projectPath?: string;
   /** Upload the built artifact as a named org asset, or to a presigned URL. */
-  upload?: { assetName: string; signedUploadUrl?: never } | { signedUploadUrl: string; assetName?: never };
+  upload?:
+    | {
+        assetName: string;
+        /**
+         * Asset TTL as a Go duration (e.g. "24h", "30m"; "1d" is invalid),
+         * forwarded to assets.getOrCreate. When omitted, a newly created
+         * asset expires 14 days after upload; re-uploads keep the asset's
+         * current expiry.
+         */
+        ttl?: string;
+        signedUploadUrl?: never;
+      }
+    | { signedUploadUrl: string; assetName?: never; ttl?: never };
   /** React Native / Expo tuning. */
   reactNative?: GradleReactNativeConfig;
   /** Release signing config; presence makes bundleRelease the default task. */
@@ -183,13 +195,15 @@ class GradleInstancesHelpers extends GradleInstances {
         };
 
         if (options?.upload && 'assetName' in options.upload) {
-          const requestPromise = mintAssetUploadUrls(client.assets, options.upload.assetName).then(
-            (asset) => {
-              request.signedUploadUrl = asset.signedUploadUrl;
-              request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
-              return request;
-            },
-          );
+          const requestPromise = mintAssetUploadUrls(
+            client.assets,
+            options.upload.assetName,
+            options.upload.ttl,
+          ).then((asset) => {
+            request.signedUploadUrl = asset.signedUploadUrl;
+            request.additionalMetadata = { signedDownloadUrl: asset.signedDownloadUrl };
+            return request;
+          });
           return exec(requestPromise, { apiUrl, token, log });
         }
 

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -188,6 +188,13 @@ export type XcodeBuildOptions = {
     | {
         assetName: string;
         /**
+         * Asset TTL as a Go duration (e.g. "24h", "30m"; "1d" is invalid),
+         * forwarded to assets.getOrCreate. When omitted, a newly created
+         * asset expires 14 days after upload; re-uploads keep the asset's
+         * current expiry.
+         */
+        ttl?: string;
+        /**
          * App metadata to record on the asset up front. limbuild extracts
          * the same metadata from the built bundle after the build and
          * overwrites whatever it found; values set here survive only for
@@ -829,7 +836,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           const requestPromise = mintAssetUploadUrls(
             client.assets,
             options.upload.assetName,
-            undefined,
+            options.upload.ttl,
             options.upload.uploadOptions,
           ).then((asset) => {
             request.signedUploadUrl = asset.signedUploadUrl;

--- a/tests/cli-gradle-build-options.test.ts
+++ b/tests/cli-gradle-build-options.test.ts
@@ -55,6 +55,12 @@ test('tasks, project path, and upload map through', () => {
   });
 });
 
+test('upload-ttl maps onto the upload asset', () => {
+  expect(gradleBuildOptionsFromFlags({ upload: 'app.apk', 'upload-ttl': '24h' })).toEqual({
+    upload: { assetName: 'app.apk', ttl: '24h' },
+  });
+});
+
 // Play Store flag validation rides the same pre-instance contract as
 // signing: contradictions throw here, never after an instance was billed.
 // The service-account file read and playstore assembly live in the

--- a/tests/gradle-client-build.test.ts
+++ b/tests/gradle-client-build.test.ts
@@ -195,15 +195,16 @@ test('gradlebuild --upload mints asset URLs before posting exec', async () => {
   });
 
   const client = new Limrun({ apiKey: 'key' });
-  jest.spyOn(client.assets, 'getOrCreate').mockResolvedValue({
+  const getOrCreate = jest.spyOn(client.assets, 'getOrCreate').mockResolvedValue({
     signedUploadUrl: 'https://storage.example.com/up',
     signedDownloadUrl: 'https://storage.example.com/down',
   } as never);
   const gradle = await client.gradleInstances.createClient({ apiUrl: API_URL, token: TOKEN });
 
-  const result = await gradle.gradlebuild({ upload: { assetName: 'myapp.apk' } });
+  const result = await gradle.gradlebuild({ upload: { assetName: 'myapp.apk', ttl: '24h' } });
   expect(result.exitCode).toBe(0);
   expect(result.signedDownloadUrl).toBe('https://storage.example.com/down');
+  expect(getOrCreate).toHaveBeenCalledWith({ name: 'myapp.apk', ttl: '24h' });
 
   const execReq = requests.find((r) => r.url.endsWith('/exec'));
   // Exact match: the client-only additionalMetadata (signedDownloadUrl) must


### PR DESCRIPTION
## Summary
- Build-product uploads now default to a 14-day asset TTL, applied in `mintAssetUploadUrls` — the single helper all build-product upload paths (`xcodebuild`, `gradlebuild`, RBE) go through. Each build upload without an explicit ttl pushes the asset's expiry to 14 days from that upload, so actively rebuilt assets (e.g. PR previews) stay alive while abandoned ones get swept.
- The general asset API is untouched: `lim asset push`, keychain saves, and `--install` uploads keep no expiry by default.
- Adds a `ttl` option to the `assetName` upload form of `xcodebuild` and `gradlebuild` (RBE uploads already had it) and exposes it as `--upload-ttl` on `lim xcode build` and `lim gradle build`.

No server change needed: the asset record and its expiry are created by this SDK when it mints the presigned upload URL for the build daemons (limrun-inc/limrun#682 was closed in favor of this).

## Test plan
- [x] `yarn jest tests/` (604 passed, incl. default-ttl and explicit-ttl plumbing assertions)
- [x] `yarn --cwd packages/cli test` (92 passed)
- [x] `./scripts/lint`