### PR TITLE
fix(cli): honor --no-create when attaching a simulator to the last target

### DIFF
--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -584,6 +584,13 @@ export abstract class BaseCommand extends Command {
         const xcodeClient = await this.resolveXcodeClient(target);
         const status = await xcodeClient.getSimulator();
         if (!status.attached) {
+          // Attaching creates a new iOS instance, so --no-create must stop here.
+          if (!this.shouldAutoCreateOnNotFound()) {
+            throw new Error(
+              `The recorded Xcode target ${target.id} has no attached simulator.\n` +
+                'Attach one with: lim xcode attach-simulator, or rerun without --no-create.',
+            );
+          }
           // attachNewSimulator deletes the simulator itself when the attach fails.
           const { simulator } = await xcodeClient.attachNewSimulator();
           this._instancesCreatedThisRun.add(simulator.metadata.id);


### PR DESCRIPTION
## Summary
- `resolveSimulatorBackedXcodeTargetOrCreate` attached a new simulator to a remembered Xcode target before consulting `shouldAutoCreateOnNotFound()`, so `lim xcode build --ios --no-create` could still create (and bill) a new iOS instance when the recorded sandbox had no simulator. Introduced today in 9735972.
- This also affected RBE child sessions, which pass `--no-create` specifically so the parent owns all instance creation — a child hitting this path could leak an instance the parent doesn't track.
- Now the attach path fails under `--no-create` with guidance: attach one via `lim xcode attach-simulator` or rerun without `--no-create`. Default (creation-allowed) behavior is unchanged.

## Test plan
- [x] `./scripts/lint` passes
- [x] packages/cli tests: 92/92 pass
- [ ] Manual: with a recorded simulator-less Xcode target, `lim xcode build --ios --no-create` errors without creating an instance; without `--no-create` it attaches as before

Made with [Cursor](https://cursor.com)