### PR TITLE
ui: select npm dist-tag from release version

### DIFF
--- a/.github/workflows/publish-ui.yaml
+++ b/.github/workflows/publish-ui.yaml
@@ -26,4 +26,10 @@ jobs:
         working-directory: packages/ui
         run: |
           npm run build
-          npm publish --provenance
+          version="$(node -p "require('./package.json').version")"
+          if [[ "$version" == *-* ]]; then
+            tag="next"
+          else
+            tag="latest"
+          fi
+          npm publish --provenance --tag "$tag"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,8 +2,7 @@
   "name": "@limrun/ui",
   "version": "0.15.0",
   "publishConfig": {
-    "access": "public",
-    "tag": "next"
+    "access": "public"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- publish stable `@limrun/ui` versions under `latest`
- keep prerelease versions under `next`
- remove the stale package-level `next` override

## Test plan
- [x] Run `./scripts/lint`
- [x] Verify `0.15.0` resolves to `latest`
- [x] Verify `0.16.0-rc.1` resolves to `next`

Made with [Cursor](https://cursor.com)