### PR TITLE
Add Android camera support (mp4 playback + WebRTC camera/mic)

### DIFF
--- a/packages/cli/src/commands/android/camera.ts
+++ b/packages/cli/src/commands/android/camera.ts
@@ -1,0 +1,83 @@
+import fs from 'fs';
+import path from 'path';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
+
+export default class AndroidCamera extends BaseCommand {
+  static summary = 'Control the virtual camera of a running Android instance';
+  static description =
+    'Upload a local video file and play it as the camera feed of a running Android instance, replacing the live browser camera. ' +
+    'Apps see the video through their regular Camera2/CameraX pipeline, and the file\'s audio track (if any) plays through the microphone in sync. ' +
+    'By default the video loops; with --no-loop it plays once and the feed freezes on the last frame. ' +
+    'Use the `clear` action to restore the default camera source.';
+  static examples = [
+    '<%= config.bin %> android camera play ./fixtures/qr-scan.mp4',
+    '<%= config.bin %> android camera play ./clip.mp4 --no-loop --id <instance-ID>',
+    '<%= config.bin %> android camera clear',
+  ];
+
+  static args = {
+    action: Args.string({
+      description:
+        'Camera action: `play` plays a video file as the camera and `clear` restores the default camera',
+      required: true,
+      options: ['play', 'clear'],
+    }),
+    path: Args.string({
+      description: 'Local video file to play as the camera (required for the `play` action).',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'Android instance ID to target. Defaults to the last created Android instance.',
+    }),
+    loop: Flags.boolean({
+      description: 'Restart the video when it ends. Use --no-loop to play once and freeze on the last frame.',
+      default: true,
+      allowNo: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(AndroidCamera);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveAndroidInstance(flags.id);
+
+      const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
+      try {
+        if (args.action === 'clear') {
+          await client.clearCameraVideo();
+          if (flags.json) {
+            this.outputJson({ ok: true });
+          } else {
+            this.output('Camera restored to the default source.');
+          }
+          return;
+        }
+
+        if (!args.path) {
+          this.error('The `play` action requires a video file path.');
+        }
+        const localPath = path.resolve(args.path);
+        if (!fs.existsSync(localPath)) {
+          this.error(`File not found: ${localPath}`);
+        }
+
+        await client.setCameraVideo(localPath, { loop: flags.loop });
+        if (flags.json) {
+          this.outputJson({ ok: true, loop: flags.loop });
+        } else {
+          this.output(`Playing ${localPath} as the camera${flags.loop ? ' on loop' : ' once'}.`);
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/android/push-file.ts
+++ b/packages/cli/src/commands/android/push-file.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import path from 'path';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
+
+export default class AndroidPushFile extends BaseCommand {
+  static summary = 'Push a local file to a running Android instance';
+  static description =
+    'Upload a local file to the Android instance without an ADB connection and print the remote path. ' +
+    'With a destination argument this behaves like `adb push`: the write happens with the same permissions ' +
+    'the ADB shell user has, so protected locations are rejected just as they would be for adb. ' +
+    'Without a destination the instance stores the file under an internal name.';
+
+  static examples = [
+    '<%= config.bin %> android push-file ./video.mp4',
+    '<%= config.bin %> android push-file ./video.mp4 /data/local/tmp/video.mp4',
+    '<%= config.bin %> android push-file ./document.pdf /sdcard/Download/document.pdf --id <instance-ID>',
+  ];
+
+  static args = {
+    path: Args.string({
+      description: 'Local file path to upload to the instance.',
+      required: true,
+    }),
+    destination: Args.string({
+      description: 'Optional absolute destination path on the instance, like the adb push destination.',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'Android instance ID to target. Defaults to the last created Android instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(AndroidPushFile);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const localPath = path.resolve(args.path);
+      if (!fs.existsSync(localPath)) {
+        this.error(`File not found: ${localPath}`);
+      }
+
+      const resolvedInstance = this.resolveAndroidInstance(flags.id);
+      const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
+      try {
+        const remotePath = await client.pushFile(localPath, args.destination);
+        if (flags.json) {
+          this.outputJson({ remotePath });
+        } else {
+          this.output(remotePath);
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -176,8 +176,9 @@ interface RemoteControlProps {
    * mode. Use it to render a richer status indicator (e.g.
    * "Camera · 1920×1080 · 30 fps · FaceTime HD").
    *
-   * Only iOS instances ever fire this callback; Android instances
-   * have no camera-injector path and stay silent.
+   * iOS instances always fire this callback. Android instances fire it
+   * when the server supports camera injection (Android 15+); older
+   * Android instances have no camera-injector path and stay silent.
    */
   onCameraDemandChange?: (active: boolean, granted?: boolean, camera?: CameraCaptureInfo) => void;
 
@@ -235,14 +236,15 @@ interface RemoteControlProps {
   cameraAspect?: CameraAspect;
 
   /**
-   * iOS only: when true, capture the user's microphone via
+   * When true, capture the user's microphone via
    * `getUserMedia({ audio: true })` and stream it live into the
-   * simulator's mock microphone. This is a manual override: iOS apps
+   * device's mock microphone. This is a manual override: apps
    * that actively consume microphone input also trigger capture
    * automatically, like camera demand. The component handles the
    * browser permission prompt, WebRTC track attachment, and
    * `microphoneStart`/`microphoneStop` signaling. Progress and failures
-   * are reported via `onMicrophoneStateChange`. Ignored on Android.
+   * are reported via `onMicrophoneStateChange`. Ignored on Android
+   * servers without camera/mic injection support (Android 14 and older).
    */
   microphoneEnabled?: boolean;
 
@@ -1931,7 +1933,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
     // handler firing on both `connected` and `completed`) must not
     // cancel an attach already in flight; only detach/teardown cancel.
     const attachMicrophone = (): Promise<void> => {
-      if (platform !== 'ios') return Promise.resolve();
+      // No platform gate: attachMicrophoneOp bails when the session never
+      // allocated a sendonly mic transceiver (non-capable servers).
       return runMicOp(() => attachMicrophoneOp());
     };
 
@@ -2479,8 +2482,13 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           updateStatus('WebSocket closed');
         };
 
-        // Request RTCConfiguration
-        const rtcConfigPromise = new Promise<RTCConfiguration>((resolve, reject) => {
+        // Request RTCConfiguration. The reply doubles as the capability
+        // handshake: camera-capable Android servers advertise
+        // `cameraSupported: true` alongside the configuration.
+        const rtcConfigPromise = new Promise<{
+          rtcConfiguration: RTCConfiguration;
+          cameraSupported: boolean;
+        }>((resolve, reject) => {
           const timeoutId = window.setTimeout(() => reject(new Error('RTCConfiguration timeout')), 30000);
 
           const messageHandler = (event: MessageEvent) => {
@@ -2489,7 +2497,10 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               if (message.type === 'rtcConfiguration') {
                 window.clearTimeout(timeoutId);
                 ws.removeEventListener('message', messageHandler);
-                resolve(message.rtcConfiguration);
+                resolve({
+                  rtcConfiguration: message.rtcConfiguration,
+                  cameraSupported: message.cameraSupported === true,
+                });
               }
             } catch (e) {
               window.clearTimeout(timeoutId);
@@ -2508,7 +2519,8 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
           );
         });
 
-        const rtcConfig = await rtcConfigPromise;
+        const { rtcConfiguration: rtcConfig, cameraSupported: serverCameraSupported } =
+          await rtcConfigPromise;
         if (!isCurrentAttempt() || wsRef.current !== ws) {
           return;
         }
@@ -2518,17 +2530,20 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
         peerConnection.addTransceiver('audio', { direction: 'recvonly' });
         const videoTransceiver = peerConnection.addTransceiver('video', { direction: 'recvonly' });
 
+        // iOS always supports camera/mic injection; Android servers
+        // advertise it through `cameraSupported` (Android 15 and newer).
+        // Never offer the extra sendonly m-lines to non-capable Android
+        // servers — older servers cannot negotiate them safely.
+        const canSendMedia = platform === 'ios' || serverCameraSupported;
+
         // Pre-allocate a sendonly slot for the user's camera so the
-        // sim can pull frames later without renegotiating SDP.
+        // device can pull frames later without renegotiating SDP.
         // Allocating up-front means we don't have to renegotiate the
-        // SDP when the simulator app actually opens its
-        // `AVCaptureSession` — the codec/SSRC negotiation happens
-        // once, here, and turning the camera on/off later is just a
-        // `replaceTrack`.
-        // iOS only: Android has no camera consumer, and the extra
-        // m=video line crashes Android 14's scrcpy/libwebrtc.
+        // SDP when the device app actually opens its camera session —
+        // the codec/SSRC negotiation happens once, here, and turning
+        // the camera on/off later is just a `replaceTrack`.
         const outboundCameraTransceiver =
-          platform === 'ios' ?
+          canSendMedia ?
             peerConnection.addTransceiver('video', {
               direction: 'sendonly',
             })
@@ -2537,10 +2552,9 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
 
         // Same pre-allocation for the live microphone: a sendonly audio
         // slot negotiated once at connection setup, so toggling the mic
-        // later is just `replaceTrack` — no SDP renegotiation. iOS only,
-        // like the camera.
+        // later is just `replaceTrack` — no SDP renegotiation.
         const outboundMicTransceiver =
-          platform === 'ios' ?
+          canSendMedia ?
             peerConnection.addTransceiver('audio', {
               direction: 'sendonly',
             })
@@ -2934,12 +2948,11 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               pendingScreenshotRejectersRef.current.delete(message.id);
               break;
             case 'cameraRequest': {
-              // Only iOS sessions allocate the sendonly outbound-camera
-              // transceiver; without it there is nothing to feed the sim, so
-              // ignore camera requests entirely — no getUserMedia prompt and
-              // no onCameraDemandChange callbacks. Android intentionally stays
-              // silent, as the API docs promise.
-              if (platform !== 'ios' || !outboundCameraSenderRef.current) {
+              // Only camera-capable sessions allocate the sendonly
+              // outbound-camera transceiver; without it there is nothing to
+              // feed the device, so ignore camera requests entirely — no
+              // getUserMedia prompt and no onCameraDemandChange callbacks.
+              if (!outboundCameraSenderRef.current) {
                 break;
               }
               const active = message.active === true;
@@ -3171,7 +3184,7 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
               break;
             }
             case 'microphoneRequest': {
-              if (platform !== 'ios' || !outboundMicSenderRef.current) {
+              if (!outboundMicSenderRef.current) {
                 break;
               }
               const active = message.active === true;

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -158,13 +158,19 @@ export type InstanceClient = {
   playOnMicrophone: (path: string, options?: PlayOnMicrophoneOptions) => Promise<PlayOnMicrophoneResult>;
   /**
    * Upload a local file to the instance, without needing an ADB connection.
-   * The instance stores it under an internal name.
+   *
+   * With no destination, the instance stores the file under an internal name
+   * and returns its path. With a destination, behaves like `adb push`: the
+   * write is performed with the same permissions the ADB shell user has, so
+   * writable locations (e.g. `/data/local/tmp`, `/sdcard`) succeed and
+   * protected ones are rejected, exactly as they would be for `adb push`.
    *
    * @param path The path of the local file to upload.
+   * @param destination Optional absolute path on the instance to write to.
    * @returns A promise that resolves to the absolute path of the file on the
    *   instance, usable with {@link playOnMicrophone}.
    */
-  pushFile: (path: string) => Promise<string>;
+  pushFile: (path: string, destination?: string) => Promise<string>;
   /**
    * Play a local video file as the camera feed.
    *
@@ -1347,8 +1353,11 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       });
     };
 
-    const pushFile = async (filePath: string): Promise<string> => {
-      const uploadUrl = `${options.apiUrl}/files`;
+    const pushFile = async (filePath: string, destination?: string): Promise<string> => {
+      const uploadUrl =
+        destination === undefined
+          ? `${options.apiUrl}/files`
+          : `${options.apiUrl}/files?path=${encodeURIComponent(destination)}`;
       const fileStream = fs.createReadStream(filePath);
       // Node's fetch (undici) supports streaming request bodies but TS DOM types may not include
       // `duplex` and may not accept Node ReadStreams as BodyInit in some configs.

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -152,9 +152,45 @@ export type InstanceClient = {
   /**
    * Play an on-device WAV/MP3 file as microphone input.
    *
-   * The file must already exist on the Android instance, for example after pushing it with ADB.
+   * The file must already exist on the Android instance, for example after
+   * uploading it with {@link pushFile} or pushing it with ADB.
    */
   playOnMicrophone: (path: string, options?: PlayOnMicrophoneOptions) => Promise<PlayOnMicrophoneResult>;
+  /**
+   * Upload a local file to the instance's staging folder
+   * (`/data/local/tmp/limrun-files`), without needing an ADB connection.
+   *
+   * @param path The path of the local file to upload.
+   * @param name Optional file name on the instance; defaults to the local
+   *   file's base name. Repeat uploads with the same name overwrite the
+   *   previous file.
+   * @returns A promise that resolves to the absolute path of the file on the
+   *   instance, usable with {@link playOnMicrophone}.
+   */
+  pushFile: (path: string, name?: string) => Promise<string>;
+  /**
+   * Play a local video file as the camera feed.
+   *
+   * Uploads the file to the instance and switches the virtual camera source
+   * to it, replacing the live WebRTC camera until {@link clearCameraVideo} is
+   * called. Apps see the video through their regular Camera2/CameraX
+   * pipeline, and the file's audio track (if any) plays through the
+   * microphone in sync.
+   *
+   * By default the video loops; with `loop: false` it plays once and the
+   * feed freezes on the last frame.
+   *
+   * @param path The path of the local video file to play as the camera.
+   * @param opts Playback options (currently just `loop`).
+   * @throws If the file has no decodable video track or the instance does not
+   *   support camera injection (Android 14 and older).
+   */
+  setCameraVideo: (path: string, opts?: CameraVideoOptions) => Promise<void>;
+  /**
+   * Stop video-file camera playback and restore the default WebRTC camera
+   * source. Safe to call when no video is playing.
+   */
+  clearCameraVideo: () => Promise<void>;
   /**
    * Set Android Wi-Fi bandwidth limits in Kbps. Omit a direction to leave it unchanged;
    * pass `0` to clear that direction's limit.
@@ -443,6 +479,18 @@ export type PlayOnMicrophoneOptions = {
   once?: boolean;
 };
 
+/**
+ * Options for playing a video file as the virtual camera feed.
+ */
+export type CameraVideoOptions = {
+  /**
+   * Whether to restart the video when it ends. When false the video
+   * plays once and the camera feed freezes on its last frame.
+   * @default true
+   */
+  loop?: boolean;
+};
+
 export type PlayOnMicrophoneResult = {
   /** Duration of the decoded audio in microseconds. */
   duration: number;
@@ -589,6 +637,15 @@ type PlayOnMicrophoneResultMessage = {
   error?: CommandError;
 };
 
+// The server sends camera control results "flat": fields at the top level and
+// `error` as a plain string, with no payload envelope.
+type CameraControlResultMessage = {
+  type: 'cameraControlResult';
+  id: string;
+  payload?: EmptyCommandResult;
+  error?: string;
+};
+
 type SetWifiBandwidthResultMessage = {
   type: 'setWifiBandwidthResult';
   id: string;
@@ -625,6 +682,7 @@ type KnownCommandResultMessage =
   | WatchAppResultMessage
   | UnwatchAppResultMessage
   | PlayOnMicrophoneResultMessage
+  | CameraControlResultMessage
   | SetWifiBandwidthResultMessage
   | StartVideoRecordingResultMessage
   | StopVideoRecordingResultMessage;
@@ -651,6 +709,9 @@ type CommandRequestMap = {
   watchApp: { packageName: string; execId: string };
   unwatchApp: { execId: string };
   playOnMicrophone: { path: string; once?: boolean };
+  cameraControl:
+    | { action: 'setSource'; source: 'video'; arg: string; loop?: boolean }
+    | { action: 'reset' };
   setWifiBandwidth: WifiBandwidthOptions;
   startRecording: { quality?: RecordingQuality };
   stopRecording: { upload?: { presignedUrl: string } };
@@ -671,6 +732,7 @@ type CommandResultMap = {
   watchApp: { packageName?: string };
   unwatchApp: EmptyCommandResult;
   playOnMicrophone: PlayOnMicrophoneResult;
+  cameraControl: EmptyCommandResult;
   setWifiBandwidth: EmptyCommandResult;
   startRecording: EmptyCommandResult;
   stopRecording: EmptyCommandResult;
@@ -812,6 +874,11 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       if ('message' in message && typeof message.message === 'string') {
         return message.message;
       }
+      // "Flat" results (e.g. cameraControlResult, playOnMicrophoneResult)
+      // carry the error as a plain string instead of a CommandError object.
+      if ('error' in message && typeof message.error === 'string' && message.error) {
+        return message.error;
+      }
       if ('error' in message && message.error && typeof message.error === 'object') {
         const obj = message.error as CommandError;
         if (typeof obj.message === 'string' && obj.message) {
@@ -845,6 +912,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         case 'watchAppResult':
         case 'unwatchAppResult':
         case 'playOnMicrophoneResult':
+        case 'cameraControlResult':
         case 'setWifiBandwidthResult':
         case 'startRecordingResult':
         case 'stopRecordingResult':
@@ -1116,6 +1184,9 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             terminateApp,
             watchApp,
             playOnMicrophone,
+            pushFile,
+            setCameraVideo,
+            clearCameraVideo,
             setWifiBandwidth,
             startRecording,
             stopRecording,
@@ -1277,6 +1348,47 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         path: inputPath,
         ...(microphoneOptions?.once === undefined ? {} : { once: microphoneOptions.once }),
       });
+    };
+
+    const pushFile = async (filePath: string, name?: string): Promise<string> => {
+      const uploadName = name ?? path.basename(filePath);
+      const uploadUrl = `${options.apiUrl}/files?name=${encodeURIComponent(uploadName)}`;
+      const fileStream = fs.createReadStream(filePath);
+      // Node's fetch (undici) supports streaming request bodies but TS DOM types may not include
+      // `duplex` and may not accept Node ReadStreams as BodyInit in some configs.
+      const response = await nodeProxyTransport.fetch(uploadUrl, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Length': fs.statSync(filePath).size.toString(),
+          Authorization: `Bearer ${options.token}`,
+        },
+        body: fileStream as any,
+        duplex: 'half' as any,
+      } as any);
+      if (!response.ok) {
+        const errorBody = await response.text();
+        logger.debug(`Upload failed: ${response.status} ${errorBody}`);
+        throw new Error(`Upload failed: ${response.status} ${errorBody}`);
+      }
+      const result = (await response.json()) as { path: string };
+      return result.path;
+    };
+
+    const setCameraVideo = async (filePath: string, cameraOptions?: CameraVideoOptions): Promise<void> => {
+      // Fixed prefix so repeat calls with the same file overwrite the
+      // previous upload instead of accumulating staging files.
+      const remotePath = await pushFile(filePath, `limrun-camera-${path.basename(filePath)}`);
+      await sendRequest('cameraControl', {
+        action: 'setSource',
+        source: 'video',
+        arg: remotePath,
+        loop: cameraOptions?.loop ?? true,
+      });
+    };
+
+    const clearCameraVideo = async (): Promise<void> => {
+      await sendRequest('cameraControl', { action: 'reset' });
     };
 
     const setWifiBandwidth = async (bandwidthOptions: WifiBandwidthOptions): Promise<void> => {

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -157,17 +157,14 @@ export type InstanceClient = {
    */
   playOnMicrophone: (path: string, options?: PlayOnMicrophoneOptions) => Promise<PlayOnMicrophoneResult>;
   /**
-   * Upload a local file to the instance's staging folder
-   * (`/data/local/tmp/limrun-files`), without needing an ADB connection.
+   * Upload a local file to the instance, without needing an ADB connection.
+   * The instance stores it under an internal name.
    *
    * @param path The path of the local file to upload.
-   * @param name Optional file name on the instance; defaults to the local
-   *   file's base name. Repeat uploads with the same name overwrite the
-   *   previous file.
    * @returns A promise that resolves to the absolute path of the file on the
    *   instance, usable with {@link playOnMicrophone}.
    */
-  pushFile: (path: string, name?: string) => Promise<string>;
+  pushFile: (path: string) => Promise<string>;
   /**
    * Play a local video file as the camera feed.
    *
@@ -1350,9 +1347,8 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       });
     };
 
-    const pushFile = async (filePath: string, name?: string): Promise<string> => {
-      const uploadName = name ?? path.basename(filePath);
-      const uploadUrl = `${options.apiUrl}/files?name=${encodeURIComponent(uploadName)}`;
+    const pushFile = async (filePath: string): Promise<string> => {
+      const uploadUrl = `${options.apiUrl}/files`;
       const fileStream = fs.createReadStream(filePath);
       // Node's fetch (undici) supports streaming request bodies but TS DOM types may not include
       // `duplex` and may not accept Node ReadStreams as BodyInit in some configs.
@@ -1376,9 +1372,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
     };
 
     const setCameraVideo = async (filePath: string, cameraOptions?: CameraVideoOptions): Promise<void> => {
-      // Fixed prefix so repeat calls with the same file overwrite the
-      // previous upload instead of accumulating staging files.
-      const remotePath = await pushFile(filePath, `limrun-camera-${path.basename(filePath)}`);
+      const remotePath = await pushFile(filePath);
       await sendRequest('cameraControl', {
         action: 'setSource',
         source: 'video',


### PR DESCRIPTION
## Summary
- `instance-client`: new `setCameraVideo(path, { loop })` / `clearCameraVideo()` for Android, matching the iOS client API. Uploads the file via the instance's new `PUT /files` endpoint (`pushFile` helper) and drives it through the `cameraControl` command. An mp4 with an audio track plays synchronized video+audio (camera + microphone).
- `cli`: new `lim android camera play/clear` command mirroring `lim ios camera`.
- `ui` (`RemoteControl`): outbound WebRTC camera and microphone tracks are now enabled on Android when the server advertises `cameraSupported` in its `rtcConfiguration` message, so apps requesting camera/microphone get live browser media via `cameraRequest`/`microphoneRequest`, same as iOS. Servers that don't advertise support keep the previous behavior.

## Test plan
- [x] `yarn build` in root, cli, and ui packages
- [x] `setCameraVideo` loop/no-loop and `clearCameraVideo` verified against a live Android instance (camera app shows the injected video; mp4 audio plays on the microphone)
- [x] File upload endpoint verified incl. name validation and error paths
- [x] Headless-browser e2e with the built `RemoteControl`: device video streams; opening the camera app triggers `cameraRequest` and the browser camera feeds the device camera; app recording triggers `microphoneRequest` and live mic attaches; both release on stop

Made with [Cursor](https://cursor.com)