### PR TITLE
Add pullFile to Android client and `lim android pull-file` CLI command

### DIFF
--- a/packages/cli/src/commands/android/pull-file.ts
+++ b/packages/cli/src/commands/android/pull-file.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base-command';
+import { getAndroidInstanceClient } from '../../lib/instance-client-factory';
+
+export default class AndroidPullFile extends BaseCommand {
+  static summary = 'Pull a file from a running Android instance';
+  static description =
+    'Download a file from the Android instance without an ADB connection and save it locally. ' +
+    'This behaves like `adb pull`: the read happens with the same permissions the ADB shell user has, ' +
+    'so protected locations are rejected just as they would be for adb.';
+
+  static examples = [
+    '<%= config.bin %> android pull-file /sdcard/Download/photo.jpeg',
+    '<%= config.bin %> android pull-file /data/local/tmp/log.txt ./device-log.txt',
+    '<%= config.bin %> android pull-file /sdcard/Download/photo.jpeg ./photo.jpeg --id <instance-ID>',
+  ];
+
+  static args = {
+    path: Args.string({
+      description: 'Absolute path of the file on the instance, like the adb pull source.',
+      required: true,
+    }),
+    destination: Args.string({
+      description:
+        'Local path to save the file to. Defaults to the remote filename in the current directory.',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    id: Flags.string({
+      description: 'Android instance ID to target. Defaults to the last created Android instance.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(AndroidPullFile);
+    this.setParsedFlags(flags);
+
+    await this.withAuth(async () => {
+      const localPath = path.resolve(args.destination ?? path.posix.basename(args.path));
+
+      const resolvedInstance = this.resolveAndroidInstance(flags.id);
+      const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);
+      try {
+        // Streamed to disk by the SDK, so large files never sit in memory.
+        await client.pullFile(args.path, localPath);
+        if (flags.json) {
+          this.outputJson({ localPath, bytes: fs.statSync(localPath).size });
+        } else {
+          this.output(localPath);
+        }
+      } finally {
+        disconnect();
+      }
+    });
+  }
+}

--- a/packages/cli/src/commands/android/pull-file.ts
+++ b/packages/cli/src/commands/android/pull-file.ts
@@ -24,7 +24,8 @@ export default class AndroidPullFile extends BaseCommand {
     }),
     destination: Args.string({
       description:
-        'Local path to save the file to. Defaults to the remote filename in the current directory.',
+        'Local path to save the file to. An existing directory saves the remote filename inside it, ' +
+        'like adb pull. Defaults to the remote filename in the current directory.',
       required: false,
     }),
   };
@@ -41,7 +42,12 @@ export default class AndroidPullFile extends BaseCommand {
     this.setParsedFlags(flags);
 
     await this.withAuth(async () => {
-      const localPath = path.resolve(args.destination ?? path.posix.basename(args.path));
+      let localPath = path.resolve(args.destination ?? path.posix.basename(args.path));
+      // adb pull semantics: an existing directory destination (e.g. `.`)
+      // receives the file under its remote basename.
+      if (fs.existsSync(localPath) && fs.statSync(localPath).isDirectory()) {
+        localPath = path.join(localPath, path.posix.basename(args.path));
+      }
 
       const resolvedInstance = this.resolveAndroidInstance(flags.id);
       const { client, disconnect } = await getAndroidInstanceClient(this.client, resolvedInstance);

--- a/src/instance-client.ts
+++ b/src/instance-client.ts
@@ -172,6 +172,21 @@ export type InstanceClient = {
    */
   pushFile: (path: string, destination?: string) => Promise<string>;
   /**
+   * Download a file from the instance, without needing an ADB connection.
+   *
+   * Behaves like `adb pull`: the read is performed with the same permissions
+   * the ADB shell user has, so readable locations (e.g. `/data/local/tmp`,
+   * `/sdcard`) succeed and protected ones are rejected, exactly as they would
+   * be for `adb pull`.
+   *
+   * The content is streamed to `localPath` without being buffered in memory,
+   * so arbitrarily large files can be pulled.
+   *
+   * @param path Absolute path of the file on the instance.
+   * @param localPath Local path to stream the file to.
+   */
+  pullFile: (path: string, localPath: string) => Promise<void>;
+  /**
    * Play a local video file as the camera feed.
    *
    * Uploads the file to the instance and switches the virtual camera source
@@ -1271,6 +1286,7 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
             watchApp,
             playOnMicrophone,
             pushFile,
+            pullFile,
             setCameraVideo,
             clearCameraVideo,
             adbShell,
@@ -1462,6 +1478,12 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
       }
       const result = (await response.json()) as { path: string };
       return result.path;
+    };
+
+    const pullFile = async (remotePath: string, localPath: string): Promise<void> => {
+      const downloadUrl = `${options.apiUrl}/files?path=${encodeURIComponent(remotePath)}`;
+      // Streams to disk without buffering the whole file in memory.
+      await downloadFileToLocalPath(downloadUrl, options.token, localPath);
     };
 
     const setCameraVideo = async (filePath: string, cameraOptions?: CameraVideoOptions): Promise<void> => {


### PR DESCRIPTION
## Summary
- Adds `client.pullFile(path, localPath)` to the Android `InstanceClient`: downloads a file from the instance and streams it to `localPath` without buffering it in memory, so arbitrarily large files can be pulled. No local `adb` installation is needed.
- Behaves like `adb pull`: the read happens with the ADB shell user's permissions, so readable locations (`/data/local/tmp`, `/sdcard`, app-accessible storage) succeed and protected ones are rejected with the same errors adb reports (`remote object '<path>' does not exist`, `open failed: Permission denied`).
- Adds a `lim android pull-file <remote> [local]` CLI command mirroring `ios pull-file`; the local path defaults to the remote filename in the current directory.

## Example
```ts
await client.pullFile('/sdcard/Download/report.pdf', './report.pdf');
```

```bash
lim android pull-file /sdcard/Download/photo.jpeg ./photo.jpeg
```

## Test plan
- [x] `yarn build` and `yarn lint` pass in root and CLI packages
- [x] Verified end-to-end against a live instance: 1 MB and 64 MB round-trips checksum-verified, device-generated file matches device `md5sum`, empty files, missing file → 404, protected path → 403, directory and relative paths → 400

Made with [Cursor](https://cursor.com)