### PR TITLE
xcode: expose build log processor

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -113,7 +113,7 @@ export default class XcodeBuild extends BaseCommand {
       default: false,
     }),
     'log-processor': Flags.string({
-      description: 'Process xcodebuild output with xcbeautify or stream it unchanged.',
+      description: 'Process xcodebuild output with xcbeautify (default) or stream it unchanged.',
       options: ['xcbeautify', 'none'],
     }),
     'dev-server-url': Flags.string({

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -112,6 +112,10 @@ export default class XcodeBuild extends BaseCommand {
         'Run git init in the synced workspace before project generation, dependency resolution, and xcodebuild.',
       default: false,
     }),
+    'log-processor': Flags.string({
+      description: 'Process xcodebuild output with xcbeautify or stream it unchanged.',
+      options: ['xcbeautify', 'none'],
+    }),
     'dev-server-url': Flags.string({
       description:
         'Launch URL for Debug React Native / Expo builds. If the build is installed on an attached iOS simulator, the app opens this URL unchanged after build; otherwise this option has no launch effect. For Expo dev-client builds, pass the exact dev-client URL or development server URL you want opened.',
@@ -291,6 +295,9 @@ export default class XcodeBuild extends BaseCommand {
       const options: XcodeBuildOptions = {};
       if (flags['git-init']) {
         options.gitInit = true;
+      }
+      if (flags['log-processor']) {
+        options.logProcessor = flags['log-processor'] as XcodeBuildOptions['logProcessor'];
       }
       const xcodegen = xcodegenConfigFromFlags(flags);
       if (xcodegen) {

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -107,6 +107,7 @@ export type XcodeBuildExecRequest = {
    */
   env?: string[];
   gitInit?: boolean;
+  /** How xcodebuild stdout is processed before streaming. Defaults to 'xcbeautify'. */
   logProcessor?: 'xcbeautify' | 'none';
   signedUploadUrl?: string;
   /**

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -107,6 +107,7 @@ export type XcodeBuildExecRequest = {
    */
   env?: string[];
   gitInit?: boolean;
+  logProcessor?: 'xcbeautify' | 'none';
   signedUploadUrl?: string;
   /**
    * ID of the Limrun asset signedUploadUrl targets, when it was minted from

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -279,6 +279,7 @@ export type XcodeBuildOptions = {
    * dependency resolution, and xcodebuild.
    */
   gitInit?: boolean;
+  /** How xcodebuild stdout is processed before streaming. Defaults to 'xcbeautify'. */
   logProcessor?: 'xcbeautify' | 'none';
   /**
    * HTTP callback fired once the build reaches a terminal state (SUCCEEDED,

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -279,6 +279,7 @@ export type XcodeBuildOptions = {
    * dependency resolution, and xcodebuild.
    */
   gitInit?: boolean;
+  logProcessor?: 'xcbeautify' | 'none';
   /**
    * HTTP callback fired once the build reaches a terminal state (SUCCEEDED,
    * FAILED, or CANCELLED). The payload carries the result (execId, status,
@@ -912,6 +913,7 @@ export class XcodeInstances extends GeneratedXcodeInstances {
           ...(options?.buildSettings && { buildSettings: options.buildSettings }),
           ...(options?.env?.length && { env: options.env }),
           ...(options?.gitInit !== undefined && { gitInit: options.gitInit }),
+          ...(options?.logProcessor && { logProcessor: options.logProcessor }),
           ...(options?.webhook && { webhook: options.webhook }),
         };
 


### PR DESCRIPTION
## Summary
- expose limbuild's `logProcessor` option through the TypeScript SDK
- add `lim xcode build --log-processor xcbeautify|none`

## Test plan
- [x] `./scripts/lint`
- [x] `yarn tsc --noEmit` in `packages/cli`


Made with [Cursor](https://cursor.com)