### PR TITLE
Release lim CLI 0.29.2 with iOS destination tunnels

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.47.0",
+    "@limrun/api": "^0.48.0",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@^0.47.0":
-  version "0.47.0"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.47.0.tgz#4560dc91f5a71ae9c868f58ebc8f0a9eab1819fc"
-  integrity sha512-+pGYJWr6sQcgJmTTm1Lghr3FP6o7oNqBDvTjuwTPWLvYEkgYH5vzqNNL59BY6Bvj24rO/Whsz3N3tqPTytxqug==
+"@limrun/api@^0.48.0":
+  version "0.48.0"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.48.0.tgz#d9c610304e89f5171317f80838da0be62be30f0b"
+  integrity sha512-YpgJ3bQKbWp2iQRpQV4NRdzW/4SqKtzVP1mReiCHjbfROhzgjClarGac6HZrsvmVNkSecmJs1dGpEkKxsR10Cw==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and dependency bump only; no application logic, auth, or data-handling changes in this diff.
> 
> **Overview**
> Bumps the published `lim` CLI to **0.29.2** and pins `@limrun/api` from `^0.47.0` to `^0.48.0` (lockfile updated). No CLI source changes in this PR; the new SDK is what ships with this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea9a3c022f896c0d2a61bc049afe9c952c114940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->