### PR TITLE
xcode: support tvOS and visionOS device builds

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -742,7 +742,14 @@ lim xcode build ./MyProject --xcodegen-spec specs/app.yml --xcodegen-project ios
 
 Pass `--build-setting KEY=VALUE` to set Xcode build settings on the build. Allowed keys are a server-maintained allowlist of safe settings (currently `SWIFT_ACTIVE_COMPILATION_CONDITIONS`) plus any `APP_CONFIG_*` key for app configuration. Keys are passed to xcodebuild verbatim; use `$(inherited)` to append rather than replace, e.g. `--build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN'` (single-quote it so your shell does not evaluate `$(inherited)`) enables `#if LIMRUN`. An `APP_CONFIG_DEV_LOGIN_SECRET` value is referenced in `Info.plist` as `<string>$(APP_CONFIG_DEV_LOGIN_SECRET)</string>` and read at runtime with `Bundle.main`; its value is redacted in build logs.
 
-Provide `--certificate-p12`, `--certificate-password`, and `--provisioning-profile` together to sign a real-device build. When signing assets are provided without `--sdk`, the CLI builds with `iphoneos`; pass `--sdk watchos` for signed watchOS device builds.
+Provide `--certificate-p12`, `--certificate-password`, and `--provisioning-profile` together to sign a real-device build. When signing assets are provided without `--sdk`, the CLI builds with `iphoneos`; pass `--sdk watchos`, `--sdk appletvos`, or `--sdk xros` for signed watchOS, tvOS, or visionOS device builds. tvOS and visionOS require an explicit SDK and scheme; their simulator SDKs are not supported yet.
+
+Cloud signing supports the same device SDKs. `--upload-to-appstore` supports `iphoneos`, `appletvos`, and `xros`:
+
+```bash
+lim xcode build ./MyProject --scheme TVApp --sdk appletvos --configuration Release --signing-method app-store-connect --team-id "$TEAM_ID" --asc-key-id "$ASC_KEY_ID" --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey.p8 --upload-to-appstore
+lim xcode build ./MyProject --scheme VisionApp --sdk xros --configuration Release --signing-method app-store-connect --team-id "$TEAM_ID" --asc-key-id "$ASC_KEY_ID" --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey.p8 --upload-to-appstore
+```
 
 ---
 

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -33,7 +33,8 @@ import {
   type XcodeSigningConfig,
 } from '@limrun/api';
 
-const DEVICE_SDKS = new Set(['iphoneos', 'watchos']);
+const DEVICE_SDKS = new Set(['iphoneos', 'watchos', 'appletvos', 'xros']);
+const APP_STORE_SDKS = new Set(['iphoneos', 'appletvos', 'xros']);
 const SIMULATOR_SDKS = new Set(['iphonesimulator', 'watchsimulator']);
 type AppStoreFlags = {
   'upload-to-appstore': boolean;
@@ -66,6 +67,8 @@ export default class XcodeBuild extends BaseCommand {
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method release-testing --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload signed-device-build.ipa',
     '<%= config.bin %> xcode build ./MyProject --sdk iphoneos --configuration Release --signing-method app-store-connect --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload-to-appstore',
+    '<%= config.bin %> xcode build ./MyProject --scheme TVApp --sdk appletvos --configuration Release --signing-method app-store-connect --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload-to-appstore',
+    '<%= config.bin %> xcode build ./MyProject --scheme VisionApp --sdk xros --configuration Release --signing-method app-store-connect --team-id VMBY3VYW4U --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8 --upload-to-appstore',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./profile.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-issuer-id "$ASC_ISSUER_ID" --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build ./MyProject --scheme MyApp --certificate-p12 ./certificate.p12 --certificate-password "$P12_PASSWORD" --provisioning-profile ./app.mobileprovision --provisioning-profile ./widgets.mobileprovision --upload-to-appstore --asc-key-id 2X9R4HXF34 --asc-key ./AuthKey_2X9R4HXF34.p8',
     '<%= config.bin %> xcode build --id <ios-instance-ID> --project MyApp.xcodeproj --upload ios-build.zip',
@@ -105,7 +108,7 @@ export default class XcodeBuild extends BaseCommand {
     }),
     sdk: Flags.string({
       description: 'SDK family to build for.',
-      options: ['iphonesimulator', 'iphoneos', 'watchsimulator', 'watchos'],
+      options: ['iphonesimulator', 'iphoneos', 'watchsimulator', 'watchos', 'appletvos', 'xros'],
     }),
     'git-init': Flags.boolean({
       description:
@@ -176,7 +179,7 @@ export default class XcodeBuild extends BaseCommand {
     }),
     'signing-method': Flags.string({
       description:
-        'Use Apple cloud signing during archive export. Supports device SDK builds (--sdk iphoneos or --sdk watchos). Distribution methods require the ASC key to have access to cloud-managed distribution certificates.',
+        'Use Apple cloud signing during archive export. Supports device SDK builds (--sdk iphoneos, --sdk watchos, --sdk appletvos, or --sdk xros). Distribution methods require the ASC key to have access to cloud-managed distribution certificates.',
       options: ['app-store-connect', 'release-testing', 'debugging'],
     }),
     'team-id': Flags.string({
@@ -329,12 +332,16 @@ export default class XcodeBuild extends BaseCommand {
       const signing = await this.buildSigningOptions(flags);
       if (signing) {
         if (flags.sdk && SIMULATOR_SDKS.has(flags.sdk)) {
-          this.error('Signing is only supported for device SDK builds. Use --sdk iphoneos or --sdk watchos.');
+          this.error(
+            'Signing is only supported for device SDK builds. Use --sdk iphoneos, --sdk watchos, --sdk appletvos, or --sdk xros.',
+          );
         }
         if (!flags.sdk) {
           settings.sdk = 'iphoneos';
         } else if (!DEVICE_SDKS.has(flags.sdk)) {
-          this.error('Signing is only supported for device SDK builds. Use --sdk iphoneos or --sdk watchos.');
+          this.error(
+            'Signing is only supported for device SDK builds. Use --sdk iphoneos, --sdk watchos, --sdk appletvos, or --sdk xros.',
+          );
         }
         options.signing = signing;
       }
@@ -342,7 +349,7 @@ export default class XcodeBuild extends BaseCommand {
       if (cloudSigning) {
         if (flags.sdk && !DEVICE_SDKS.has(flags.sdk)) {
           this.error(
-            'Cloud signing is only supported for device SDK builds. Use --sdk iphoneos or --sdk watchos.',
+            'Cloud signing is only supported for device SDK builds. Use --sdk iphoneos, --sdk watchos, --sdk appletvos, or --sdk xros.',
           );
         }
         if (!flags.sdk) {
@@ -365,8 +372,8 @@ export default class XcodeBuild extends BaseCommand {
             '--upload-to-appstore delivers a signed IPA, so it requires manual signing flags or --signing-method.',
           );
         }
-        if (settings.sdk !== 'iphoneos') {
-          this.error('--upload-to-appstore requires --sdk iphoneos.');
+        if (!APP_STORE_SDKS.has(settings.sdk ?? '')) {
+          this.error('--upload-to-appstore requires --sdk iphoneos, --sdk appletvos, or --sdk xros.');
         }
         options.appstore = await this.buildAppStoreOptions(flags);
       }

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -48,7 +48,7 @@ export type XcodeBuildExecRequest = {
     workspace?: string;
     project?: string;
     scheme?: string;
-    sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos';
+    sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos' | 'appletvos' | 'xros';
     configuration?: 'Debug' | 'Release';
     artifactName?: string;
     /**

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -104,7 +104,7 @@ export type XcodeProjectConfig = {
   workspace?: string;
   project?: string;
   scheme?: string;
-  sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos';
+  sdk?: 'iphonesimulator' | 'iphoneos' | 'watchsimulator' | 'watchos' | 'appletvos' | 'xros';
   /**
    * xcodebuild configuration. Omit to use limbuild's project-type default:
    * Debug for native Xcode builds and Release for React Native / Expo builds.

--- a/tests/xcode-client-signing.test.ts
+++ b/tests/xcode-client-signing.test.ts
@@ -33,7 +33,7 @@ describe('xcode client signing', () => {
     });
 
     const result = await xcode.xcodebuild(
-      { sdk: 'iphoneos' },
+      { sdk: 'appletvos' },
       {
         signing: {
           certificateP12Base64: 'cert',
@@ -47,7 +47,7 @@ describe('xcode client signing', () => {
     expect(calls[0]?.init?.method).toBe('POST');
     expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
       command: 'xcodebuild',
-      xcodebuild: { sdk: 'iphoneos' },
+      xcodebuild: { sdk: 'appletvos' },
       signing: {
         certificateP12Base64: 'cert',
         certificatePassword: 'pw',
@@ -72,7 +72,7 @@ describe('xcode client signing', () => {
       token: 'xcode-token',
     });
     const result = await xcode.xcodebuild(
-      { sdk: 'iphoneos', configuration: 'Release' },
+      { sdk: 'xros', configuration: 'Release' },
       {
         cloudSigning: {
           method: 'app-store-connect',
@@ -93,7 +93,7 @@ describe('xcode client signing', () => {
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
       command: 'xcodebuild',
-      xcodebuild: { sdk: 'iphoneos', configuration: 'Release' },
+      xcodebuild: { sdk: 'xros', configuration: 'Release' },
       cloudSigning: {
         method: 'app-store-connect',
         teamId: 'TEAM123456',


### PR DESCRIPTION
## Summary
- expose `appletvos` and `xros` in the TypeScript Xcode build types and CLI SDK options
- allow manual/cloud signing and App Store Connect uploads for the new device SDKs
- add CLI examples and signing serialization coverage

## Test plan
- [x] `yarn test tests/xcode-client-signing.test.ts --runInBand`
- [x] `yarn build`
- [x] CLI build and 137-test suite
- [x] CLI lint and generated help verification

## Dependency
Requires [limrun#768](https://github.com/limrun-inc/limrun/pull/768).

Made with [Cursor](https://cursor.com)