### PR TITLE
Scope the default 14-day asset TTL to build-product uploads

### DIFF
--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -75,7 +75,7 @@ export default class AndroidCreate extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. Defaults to no expiry.',
     }),
     open: Flags.boolean({
       description:

--- a/packages/cli/src/commands/android/install-app.ts
+++ b/packages/cli/src/commands/android/install-app.ts
@@ -33,7 +33,7 @@ export default class AndroidInstallApp extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
     }),
   };
 

--- a/packages/cli/src/commands/asset/push.ts
+++ b/packages/cli/src/commands/asset/push.ts
@@ -25,8 +25,7 @@ export default class AssetPush extends BaseCommand {
     ...BaseCommand.baseFlags,
     name: Flags.string({ char: 'n', description: 'Asset name to store. Defaults to the source filename.' }),
     ttl: Flags.string({
-      description:
-        'Time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+      description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
     }),
     'upload-option': Flags.string({
       multiple: true,

--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -74,7 +74,7 @@ export default class GradleBuild extends BaseCommand {
     'upload-ttl': Flags.string({
       dependsOn: ['upload'],
       description:
-        'TTL of the uploaded asset as a Go duration (e.g. 24h, 30m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+        "TTL of the uploaded asset as a Go duration (e.g. 24h, 30m). Defaults to 336h (14 days); each build upload pushes the asset's expiry that far out from the upload.",
     }),
     'signed-upload-url': Flags.string({
       description: 'Presigned URL to upload the resulting APK or AAB to.',

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -98,7 +98,7 @@ export default class IosCreate extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+        'Asset time-to-live for files uploaded via --install, as a Go duration (e.g. "24h", min 1m). Does not affect --install-asset. Defaults to no expiry.',
     }),
     xcode: Flags.boolean({
       description: 'Enable an attached Xcode sandbox for build and sync workflows',

--- a/packages/cli/src/commands/ios/install-app.ts
+++ b/packages/cli/src/commands/ios/install-app.ts
@@ -45,7 +45,7 @@ export default class IosInstallApp extends BaseCommand {
     }),
     'asset-ttl': Flags.string({
       description:
-        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+        'When uploading a local file, set its asset time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
     }),
   };
 

--- a/packages/cli/src/commands/ios/keychain/save.ts
+++ b/packages/cli/src/commands/ios/keychain/save.ts
@@ -43,8 +43,7 @@ export default class IosKeychainSave extends BaseCommand {
       description: `Asset name to store the saved keychain under. Defaults to ${DEFAULT_KEYCHAIN_ASSET_NAME}. Prefer the positional <asset-name> argument.`,
     }),
     ttl: Flags.string({
-      description:
-        'Time-to-live as a Go duration (e.g. "24h", min 1m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+      description: 'Time-to-live as a Go duration (e.g. "24h", min 1m). Defaults to no expiry.',
     }),
     'encryption-key': Flags.string({
       description:

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -137,7 +137,7 @@ export default class XcodeBuild extends BaseCommand {
     'upload-ttl': Flags.string({
       dependsOn: ['upload'],
       description:
-        'TTL of the uploaded asset as a Go duration (e.g. 24h, 30m). When omitted, a newly created asset expires 14 days after upload; re-uploads keep the current expiry.',
+        "TTL of the uploaded asset as a Go duration (e.g. 24h, 30m). Defaults to 336h (14 days); each build upload pushes the asset's expiry that far out from the upload.",
     }),
     'artifact-name': Flags.string({
       description:

--- a/packages/cli/src/commands/xcode/rbe/index.ts
+++ b/packages/cli/src/commands/xcode/rbe/index.ts
@@ -73,7 +73,8 @@ export default class XcodeRbe extends BaseCommand {
       exclusive: ['stop'],
     }),
     'upload-ttl': Flags.string({
-      description: 'Asset TTL for --auto-upload as a Go duration (e.g. 24h, 30m).',
+      description:
+        "Asset TTL for --auto-upload as a Go duration (e.g. 24h, 30m). Defaults to 336h (14 days); each upload pushes the asset's expiry that far out from the upload.",
       dependsOn: ['auto-upload'],
     }),
     ios: Flags.boolean({

--- a/packages/cli/src/commands/xcode/rbe/upload.ts
+++ b/packages/cli/src/commands/xcode/rbe/upload.ts
@@ -34,7 +34,8 @@ export default class XcodeRbeUpload extends BaseCommand {
       hidden: true,
     }),
     ttl: Flags.string({
-      description: 'Asset TTL as a Go duration (e.g. 24h, 30m).',
+      description:
+        "Asset TTL as a Go duration (e.g. 24h, 30m). Defaults to 336h (14 days); each upload pushes the asset's expiry that far out from the upload.",
     }),
   };
 

--- a/src/resources/assets-helpers.ts
+++ b/src/resources/assets-helpers.ts
@@ -20,9 +20,8 @@ export interface AssetGetOrUploadParams {
 
   /**
    * Optional time-to-live as a Go duration string (e.g. "24h"). When set, the asset is deleted
-   * this long after now; minimum is 1m. When omitted, a newly created asset expires 14 days
-   * after now. On re-upload of an existing asset, a value updates the expiry while omitting
-   * it leaves the current expiry unchanged.
+   * this long after now; minimum is 1m. Omit for no expiry. On re-upload of an existing asset,
+   * a value updates the expiry while omitting it leaves the current expiry unchanged.
    */
   ttl?: string;
 

--- a/src/resources/assets.ts
+++ b/src/resources/assets.ts
@@ -183,9 +183,9 @@ export interface AssetGetOrCreateParams {
 
   /**
    * Optional time-to-live as a Go duration string (e.g. "24h"). When set, the asset
-   * is deleted this long after now; minimum is 1m. When omitted, a newly created
-   * asset expires 336h (14 days) after now. On re-upload of an existing asset, a
-   * value updates the expiry while omitting it leaves the current expiry unchanged.
+   * is deleted this long after now; minimum is 1m. Omit for no expiry. On re-upload
+   * of an existing asset, a value updates the expiry while omitting it leaves the
+   * current expiry unchanged.
    */
   ttl?: string;
 

--- a/src/resources/daemon-client-shared.ts
+++ b/src/resources/daemon-client-shared.ts
@@ -89,8 +89,18 @@ export type AssetUploadOptions = {
 };
 
 /**
+ * Default TTL for build-product uploads. Every build upload without an
+ * explicit ttl pushes the asset's expiry to 14 days from that upload, so
+ * abandoned build artifacts don't accumulate in Asset Storage forever.
+ * Assets uploaded through the general asset API keep no expiry by default.
+ */
+export const DEFAULT_BUILD_ASSET_TTL = '336h';
+
+/**
  * Mints presigned upload/download URLs for a named asset via assets.getOrCreate,
  * wrapping failures with the asset name (and the original error as cause).
+ * All build-product upload paths (xcodebuild, gradlebuild, RBE) go through
+ * here, which is what scopes DEFAULT_BUILD_ASSET_TTL to build uploads.
  */
 export function mintAssetUploadUrls(
   assets: {
@@ -100,7 +110,7 @@ export function mintAssetUploadUrls(
   ttl?: string,
   uploadOptions?: AssetUploadOptions,
 ): Promise<AssetUploadUrls> {
-  return assets.getOrCreate({ name, ...(ttl && { ttl }), ...uploadOptions }).catch((err) => {
+  return assets.getOrCreate({ name, ttl: ttl || DEFAULT_BUILD_ASSET_TTL, ...uploadOptions }).catch((err) => {
     const message = `Failed to create upload URL for asset '${name}': ${
       err instanceof Error ? err.message : err
     }`;

--- a/src/resources/gradle-instances-helpers.ts
+++ b/src/resources/gradle-instances-helpers.ts
@@ -61,9 +61,9 @@ export type GradleBuildOptions = {
         assetName: string;
         /**
          * Asset TTL as a Go duration (e.g. "24h", "30m"; "1d" is invalid),
-         * forwarded to assets.getOrCreate. When omitted, a newly created
-         * asset expires 14 days after upload; re-uploads keep the asset's
-         * current expiry.
+         * forwarded to assets.getOrCreate. Defaults to 336h (14 days): each
+         * build upload without an explicit ttl pushes the asset's expiry to
+         * 14 days from that upload.
          */
         ttl?: string;
         signedUploadUrl?: never;

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -189,9 +189,9 @@ export type XcodeBuildOptions = {
         assetName: string;
         /**
          * Asset TTL as a Go duration (e.g. "24h", "30m"; "1d" is invalid),
-         * forwarded to assets.getOrCreate. When omitted, a newly created
-         * asset expires 14 days after upload; re-uploads keep the asset's
-         * current expiry.
+         * forwarded to assets.getOrCreate. Defaults to 336h (14 days): each
+         * build upload without an explicit ttl pushes the asset's expiry to
+         * 14 days from that upload.
          */
         ttl?: string;
         /**
@@ -338,7 +338,12 @@ export type RbeUploadOptions =
   | {
       /** Upload as a named asset: the SDK mints the presigned upload URL via assets.getOrCreate. */
       assetName: string;
-      /** Optional asset TTL as a Go duration (e.g. "24h", "30m"; "1d" is invalid), forwarded to assets.getOrCreate. */
+      /**
+       * Optional asset TTL as a Go duration (e.g. "24h", "30m"; "1d" is
+       * invalid), forwarded to assets.getOrCreate. Defaults to 336h (14
+       * days): each upload without an explicit ttl pushes the asset's
+       * expiry to 14 days from that upload.
+       */
       ttl?: string;
       signedUploadUrl?: never;
     }

--- a/tests/gradle-client-build.test.ts
+++ b/tests/gradle-client-build.test.ts
@@ -206,6 +206,10 @@ test('gradlebuild --upload mints asset URLs before posting exec', async () => {
   expect(result.signedDownloadUrl).toBe('https://storage.example.com/down');
   expect(getOrCreate).toHaveBeenCalledWith({ name: 'myapp.apk', ttl: '24h' });
 
+  // An omitted ttl falls back to the build-upload default of 14 days.
+  await gradle.gradlebuild({ upload: { assetName: 'myapp.apk' } });
+  expect(getOrCreate).toHaveBeenLastCalledWith({ name: 'myapp.apk', ttl: '336h' });
+
   const execReq = requests.find((r) => r.url.endsWith('/exec'));
   // Exact match: the client-only additionalMetadata (signedDownloadUrl) must
   // stay OFF the wire; toMatchObject would pass even if it leaked.


### PR DESCRIPTION
## Summary
Follow-up to #336, which merged before this correction landed on its branch.

- The 14-day default TTL now lives in `mintAssetUploadUrls` — the single helper all build-product upload paths (`xcodebuild`, `gradlebuild`, RBE) go through — instead of relying on a general asset API default (limrun-inc/limrun#682 was closed unmerged, so without this commit the default documented in #336 doesn't exist anywhere). Each build upload without an explicit ttl pushes the asset's expiry to 14 days from that upload.
- Restores the "defaults to no expiry" wording on the general asset commands (`asset push`, keychain save, install-app, create `--asset-ttl`), which are unaffected.
- Updates the `--upload-ttl` / RBE ttl descriptions to the sliding-window semantics.

## Test plan
- [x] `yarn jest tests/` (604 passed, incl. a new assertion that an omitted ttl reaches `getOrCreate` as `336h`)
- [x] `yarn --cwd packages/cli test` (92 passed)
- [x] `./scripts/lint`

Made with [Cursor](https://cursor.com)