### PR TITLE
Add Android camera/microphone simulation parity with iOS

### DIFF
--- a/packages/cli/src/commands/android/camera.ts
+++ b/packages/cli/src/commands/android/camera.ts
@@ -1,0 +1,117 @@
+import fs from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
+
+const REMOTE_VIDEO_DIR = '/data/local/tmp';
+
+export default class AndroidCamera extends BaseCommand {
+  static summary = 'Control the simulated camera of a running Android instance';
+  static description =
+    'Upload a local video file with ADB and play it as the camera feed of a running Android instance, replacing the live browser camera. ' +
+    'Apps see the video through the regular Camera2 pipeline; if the video has an audio track it is forwarded to the mock microphone in sync. ' +
+    'By default the video loops; with --no-loop it plays once and the feed freezes on the last frame. ' +
+    'Use the `clear` action to restore the default camera source.';
+  static examples = [
+    '<%= config.bin %> android camera play ./fixtures/qr-scan.mp4',
+    '<%= config.bin %> android camera play ./clip.mp4 --no-loop --id <instance-ID>',
+    '<%= config.bin %> android camera clear',
+  ];
+
+  static args = {
+    action: Args.string({
+      description:
+        'Camera action: `play` plays a video file as the camera and `clear` restores the default camera',
+      required: true,
+      options: ['play', 'clear'],
+    }),
+    path: Args.string({
+      description: 'Local video file to play as the camera (required for the `play` action).',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'Android instance ID to target. Defaults to the last created Android instance.',
+    }),
+    loop: Flags.boolean({
+      description: 'Restart the video when it ends. Use --no-loop to play once and freeze on the last frame.',
+      default: true,
+      allowNo: true,
+    }),
+    'adb-path': Flags.string({
+      description: 'Path to the adb binary available on your machine',
+      default: 'adb',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(AndroidCamera);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveAndroidInstance(flags.id);
+      const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance, {
+        adbPath: flags['adb-path'],
+      });
+
+      let tunnel: Awaited<ReturnType<typeof client.startAdbTunnel>> | undefined;
+      try {
+        if (args.action === 'clear') {
+          await client.clearCameraVideo();
+          if (flags.json) {
+            this.outputJson({ ok: true });
+          } else {
+            this.output('Camera restored to the default source.');
+          }
+          return;
+        }
+
+        if (!args.path) {
+          this.error('The `play` action requires a video file path.');
+        }
+        const localPath = path.resolve(args.path);
+        if (!fs.existsSync(localPath)) {
+          this.error(`File not found: ${localPath}`);
+        }
+        const stat = fs.statSync(localPath);
+        if (!stat.isFile()) {
+          this.error(`Path is not a file: ${localPath}`);
+        }
+
+        const remotePath = `${REMOTE_VIDEO_DIR}/${path.basename(localPath)}`;
+        tunnel = await client.startAdbTunnel();
+        const serial = `${tunnel.address.address}:${tunnel.address.port}`;
+        this.info(`Pushing ${path.basename(localPath)} to ${remotePath}...`);
+        await this.execAdb(flags['adb-path'], ['-s', serial, 'push', localPath, remotePath]);
+
+        await client.setCameraVideo(remotePath, { loop: flags.loop });
+        if (flags.json) {
+          this.outputJson({ ok: true, loop: flags.loop });
+        } else {
+          this.output(`Playing ${remotePath} as the camera${flags.loop ? ' on loop' : ' once'}.`);
+        }
+      } finally {
+        tunnel?.close();
+        disconnect();
+      }
+    });
+  }
+
+  private execAdb(adbPath: string, args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      execFile(adbPath, args, (error, stdout, stderr) => {
+        if (error) {
+          const output = `${stdout}${stderr}`.trim();
+          reject(new Error(output ? `${error.message}: ${output}` : error.message));
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}

--- a/packages/cli/src/commands/android/play-on-microphone.ts
+++ b/packages/cli/src/commands/android/play-on-microphone.ts
@@ -71,9 +71,7 @@ export default class AndroidPlayOnMicrophone extends BaseCommand {
         if (flags.json) {
           this.outputJson(result);
         } else {
-          this.log(
-            `Playing ${remotePath} on microphone (duration=${result.duration}us, once=${result.once}, generation=${result.generation})`,
-          );
+          this.log(`Playing ${remotePath} on microphone (duration=${result.duration}us, once=${result.once})`);
         }
       } finally {
         tunnel?.close();

--- a/packages/cli/src/commands/android/stop-microphone-playback.ts
+++ b/packages/cli/src/commands/android/stop-microphone-playback.ts
@@ -1,0 +1,41 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
+
+export default class AndroidStopMicrophonePlayback extends BaseCommand {
+  static summary = 'Stop mocked microphone playback on a running Android instance';
+  static description =
+    'Stops audio started with `android play-on-microphone`; the microphone goes back to silence (or the live WebRTC microphone when one is attached).';
+
+  static examples = [
+    '<%= config.bin %> android stop-microphone-playback',
+    '<%= config.bin %> android stop-microphone-playback --id <instance-ID>',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'Android instance ID to target. Defaults to the last created Android instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(AndroidStopMicrophonePlayback);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveAndroidInstance(flags.id);
+      const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
+      try {
+        await client.stopMicrophonePlayback();
+        if (flags.json) {
+          this.outputJson({ stopped: true });
+        } else {
+          this.output('Stopped microphone playback');
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -176,8 +176,8 @@ interface RemoteControlProps {
    * mode. Use it to render a richer status indicator (e.g.
    * "Camera · 1920×1080 · 30 fps · FaceTime HD").
    *
-   * Only iOS instances ever fire this callback; Android instances
-   * have no camera-injector path and stay silent.
+   * Fires on both platforms: limulator drives it on iOS, and
+   * scrcpy-webrtc's virtual camera relay drives it on Android 15.
    */
   onCameraDemandChange?: (active: boolean, granted?: boolean, camera?: CameraCaptureInfo) => void;
 
@@ -235,14 +235,15 @@ interface RemoteControlProps {
   cameraAspect?: CameraAspect;
 
   /**
-   * iOS only: when true, capture the user's microphone via
+   * When true, capture the user's microphone via
    * `getUserMedia({ audio: true })` and stream it live into the
    * simulator's mock microphone. This is a manual override: iOS apps
    * that actively consume microphone input also trigger capture
    * automatically, like camera demand. The component handles the
    * browser permission prompt, WebRTC track attachment, and
    * `microphoneStart`/`microphoneStop` signaling. Progress and failures
-   * are reported via `onMicrophoneStateChange`. Ignored on Android.
+   * are reported via `onMicrophoneStateChange`. Works on iOS simulators
+   * and Android 15 instances.
    */
   microphoneEnabled?: boolean;
 
@@ -639,7 +640,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       packetsSent?: number;
       packetsLost?: number;
     } | null>(null);
-    // Outbound microphone state (iOS only). The manual prop and guest-driven
+    // Outbound microphone state. The manual prop and guest-driven
     // microphoneRequest signals share one pre-allocated audio transceiver.
     const microphoneEnabledRef = useRef(microphoneEnabled);
     microphoneEnabledRef.current = microphoneEnabled;
@@ -1931,7 +1932,6 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // handler firing on both `connected` and `completed`) must not
     // cancel an attach already in flight; only detach/teardown cancel.
     const attachMicrophone = (): Promise<void> => {
-      if (platform !== 'ios') return Promise.resolve();
       return runMicOp(() => attachMicrophoneOp());
     };
 
@@ -2519,33 +2519,25 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         const videoTransceiver = peerConnection.addTransceiver('video', { direction: 'recvonly' });
 
         // Pre-allocate a sendonly slot for the user's camera so the
-        // sim can pull frames later without renegotiating SDP.
+        // device can pull frames later without renegotiating SDP.
         // Allocating up-front means we don't have to renegotiate the
-        // SDP when the simulator app actually opens its
-        // `AVCaptureSession` — the codec/SSRC negotiation happens
-        // once, here, and turning the camera on/off later is just a
-        // `replaceTrack`.
-        // iOS only: Android has no camera consumer, and the extra
-        // m=video line crashes Android 14's scrcpy/libwebrtc.
-        const outboundCameraTransceiver =
-          platform === 'ios' ?
-            peerConnection.addTransceiver('video', {
-              direction: 'sendonly',
-            })
-          : null;
-        outboundCameraSenderRef.current = outboundCameraTransceiver?.sender ?? null;
+        // SDP when an app actually opens its camera — the codec/SSRC
+        // negotiation happens once, here, and turning the camera
+        // on/off later is just a `replaceTrack`. Both platforms speak
+        // the same cameraRequest/cameraResult protocol (limulator on
+        // iOS, scrcpy-webrtc's virtual camera relay on Android 15).
+        const outboundCameraTransceiver = peerConnection.addTransceiver('video', {
+          direction: 'sendonly',
+        });
+        outboundCameraSenderRef.current = outboundCameraTransceiver.sender;
 
         // Same pre-allocation for the live microphone: a sendonly audio
         // slot negotiated once at connection setup, so toggling the mic
-        // later is just `replaceTrack` — no SDP renegotiation. iOS only,
-        // like the camera.
-        const outboundMicTransceiver =
-          platform === 'ios' ?
-            peerConnection.addTransceiver('audio', {
-              direction: 'sendonly',
-            })
-          : null;
-        outboundMicSenderRef.current = outboundMicTransceiver?.sender ?? null;
+        // later is just `replaceTrack` — no SDP renegotiation.
+        const outboundMicTransceiver = peerConnection.addTransceiver('audio', {
+          direction: 'sendonly',
+        });
+        outboundMicSenderRef.current = outboundMicTransceiver.sender;
 
         // As hardware encoder, we use H265 for iOS and VP9 for Android.
         // We make sure these two are the first ones in the list.
@@ -2934,12 +2926,11 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               pendingScreenshotRejectersRef.current.delete(message.id);
               break;
             case 'cameraRequest': {
-              // Only iOS sessions allocate the sendonly outbound-camera
-              // transceiver; without it there is nothing to feed the sim, so
-              // ignore camera requests entirely — no getUserMedia prompt and
-              // no onCameraDemandChange callbacks. Android intentionally stays
-              // silent, as the API docs promise.
-              if (platform !== 'ios' || !outboundCameraSenderRef.current) {
+              // Without the pre-allocated sendonly outbound-camera
+              // transceiver there is nothing to feed the device, so ignore
+              // camera requests entirely — no getUserMedia prompt and no
+              // onCameraDemandChange callbacks.
+              if (!outboundCameraSenderRef.current) {
                 break;
               }
               const active = message.active === true;

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -156,6 +156,30 @@ export type InstanceClient = {
    */
   playOnMicrophone: (path: string, options?: PlayOnMicrophoneOptions) => Promise<PlayOnMicrophoneResult>;
   /**
+   * Stop mock-microphone file playback, if any. The microphone returns to the
+   * live WebRTC source when one is attached, otherwise silence.
+   */
+  stopMicrophonePlayback: () => Promise<void>;
+  /**
+   * Get the current mock-microphone state.
+   */
+  microphoneStatus: () => Promise<MicrophoneStatus>;
+  /**
+   * Play an on-device video file as the camera feed, replacing the live
+   * WebRTC camera until {@link clearCameraVideo} is called. If the video has
+   * an audio track, it is forwarded to the mock microphone in sync.
+   *
+   * The file must already exist on the Android instance, for example after
+   * pushing it with ADB. By default the video loops; with `loop: false` it
+   * plays once and the feed freezes on the last frame.
+   */
+  setCameraVideo: (path: string, options?: CameraVideoOptions) => Promise<void>;
+  /**
+   * Stop video-file camera playback and restore the default WebRTC camera
+   * source. Safe to call when no video is playing.
+   */
+  clearCameraVideo: () => Promise<void>;
+  /**
    * Set Android Wi-Fi bandwidth limits in Kbps. Omit a direction to leave it unchanged;
    * pass `0` to clear that direction's limit.
    */
@@ -447,7 +471,20 @@ export type PlayOnMicrophoneResult = {
   /** Duration of the decoded audio in microseconds. */
   duration: number;
   once: boolean;
-  generation: number;
+};
+
+/** Mock-microphone state returned by {@link InstanceClient.microphoneStatus}. */
+export type MicrophoneStatus = {
+  /** Active audio source. */
+  source: 'silence' | 'file' | 'webrtcMic';
+  /** Path of the currently playing file, when source is `file`. */
+  filePath?: string;
+};
+
+/** Options for {@link InstanceClient.setCameraVideo}. */
+export type CameraVideoOptions = {
+  /** Restart the video when it ends. Defaults to true. */
+  loop?: boolean;
 };
 
 export type WifiBandwidthOptions = {
@@ -589,6 +626,28 @@ type PlayOnMicrophoneResultMessage = {
   error?: CommandError;
 };
 
+type StopMicrophonePlaybackResultMessage = {
+  type: 'stopMicrophonePlaybackResult';
+  id: string;
+  payload?: EmptyCommandResult;
+  error?: CommandError;
+};
+
+type MicrophoneStatusResultMessage = {
+  type: 'microphoneStatusResult';
+  id: string;
+  status?: MicrophoneStatus;
+  payload?: { status?: MicrophoneStatus };
+  error?: CommandError;
+};
+
+type CameraControlResultMessage = {
+  type: 'cameraControlResult';
+  id: string;
+  payload?: EmptyCommandResult;
+  error?: CommandError;
+};
+
 type SetWifiBandwidthResultMessage = {
   type: 'setWifiBandwidthResult';
   id: string;
@@ -625,6 +684,9 @@ type KnownCommandResultMessage =
   | WatchAppResultMessage
   | UnwatchAppResultMessage
   | PlayOnMicrophoneResultMessage
+  | StopMicrophonePlaybackResultMessage
+  | MicrophoneStatusResultMessage
+  | CameraControlResultMessage
   | SetWifiBandwidthResultMessage
   | StartVideoRecordingResultMessage
   | StopVideoRecordingResultMessage;
@@ -651,6 +713,12 @@ type CommandRequestMap = {
   watchApp: { packageName: string; execId: string };
   unwatchApp: { execId: string };
   playOnMicrophone: { path: string; once?: boolean };
+  stopMicrophonePlayback: {};
+  microphoneStatus: {};
+  cameraControl:
+    | { action: 'setSource'; source: 'video'; arg: string; loop?: boolean }
+    | { action: 'setSource'; source: 'webRTC' }
+    | { action: 'reset' };
   setWifiBandwidth: WifiBandwidthOptions;
   startRecording: { quality?: RecordingQuality };
   stopRecording: { upload?: { presignedUrl: string } };
@@ -671,6 +739,9 @@ type CommandResultMap = {
   watchApp: { packageName?: string };
   unwatchApp: EmptyCommandResult;
   playOnMicrophone: PlayOnMicrophoneResult;
+  stopMicrophonePlayback: EmptyCommandResult;
+  microphoneStatus: { status?: MicrophoneStatus };
+  cameraControl: EmptyCommandResult;
   setWifiBandwidth: EmptyCommandResult;
   startRecording: EmptyCommandResult;
   stopRecording: EmptyCommandResult;
@@ -845,6 +916,9 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         case 'watchAppResult':
         case 'unwatchAppResult':
         case 'playOnMicrophoneResult':
+        case 'stopMicrophonePlaybackResult':
+        case 'microphoneStatusResult':
+        case 'cameraControlResult':
         case 'setWifiBandwidthResult':
         case 'startRecordingResult':
         case 'stopRecordingResult':
@@ -1116,6 +1190,10 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             terminateApp,
             watchApp,
             playOnMicrophone,
+            stopMicrophonePlayback,
+            microphoneStatus,
+            setCameraVideo,
+            clearCameraVideo,
             setWifiBandwidth,
             startRecording,
             stopRecording,
@@ -1277,6 +1355,31 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         path: inputPath,
         ...(microphoneOptions?.once === undefined ? {} : { once: microphoneOptions.once }),
       });
+    };
+
+    const stopMicrophonePlayback = async (): Promise<void> => {
+      await sendRequest('stopMicrophonePlayback', {});
+    };
+
+    const microphoneStatus = async (): Promise<MicrophoneStatus> => {
+      const result = await sendRequest('microphoneStatus', {});
+      return result.status ?? { source: 'silence' };
+    };
+
+    const setCameraVideo = async (inputPath: string, cameraOptions?: CameraVideoOptions): Promise<void> => {
+      if (!inputPath) {
+        throw new Error('path must be a non-empty string');
+      }
+      await sendRequest('cameraControl', {
+        action: 'setSource',
+        source: 'video',
+        arg: inputPath,
+        loop: cameraOptions?.loop ?? true,
+      });
+    };
+
+    const clearCameraVideo = async (): Promise<void> => {
+      await sendRequest('cameraControl', { action: 'reset' });
     };
 
     const setWifiBandwidth = async (bandwidthOptions: WifiBandwidthOptions): Promise<void> => {


### PR DESCRIPTION
## Summary
- Expose Android camera/microphone simulation in the SDK and CLI, matching the existing iOS media simulation surface. Server-side support (virtual camera devices, media-synced mock mic, live WebRTC microphone) already shipped in limdroid 15; this is the client half that was left on a branch without a PR.

Made with [Cursor](https://cursor.com)