### PR TITLE
Use signed download URL for assets uploaded during iOS/Android create

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -180,6 +180,7 @@ lim ios create --region us-west --display-name "CI Test" --label env=ci --rm
 | `--reuse-if-exists`               | Reuse an existing instance with matching labels/region                            |
 | `--install <file>`                | Local file to install (auto-uploads, repeatable)                                  |
 | `--install-asset <name>`          | Asset name to install (repeatable)                                                |
+| `--install-url <url>`             | Signed download URL of an app to install (repeatable)                             |
 
 #### List and Filter
 

--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -95,8 +95,10 @@ export default class AndroidCreate extends BaseCommand {
     this.setParsedFlags(flags);
 
     await this.withAuth(async () => {
-      // Upload local files first
-      const assetNames: string[] = [...(flags['install-asset'] || [])];
+      // Upload local files first. Uploaded files are installed via their
+      // signed download URL so the instance can fetch them directly without
+      // a server-side name lookup.
+      const uploadedAssetUrls: string[] = [];
       if (flags.install) {
         for (const filePath of flags.install) {
           const resolved = path.resolve(filePath);
@@ -107,7 +109,7 @@ export default class AndroidCreate extends BaseCommand {
             name,
             ttl: flags['asset-ttl'],
           });
-          assetNames.push(asset.name);
+          uploadedAssetUrls.push(asset.signedDownloadUrl);
         }
         this.info(`Successfully uploaded ${flags.install.length} file(s)`);
       }
@@ -119,13 +121,22 @@ export default class AndroidCreate extends BaseCommand {
         spec: {},
       };
 
-      if (assetNames.length > 0) {
-        params.spec!.initialAssets = assetNames.map((name) => ({
+      const initialAssets = [
+        ...(flags['install-asset'] || []).map((name) => ({
           kind: 'App' as const,
           source: 'AssetName' as const,
           assetName: name,
           launchMode: 'RelaunchIfRunning',
-        }));
+        })),
+        ...uploadedAssetUrls.map((url) => ({
+          kind: 'App' as const,
+          source: 'URL' as const,
+          url,
+          launchMode: 'RelaunchIfRunning',
+        })),
+      ];
+      if (initialAssets.length > 0) {
+        params.spec!.initialAssets = initialAssets;
       }
 
       if (flags.region) params.spec!.region = flags.region;

--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -15,6 +15,7 @@ export default class AndroidCreate extends BaseCommand {
   static examples = [
     '<%= config.bin %> android create',
     '<%= config.bin %> android create --rm --install ./app.apk',
+    '<%= config.bin %> android create --install-url https://example.t3.storage.dev/app.apk?...',
     '<%= config.bin %> android create --jurisdiction us --label env=dev',
     '<%= config.bin %> android create --no-connect',
     '<%= config.bin %> android create --daemon=false',
@@ -66,6 +67,10 @@ export default class AndroidCreate extends BaseCommand {
     }),
     'install-asset': Flags.string({
       description: 'Existing asset name to install after creation. Repeat for multiple assets.',
+      multiple: true,
+    }),
+    'install-url': Flags.string({
+      description: 'Signed download URL of an app to install after creation. Repeat for multiple URLs.',
       multiple: true,
     }),
     install: Flags.string({
@@ -128,7 +133,7 @@ export default class AndroidCreate extends BaseCommand {
           assetName: name,
           launchMode: 'RelaunchIfRunning',
         })),
-        ...uploadedAssetUrls.map((url) => ({
+        ...[...(flags['install-url'] || []), ...uploadedAssetUrls].map((url) => ({
           kind: 'App' as const,
           source: 'URL' as const,
           url,

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -155,7 +155,9 @@ export default class IosCreate extends BaseCommand {
       }
       const attachClient = attachTarget ? await this.resolveXcodeClient(attachTarget) : undefined;
 
-      const assetNames: string[] = [...(flags['install-asset'] || [])];
+      // Uploaded files are installed via their signed download URL so the
+      // instance can fetch them directly without a server-side name lookup.
+      const uploadedAssetUrls: string[] = [];
       if (flags.install) {
         for (const filePath of flags.install) {
           const resolved = path.resolve(filePath);
@@ -166,7 +168,7 @@ export default class IosCreate extends BaseCommand {
             name,
             ttl: flags['asset-ttl'],
           });
-          assetNames.push(asset.name);
+          uploadedAssetUrls.push(asset.signedDownloadUrl);
         }
         this.info(`Successfully uploaded ${flags.install.length} file(s)`);
       }
@@ -177,12 +179,20 @@ export default class IosCreate extends BaseCommand {
         spec: {},
       };
 
-      if (assetNames.length > 0) {
-        params.spec!.initialAssets = assetNames.map((name) => ({
+      const appAssets = [
+        ...(flags['install-asset'] || []).map((name) => ({
           kind: 'App' as const,
           source: 'AssetName' as const,
           assetName: name,
-        }));
+        })),
+        ...uploadedAssetUrls.map((url) => ({
+          kind: 'App' as const,
+          source: 'URL' as const,
+          url,
+        })),
+      ];
+      if (appAssets.length > 0) {
+        params.spec!.initialAssets = appAssets;
       }
       if (hasKeychainInitialAssets) {
         const encryptionKey = keychainEncryptionKey!;

--- a/packages/cli/src/commands/ios/create.ts
+++ b/packages/cli/src/commands/ios/create.ts
@@ -22,6 +22,7 @@ export default class IosCreate extends BaseCommand {
     '<%= config.bin %> ios create --keychain keychain/login.tar.gz --encryption-key-stdin < keychain.key',
     '<%= config.bin %> ios create --keychain-url https://example.t3.storage.dev/... --encryption-key <key>',
     '<%= config.bin %> ios create --install ./MyApp.ipa',
+    '<%= config.bin %> ios create --install-url https://example.t3.storage.dev/MyApp.ipa?...',
     '<%= config.bin %> ios create --attach <xcode-instance-ID>',
     '<%= config.bin %> ios create --force-bundle-id com.example.myapp',
   ];
@@ -72,6 +73,11 @@ export default class IosCreate extends BaseCommand {
     }),
     'install-asset': Flags.string({
       description: 'Existing asset name to install onto the instance after creation',
+      multiple: true,
+    }),
+    'install-url': Flags.string({
+      description:
+        'Signed download URL of an app to install onto the instance after creation. Repeat for multiple URLs.',
       multiple: true,
     }),
     keychain: Flags.string({
@@ -185,7 +191,7 @@ export default class IosCreate extends BaseCommand {
           source: 'AssetName' as const,
           assetName: name,
         })),
-        ...uploadedAssetUrls.map((url) => ({
+        ...[...(flags['install-url'] || []), ...uploadedAssetUrls].map((url) => ({
           kind: 'App' as const,
           source: 'URL' as const,
           url,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`lim ios create --install` and `lim android create --install` already receive a `signedDownloadUrl` from `assets.getOrUpload`, but discarded it and passed only `source: 'AssetName'` in `spec.initialAssets`, forcing a server-side name lookup at install time.

Uploaded files are now passed as `source: 'URL'` with their signed download URL, so the instance can fetch them directly. This matches the existing behavior of `lim ios install-app` / `lim android install-app`, which already install via `asset.signedDownloadUrl`.

A new `--install-url` flag (repeatable, consistent with the existing `--keychain-url` naming) also lets users provide a signed download URL directly, which is passed through as a `source: 'URL'` initial asset.

Existing assets referenced by name via `--install-asset` keep `source: 'AssetName'`, since only a name is available for those. Android entries retain `launchMode: 'RelaunchIfRunning'` for all sources.

## Changes

- `packages/cli/src/commands/ios/create.ts`: collect signed download URLs from `--install` uploads and the new `--install-url` flag, and emit `{ kind: 'App', source: 'URL', url }` initial assets alongside the `AssetName` entries from `--install-asset`.
- `packages/cli/src/commands/android/create.ts`: same change, preserving `launchMode: 'RelaunchIfRunning'`.
- `packages/cli/README.md`: document `--install-url` in the `ios create` flags table.

## Testing

- `./scripts/lint` (prettier, eslint, build, tsc, attw, publint) passes.
- `tsc --noEmit` and eslint on `packages/cli` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0250c-a632-7439-b30f-3bea026dd708?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0250c-a632-7439-b30f-3bea026dd708&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

