### PR TITLE
cli: release 0.29.3 for watchOS cloud signing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.48.0",
+    "@limrun/api": "^0.48.1",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@^0.48.0":
-  version "0.48.0"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.48.0.tgz#d9c610304e89f5171317f80838da0be62be30f0b"
-  integrity sha512-YpgJ3bQKbWp2iQRpQV4NRdzW/4SqKtzVP1mReiCHjbfROhzgjClarGac6HZrsvmVNkSecmJs1dGpEkKxsR10Cw==
+"@limrun/api@^0.48.1":
+  version "0.48.1"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.48.1.tgz#9f7e99f6bbd601be1c426f6ed262575a3dfd4579"
+  integrity sha512-OxBhlzltzALONeu5s3JoNC2t1N7ZXVz+aAGo49S27bDX8RbaUU1TmqXVKl/OKmKPEVLoQP4UgtzKZFzxMQzDWg==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only version and lockfile updates for a dependency bump; no CLI source or behavior changes in this diff.
> 
> **Overview**
> **Releases `lim` CLI 0.29.3** by bumping the package version and upgrading **`@limrun/api`** from `^0.48.0` to **`^0.48.1`**, with the matching **`yarn.lock`** update.
> 
> This is a **release packaging** change so the published CLI ships the newer API client that backs **watchOS cloud signing** (alongside existing `iphoneos` device builds) for `xcode build` archive export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af2a11260059636cfd7408d1fb4c2420f337854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->