### PR TITLE
Add adbShell to Android client and `lim android adb-shell` CLI command

### DIFF
--- a/packages/cli/src/commands/android/adb-shell.ts
+++ b/packages/cli/src/commands/android/adb-shell.ts
@@ -1,0 +1,70 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
+
+export default class AndroidAdbShell extends BaseCommand {
+  static summary = 'Run a shell command on a running Android instance (like adb shell)';
+  static description =
+    'Run a command on the Android instance without needing adb installed locally. ' +
+    'The command runs with the same permissions the adb shell user has, and its stdout, stderr, ' +
+    'and exit code are returned. Pass the command and its arguments after `--`; each argument is ' +
+    'sent as a separate, quoted token. To use shell features like pipes, invoke a shell explicitly ' +
+    '(e.g. `-- sh -c "..."`). The CLI exits with the command\'s exit code.';
+
+  // Everything after `--` is captured verbatim as the command and its args.
+  static strict = false;
+
+  static examples = [
+    '<%= config.bin %> android adb-shell -- pm list packages -3',
+    '<%= config.bin %> android adb-shell -- getprop ro.build.version.sdk',
+    '<%= config.bin %> android adb-shell --id <instance-ID> -- sh -c "dumpsys battery | grep level"',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'Android instance ID to target. Defaults to the last created Android instance.',
+    }),
+    timeout: Flags.integer({
+      description: 'Command timeout in milliseconds.',
+      default: 30000,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { argv, flags } = await this.parse(AndroidAdbShell);
+    this.setParsedFlags(flags);
+
+    const tokens = argv as string[];
+    if (tokens.length === 0) {
+      this.error('Provide a command after `--`, e.g. `android adb-shell -- pm list packages -3`.');
+    }
+    const [command, ...args] = tokens;
+
+    await this.withAuth(async () => {
+      const resolvedInstance = this.resolveAndroidInstance(flags.id);
+      const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
+      try {
+        const result = await client.adbShell(command, args, { timeoutMs: flags.timeout });
+        if (flags.json) {
+          this.outputJson(result);
+        } else {
+          if (result.stdout) {
+            process.stdout.write(result.stdout);
+          }
+          if (result.stderr) {
+            process.stderr.write(result.stderr);
+          }
+          if (result.truncated) {
+            process.stderr.write('\n[output truncated]\n');
+          }
+        }
+        if (result.exitCode !== 0) {
+          this.exit(result.exitCode);
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -195,6 +195,34 @@ export type InstanceClient = {
    */
   clearCameraVideo: () => Promise<void>;
   /**
+   * Run a shell command on the instance, without needing `adb` installed
+   * locally. The command runs with the same permissions the ADB shell user
+   * has (exactly like `adb shell`), and its stdout, stderr, and exit code are
+   * returned separately.
+   *
+   * The command and each argument are safely quoted before being sent, so
+   * argument values cannot be interpreted as extra shell syntax (no injection
+   * from untrusted args), mirroring `child_process.execFile`:
+   *
+   * ```ts
+   * await client.adbShell('pm', ['list', 'packages', '-3']);
+   * await client.adbShell('getprop', ['ro.build.version.sdk']);
+   * ```
+   *
+   * To use shell features such as pipes or redirection, invoke a shell
+   * explicitly and pass the script as an argument:
+   *
+   * ```ts
+   * await client.adbShell('sh', ['-c', 'dumpsys battery | grep level']);
+   * ```
+   *
+   * @param command The executable or shell builtin to run.
+   * @param args Arguments passed to the command; each is individually quoted.
+   * @throws If the command times out or the ADB transport is unavailable. A
+   *   non-zero `exitCode` is returned in the result, not thrown.
+   */
+  adbShell: (command: string, args?: string[], options?: AdbShellOptions) => Promise<AdbShellResult>;
+  /**
    * Set Android Wi-Fi bandwidth limits in Kbps. Omit a direction to leave it unchanged;
    * pass `0` to clear that direction's limit.
    */
@@ -506,6 +534,46 @@ export type WifiBandwidthOptions = {
   upKbps?: number;
 };
 
+/**
+ * Quotes each token so the remote `sh -c` receives them as literal,
+ * separate arguments — values cannot inject extra shell syntax. Uses
+ * POSIX single-quoting: wrap in single quotes and escape embedded single
+ * quotes as `'\''`.
+ */
+function quoteShellArgs(tokens: string[]): string {
+  return tokens.map((token) => `'${token.replace(/'/g, `'\\''`)}'`).join(' ');
+}
+
+/**
+ * Options for {@link InstanceClient.adbShell}.
+ */
+export type AdbShellOptions = {
+  /**
+   * Maximum time to wait for the command to finish, in milliseconds.
+   * @default 30000
+   */
+  timeoutMs?: number;
+  /**
+   * Encoding used to decode stdout/stderr into strings.
+   * @default 'utf8'
+   */
+  encoding?: BufferEncoding;
+};
+
+/**
+ * Result of a shell command run via {@link InstanceClient.adbShell}.
+ */
+export type AdbShellResult = {
+  /** Standard output, decoded with the requested encoding. */
+  stdout: string;
+  /** Standard error, decoded with the requested encoding. */
+  stderr: string;
+  /** Process exit code (`-1` if the device reported no exit status). */
+  exitCode: number;
+  /** True if output exceeded the capture limit and was truncated. */
+  truncated: boolean;
+};
+
 type EmptyCommandResult = Record<string, never>;
 
 type ScreenshotErrorResponse = {
@@ -656,6 +724,19 @@ type SetWifiBandwidthResultMessage = {
   error?: CommandError;
 };
 
+// The server sends adb shell results "flat": stdout/stderr (base64) and
+// exitCode at the top level, with `error` as a plain string.
+type AdbShellResultMessage = {
+  type: 'adbShellResult';
+  id: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  truncated?: boolean;
+  payload?: EmptyCommandResult;
+  error?: string;
+};
+
 type StartVideoRecordingResultMessage = {
   type: 'startRecordingResult';
   id: string;
@@ -686,6 +767,7 @@ type KnownCommandResultMessage =
   | UnwatchAppResultMessage
   | PlayOnMicrophoneResultMessage
   | CameraControlResultMessage
+  | AdbShellResultMessage
   | SetWifiBandwidthResultMessage
   | StartVideoRecordingResultMessage
   | StopVideoRecordingResultMessage;
@@ -713,6 +795,7 @@ type CommandRequestMap = {
   unwatchApp: { execId: string };
   playOnMicrophone: { path: string; once?: boolean };
   cameraControl: { action: 'setSource'; source: 'video'; arg: string; loop?: boolean } | { action: 'reset' };
+  adbShell: { command: string; timeoutMs?: number };
   setWifiBandwidth: WifiBandwidthOptions;
   startRecording: { quality?: RecordingQuality };
   stopRecording: { upload?: { presignedUrl: string } };
@@ -734,6 +817,7 @@ type CommandResultMap = {
   unwatchApp: EmptyCommandResult;
   playOnMicrophone: PlayOnMicrophoneResult;
   cameraControl: EmptyCommandResult;
+  adbShell: AdbShellResultMessage;
   setWifiBandwidth: EmptyCommandResult;
   startRecording: EmptyCommandResult;
   stopRecording: EmptyCommandResult;
@@ -914,6 +998,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
         case 'unwatchAppResult':
         case 'playOnMicrophoneResult':
         case 'cameraControlResult':
+        case 'adbShellResult':
         case 'setWifiBandwidthResult':
         case 'startRecordingResult':
         case 'stopRecordingResult':
@@ -1188,6 +1273,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             pushFile,
             setCameraVideo,
             clearCameraVideo,
+            adbShell,
             setWifiBandwidth,
             startRecording,
             stopRecording,
@@ -1390,6 +1476,33 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
 
     const clearCameraVideo = async (): Promise<void> => {
       await sendRequest('cameraControl', { action: 'reset' });
+    };
+
+    const adbShell = async (
+      command: string,
+      args: string[] = [],
+      adbOptions?: AdbShellOptions,
+    ): Promise<AdbShellResult> => {
+      if (!command) {
+        throw new Error('command must be a non-empty string');
+      }
+      const commandLine = quoteShellArgs([command, ...args]);
+      const timeoutMs = adbOptions?.timeoutMs;
+      // Wait a little longer than the device-side timeout so the server's own
+      // error surfaces instead of a generic client timeout.
+      const requestTimeoutMs = (timeoutMs ?? 30000) + 15000;
+      const result = await sendRequest(
+        'adbShell',
+        { command: commandLine, ...(timeoutMs === undefined ? {} : { timeoutMs }) },
+        requestTimeoutMs,
+      );
+      const encoding = adbOptions?.encoding ?? 'utf8';
+      return {
+        stdout: Buffer.from(result.stdout ?? '', 'base64').toString(encoding),
+        stderr: Buffer.from(result.stderr ?? '', 'base64').toString(encoding),
+        exitCode: typeof result.exitCode === 'number' ? result.exitCode : -1,
+        truncated: result.truncated === true,
+      };
     };
 
     const setWifiBandwidth = async (bandwidthOptions: WifiBandwidthOptions): Promise<void> => {


### PR DESCRIPTION
## Summary
- Adds `client.adbShell(command, args?, options?)` to the Android `InstanceClient`. It runs a shell command on the instance through the streaming connection, so no local `adb` installation or port forwarding is needed.
- The signature follows the `execFile` pattern: a command string plus an optional args array. Args are single-quoted client-side so values with spaces or shell metacharacters are passed literally instead of being interpreted.
- Returns `{ stdout, stderr, exitCode, truncated }` with stdout and stderr separated and the real exit code preserved. Output is capped server-side (16 MiB per stream) and `truncated` is set when the cap is hit. An optional `timeoutMs` (default 30s, max 5m) bounds execution.
- Adds a `lim android adb-shell <id> -- <command> [args...]` CLI command that prints stdout/stderr and exits with the remote command's exit code.

## Example
```ts
const result = await client.adbShell('ls', ['-la', '/sdcard/Download']);
console.log(result.stdout);
```

```bash
lim android adb-shell my-instance -- getprop ro.build.version.release
```

## Test plan
- [x] `yarn build` and `yarn lint` pass in root and CLI packages
- [x] Verified end-to-end against a live instance: stdout/stderr separation, non-zero exit codes, args with spaces/quotes passed literally, output truncation flag

Made with [Cursor](https://cursor.com)