### PR TITLE
cli: allow cloud signing for watchos device builds

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -372,7 +372,9 @@ export default class XcodeBuild extends BaseCommand {
       const cloudSigning = await this.buildCloudSigningOptions(flags);
       if (cloudSigning) {
         if (flags.sdk && !DEVICE_SDKS.has(flags.sdk)) {
-          this.error('Cloud signing is only supported for device SDK builds. Use --sdk iphoneos or --sdk watchos.');
+          this.error(
+            'Cloud signing is only supported for device SDK builds. Use --sdk iphoneos or --sdk watchos.',
+          );
         }
         if (!flags.sdk) {
           settings.sdk = 'iphoneos';

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -187,7 +187,7 @@ export default class XcodeBuild extends BaseCommand {
     }),
     'signing-method': Flags.string({
       description:
-        'Use Apple cloud signing during archive export. Distribution methods require the ASC key to have access to cloud-managed distribution certificates.',
+        'Use Apple cloud signing during archive export. Supports device SDK builds (--sdk iphoneos or --sdk watchos). Distribution methods require the ASC key to have access to cloud-managed distribution certificates.',
       options: ['app-store-connect', 'release-testing', 'debugging'],
     }),
     'team-id': Flags.string({
@@ -371,10 +371,12 @@ export default class XcodeBuild extends BaseCommand {
       }
       const cloudSigning = await this.buildCloudSigningOptions(flags);
       if (cloudSigning) {
-        if (flags.sdk && flags.sdk !== 'iphoneos') {
-          this.error('Cloud signing requires --sdk iphoneos.');
+        if (flags.sdk && !DEVICE_SDKS.has(flags.sdk)) {
+          this.error('Cloud signing is only supported for device SDK builds. Use --sdk iphoneos or --sdk watchos.');
         }
-        settings.sdk = 'iphoneos';
+        if (!flags.sdk) {
+          settings.sdk = 'iphoneos';
+        }
         options.cloudSigning = cloudSigning;
       }
       if (

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -220,7 +220,8 @@ export type XcodeBuildOptions = {
   cloudSigning?: XcodeCloudSigningConfig;
   /**
    * Upload the signed device IPA to App Store Connect after the build.
-   * Requires manual or cloud signing and sdk=iphoneos. Check ExecResult.appstore on
+   * Requires manual or cloud signing; the upload itself supports only
+   * sdk=iphoneos builds. Check ExecResult.appstore on
    * completion; it is absent when the instance's limbuild predates the
    * feature (old servers silently ignore this option).
    */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CLI validation change that widens an existing signing path to watchOS device SDKs. App Store upload constraints are unchanged.
> 
> **Overview**
> `--signing-method` now works with `--sdk watchos`, matching manual signing. Cloud signing previously rejected any SDK other than `iphoneos`.
> 
> If no SDK is set, cloud signing still defaults to `iphoneos`. App Store Connect upload remains iPhone-only. Flag and API comments are updated to describe that split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018b0af045e0841c68e7e32d777022819aa6c9e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->