### PR TITLE
feat(cli): add Android OS version flag

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -382,7 +382,7 @@ lim android create --region us-west --display-name "CI Test" --label env=ci --rm
 
 | Flag                     | Description                                     |
 | ------------------------ | ----------------------------------------------- |
-| `--os-version <version>` | Android OS major version (e.g. 13, 14, or 15)   |
+| `--os-version <version>` | Android OS major version (14 or 15)             |
 | `--[no-]connect`         | Start an ADB tunnel immediately (default: true) |
 | `--adb-path <path>`      | Path to `adb` binary (default: `adb`)           |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -368,6 +368,9 @@ lim android create
 # With apps pre-installed
 lim android create --install ./my-app.apk --install ./another.apk
 
+# With a specific Android OS version
+lim android create --os-version 15
+
 # Create without opening an ADB tunnel
 lim android create --no-connect
 
@@ -377,10 +380,11 @@ lim android create --region us-west --display-name "CI Test" --label env=ci --rm
 
 **Android-specific flags:**
 
-| Flag                | Description                                     |
-| ------------------- | ----------------------------------------------- |
-| `--[no-]connect`    | Start an ADB tunnel immediately (default: true) |
-| `--adb-path <path>` | Path to `adb` binary (default: `adb`)           |
+| Flag                     | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| `--os-version <version>` | Android OS major version (e.g. 13, 14, or 15)   |
+| `--[no-]connect`         | Start an ADB tunnel immediately (default: true) |
+| `--adb-path <path>`      | Path to `adb` binary (default: `adb`)           |
 
 `lim android create` always prints a Console URL such as `https://console.limrun.com/stream/android_...` that you can open in the browser for live viewing. For automation, `--no-connect` is usually the safest default.
 

--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -16,6 +16,7 @@ export default class AndroidCreate extends BaseCommand {
     '<%= config.bin %> android create',
     '<%= config.bin %> android create --rm --install ./app.apk',
     '<%= config.bin %> android create --install-url https://example.t3.storage.dev/app.apk?...',
+    '<%= config.bin %> android create --os-version 15',
     '<%= config.bin %> android create --jurisdiction us --label env=dev',
     '<%= config.bin %> android create --no-connect',
     '<%= config.bin %> android create --daemon=false',
@@ -52,6 +53,9 @@ export default class AndroidCreate extends BaseCommand {
       description:
         'Jurisdiction the instance must be created in. Unlike --region, this is a hard constraint: creation fails when no region in the jurisdiction has capacity.',
       options: ['us', 'eu', 'as'],
+    }),
+    'os-version': Flags.string({
+      description: 'Android OS major version to create (e.g. 13, 14, or 15)',
     }),
     'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
     'inactivity-timeout': Flags.string({
@@ -146,6 +150,9 @@ export default class AndroidCreate extends BaseCommand {
 
       if (flags.region) params.spec!.region = flags.region;
       if (flags.jurisdiction) params.spec!.jurisdiction = flags.jurisdiction as 'us' | 'eu' | 'as';
+      if (flags['os-version']) {
+        params.spec!.clues = [{ kind: 'OSVersion', osVersion: flags['os-version'] }];
+      }
       if (flags['hard-timeout']) params.spec!.hardTimeout = flags['hard-timeout'];
       if (flags['inactivity-timeout']) params.spec!.inactivityTimeout = flags['inactivity-timeout'];
 

--- a/packages/cli/src/commands/android/create.ts
+++ b/packages/cli/src/commands/android/create.ts
@@ -55,7 +55,7 @@ export default class AndroidCreate extends BaseCommand {
       options: ['us', 'eu', 'as'],
     }),
     'os-version': Flags.string({
-      description: 'Android OS major version to create (e.g. 13, 14, or 15)',
+      description: 'Android OS major version to create (14 or 15)',
     }),
     'hard-timeout': Flags.string({ description: 'Hard timeout (e.g. 1m, 10m, 3h). Default: no timeout' }),
     'inactivity-timeout': Flags.string({

--- a/src/resources/android-instances.ts
+++ b/src/resources/android-instances.ts
@@ -228,7 +228,7 @@ export namespace AndroidInstanceCreateParams {
       clientIp?: string;
 
       /**
-       * The major version of Android, e.g. "13", "14" or "15".
+       * The major version of Android, e.g. "14" or "15".
        */
       osVersion?: string;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `--os-version` to `lim android create`
- send the selected version as an `OSVersion` scheduling clue
- document supported Android versions as 14 and 15

## Testing
- `./scripts/lint`
- `yarn --cwd packages/cli build`
- `yarn --cwd packages/cli test --runInBand` (92 tests passed)
- verified `lim android create --help` lists only Android 14 and 15
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0701601d-4f56-4d8b-bd32-0ee5fc48418a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0701601d-4f56-4d8b-bd32-0ee5fc48418a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

