### PR TITLE
cli: release 0.30.0 for xcode test

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.29.3",
+  "version": "0.30.0",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.48.1",
+    "@limrun/api": "^0.48.2",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@^0.48.1":
-  version "0.48.1"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.48.1.tgz#9f7e99f6bbd601be1c426f6ed262575a3dfd4579"
-  integrity sha512-OxBhlzltzALONeu5s3JoNC2t1N7ZXVz+aAGo49S27bDX8RbaUU1TmqXVKl/OKmKPEVLoQP4UgtzKZFzxMQzDWg==
+"@limrun/api@^0.48.2":
+  version "0.48.2"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.48.2.tgz#3be00c53b47be056cb98732a6c91479f5e6c2078"
+  integrity sha512-wEwlkpZYHYq3CZm/rOqMA6s+tDvhqI2ERZ6ZL4tV80UoqjVT5C4arw7fIzbGhCISnLbxqKPWxTRIZ9aKcaddtg==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and lockfile-only release with a patch-level API dependency bump; no application logic changes in this PR.
> 
> **Overview**
> **Releases `lim` CLI 0.30.0** (from 0.29.3) and bumps the runtime dependency **`@limrun/api`** from `^0.48.1` to **`^0.48.2`**, with the matching **`yarn.lock`** entry updated.
> 
> There are no CLI source changes in this diff—only version and dependency alignment, consistent with shipping Xcode test–related API support to npm users on the new minor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653f276de5a3f624dbe95c12241bc7243ae21410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->