### PR TITLE
Fix npm trusted publishing authentication

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 
 permissions:
-  id-token: write  # Required for OIDC
+  id-token: write # Required for OIDC
   contents: read
 
 jobs:
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -2,8 +2,6 @@
 
 set -eux
 
-npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
-
 yarn build
 cd dist
 
@@ -58,4 +56,4 @@ else
 fi
 
 # Publish with the appropriate tag
-yarn publish --tag "$TAG"
+npm publish --tag "$TAG"


### PR DESCRIPTION
## Summary
- grant the publish job permission to request a GitHub OIDC token
- publish with the npm CLI so trusted publishing is used without `NPM_TOKEN`

## Test plan
- [x] Run `./scripts/lint`
- [ ] Trigger the Publish NPM workflow

Made with [Cursor](https://cursor.com)