### PR TITLE
Bump deepmerge-ts to 8.0.2 in appium-ios example to fix stack exhaustion advisory

### DIFF
--- a/examples/appium-ios/package.json
+++ b/examples/appium-ios/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
+  },
+  "resolutions": {
+    "deepmerge-ts": "^8.0.2"
   }
 }

--- a/examples/appium-ios/yarn.lock
+++ b/examples/appium-ios/yarn.lock
@@ -622,10 +622,10 @@ decamelize@^6.0.0, decamelize@^6.0.1:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-6.0.1.tgz#e858c37870153e1f733e92347ac3a3f009081ca7"
   integrity sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==
 
-deepmerge-ts@^7.0.3:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/deepmerge-ts/-/deepmerge-ts-7.1.6.tgz#e226a79609c20aa6b89b00a1f4c5705ca71d9d2e"
-  integrity sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==
+deepmerge-ts@^7.0.3, deepmerge-ts@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz#4f3e5588c3a7c59ea80d54b583948d6f404cf13e"
+  integrity sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==
 
 degenerator@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
## Summary
- Forces the transitive `deepmerge-ts` dependency of `webdriverio` (pulled in via `@wdio/utils`, which still pins `^7.0.3`) to the patched `^8.0.2` line using a yarn resolution in `examples/appium-ios/package.json`.
- Fixes Dependabot alert [#677](https://github.com/limrun-inc/typescript-sdk/security/dependabot/677) (CVE-2026-40345, high): "DeepmergeTS has stack exhaustion when merging recursive objects". This was the only open Dependabot alert on the repo, and clears the matching Oneleet dependency-scan findings.
- Not fixed: `extract-zip <= 2.0.1` (unvalidated symlink path traversal, also under `examples/appium-ios`, flagged low-risk by Oneleet). No patched release of `extract-zip` exists; the dependency is only dropped in `@puppeteer/browsers` 3.x, but `@wdio/utils` pins `^2.2.0` and forcing that major bump through a resolution would be riskier than the vulnerability itself. It should disappear once wdio upgrades upstream.

`yarn audit` on the root, all `packages/*`, and all other `examples/*` lockfiles is otherwise clean.

## Test plan
- [x] `yarn audit` in `examples/appium-ios` no longer reports `deepmerge-ts`
- [x] `yarn build` (`tsc -b`) in `examples/appium-ios` passes
- [x] Root SDK `yarn build` passes (0 errors)
- [x] Root SDK `yarn test`: 604 passed, 28 skipped, 0 failed

## Release
After merging, a release should follow so downstream consumers pick up the fixed lockfile/example. This PR does not tag or publish anything itself.

Made with [Cursor](https://cursor.com)