### PR TITLE
Point Detox CLI help at destination tunnels

### DIFF
--- a/packages/cli/src/commands/ios/launch-app.ts
+++ b/packages/cli/src/commands/ios/launch-app.ts
@@ -34,7 +34,7 @@ export default class IosLaunchApp extends BaseCommand {
     '<%= config.bin %> ios launch-app com.example.app',
     '<%= config.bin %> ios launch-app com.example.app --detach',
     '<%= config.bin %> ios launch-app com.example.app --mode RelaunchIfRunning --id <instance-ID>',
-    '<%= config.bin %> ios launch-app host.exp.Exponent --runtime detox --detox-server-url ws://10.244.0.10:57091 --detox-session-id limrun-detox --detox-version 20.51.1 --id <instance-ID>',
+    '<%= config.bin %> ios launch-app host.exp.Exponent --runtime detox --detox-server-url ws://localhost:8099 --detox-session-id limrun-detox --detox-version 20.51.1 --id <instance-ID>',
   ];
 
   static args = {
@@ -61,7 +61,8 @@ export default class IosLaunchApp extends BaseCommand {
       options: ['detox'],
     }),
     'detox-server-url': Flags.string({
-      description: 'Detox mediator URL reachable from the simulator, usually from `lim ios reverse`',
+      description:
+        'Detox mediator URL reachable from the simulator, usually exposed with `lim ios tunnel --route localhost:<port>`',
     }),
     'detox-session-id': Flags.string({
       description: 'Detox session ID shared by the app and tester',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and example-only changes to CLI help; no runtime or launch behavior is modified.
> 
> **Overview**
> Updates **Detox-related CLI help** on `ios launch-app` so it matches the destination-tunnel workflow instead of `ios reverse`.
> 
> The `--detox-server-url` flag description now tells users to expose the mediator with `lim ios tunnel --route localhost:<port>`. The Detox example switches the sample URL from a cluster-style `ws://10.244.0.10:57091` to `ws://localhost:8099`, consistent with tunneling to localhost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1514463a58d90ef0017e1f02afa409482696b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->