### PR TITLE
cli: add --entitlements for cloud signing

### DIFF
--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -17,6 +17,7 @@ import { webhookConfigFromFlags } from '../../lib/webhook-options';
 import { parseUploadOptions } from '../../lib/upload-options';
 import {
   cloudSigningFlagsProblem,
+  parseEntitlementsEntries,
   hasCloudSigningFlags,
   hasSigningFlags,
   signingFlagsProblem,
@@ -184,6 +185,12 @@ export default class XcodeBuild extends BaseCommand {
     }),
     'team-id': Flags.string({
       description: 'Apple Developer team ID for --signing-method, e.g. VMBY3VYW4U.',
+    }),
+    entitlements: Flags.string({
+      description:
+        'Path to a code-signing entitlements plist embedded during cloud signing (--signing-method), so capabilities like HealthKit or App Groups survive export. A bare path applies to the app; use <bundleId>=<path> for embedded bundles (widgets, watch apps). Values must be fully expanded (no $(...) build settings) and every capability must be enabled on the App ID. Repeatable.',
+      multiple: true,
+      multipleNonGreedy: true,
     }),
     'upload-to-appstore': Flags.boolean({
       description:
@@ -538,12 +545,27 @@ export default class XcodeBuild extends BaseCommand {
     if (!flags['signing-method']) {
       return undefined;
     }
+    // Entry problems are rejected by cloudSigningFlagsProblem before
+    // instance resolution; failing loudly here keeps that invariant honest.
+    const { entries, problem } = parseEntitlementsEntries(flags.entitlements ?? []);
+    if (problem) {
+      this.error(problem);
+    }
+    const entitlements = Object.fromEntries(
+      await Promise.all(
+        (entries ?? []).map(async (entry) => [
+          entry.bundleId,
+          await this.readFileBase64(entry.path, '--entitlements'),
+        ]),
+      ),
+    );
     return {
       method: flags['signing-method'] as XcodeCloudSigningMethod,
       teamId: flags['team-id']!,
       apiKeyId: flags['asc-key-id']!,
       apiIssuerId: flags['asc-issuer-id']!,
       apiPrivateKeyBase64: await this.readFileBase64(flags['asc-key']!, '--asc-key'),
+      ...(entries?.length && { entitlements }),
     };
   }
 

--- a/packages/cli/src/lib/xcode-signing-options.test.ts
+++ b/packages/cli/src/lib/xcode-signing-options.test.ts
@@ -2,6 +2,7 @@ import {
   cloudSigningFlagsProblem,
   hasCloudSigningFlags,
   hasSigningFlags,
+  parseEntitlementsEntries,
   signingFlagsProblem,
 } from './xcode-signing-options';
 
@@ -76,5 +77,53 @@ describe('hasCloudSigningFlags', () => {
     expect(hasCloudSigningFlags({})).toBe(false);
     expect(hasCloudSigningFlags({ 'signing-method': 'debugging' })).toBe(true);
     expect(hasCloudSigningFlags({ 'team-id': 'TEAM123456' })).toBe(true);
+  });
+});
+
+describe('parseEntitlementsEntries', () => {
+  it('treats a bare path as the app entry', () => {
+    expect(parseEntitlementsEntries(['./app.entitlements'])).toEqual({
+      entries: [{ bundleId: '', path: './app.entitlements' }],
+    });
+  });
+
+  it('splits bundleId=path entries', () => {
+    expect(parseEntitlementsEntries(['com.example.app.widgets=./w.entitlements'])).toEqual({
+      entries: [{ bundleId: 'com.example.app.widgets', path: './w.entitlements' }],
+    });
+  });
+
+  it('combines a bare path with bundle entries', () => {
+    expect(
+      parseEntitlementsEntries(['app.entitlements', 'com.example.app.widgets=w.entitlements']).entries,
+    ).toHaveLength(2);
+  });
+
+  it('keeps paths containing = when the prefix is not a bundle id', () => {
+    expect(parseEntitlementsEntries(['./builds/name=prod/app.entitlements'])).toEqual({
+      entries: [{ bundleId: '', path: './builds/name=prod/app.entitlements' }],
+    });
+  });
+
+  it('rejects a second bare path', () => {
+    expect(parseEntitlementsEntries(['a.entitlements', 'b.entitlements']).problem).toMatch(
+      /at most one bare path/,
+    );
+  });
+
+  it('rejects a duplicate bundle id', () => {
+    expect(parseEntitlementsEntries(['com.example.a=x.plist', 'com.example.a=y.plist']).problem).toMatch(
+      /provided twice/,
+    );
+  });
+
+  it('rejects an empty path after the bundle id', () => {
+    expect(parseEntitlementsEntries(['com.example.a=']).problem).toMatch(/missing the plist path/);
+  });
+
+  it('requires --signing-method through cloudSigningFlagsProblem', () => {
+    expect(cloudSigningFlagsProblem({ entitlements: ['app.entitlements'] })).toBe(
+      '--entitlements requires --signing-method.',
+    );
   });
 });

--- a/packages/cli/src/lib/xcode-signing-options.ts
+++ b/packages/cli/src/lib/xcode-signing-options.ts
@@ -10,6 +10,53 @@ export interface XcodeCloudSigningFlagValues extends XcodeSigningFlagValues {
   'asc-key-id'?: string;
   'asc-issuer-id'?: string;
   'asc-key'?: string;
+  entitlements?: string[];
+}
+
+export interface EntitlementsEntry {
+  /** Empty string targets the top-level app; the server resolves its bundle id. */
+  bundleId: string;
+  path: string;
+}
+
+// A value is <bundleId>=<path> when the left side of its first '=' looks
+// like a reverse-DNS bundle id: bundle-id charset and at least one dot.
+// Anything else, including paths containing '=', is a bare path; ./-prefix a
+// path to force that reading.
+const bundleIDPrefixPattern = /^[A-Za-z0-9][A-Za-z0-9.-]*$/;
+
+export function parseEntitlementsEntries(values: string[]): {
+  entries?: EntitlementsEntry[];
+  problem?: string;
+} {
+  const entries: EntitlementsEntry[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    let bundleId = '';
+    let path = value;
+    const eq = value.indexOf('=');
+    if (eq > 0) {
+      const prefix = value.slice(0, eq);
+      if (bundleIDPrefixPattern.test(prefix) && prefix.includes('.')) {
+        bundleId = prefix;
+        path = value.slice(eq + 1);
+      }
+    }
+    if (path === '') {
+      return { problem: `--entitlements ${value} is missing the plist path.` };
+    }
+    if (seen.has(bundleId)) {
+      return {
+        problem:
+          bundleId === '' ?
+            '--entitlements takes at most one bare path (the app); use <bundleId>=<path> for embedded bundles.'
+          : `--entitlements provided twice for bundle id ${bundleId}.`,
+      };
+    }
+    seen.add(bundleId);
+    entries.push({ bundleId, path });
+  }
+  return { entries };
 }
 
 export function hasSigningFlags(flags: XcodeSigningFlagValues): boolean {
@@ -45,11 +92,18 @@ export function hasCloudSigningFlags(flags: XcodeCloudSigningFlagValues): boolea
 }
 
 export function cloudSigningFlagsProblem(flags: XcodeCloudSigningFlagValues): string | undefined {
+  if (flags.entitlements !== undefined && flags['signing-method'] === undefined) {
+    return '--entitlements requires --signing-method.';
+  }
   if (!hasCloudSigningFlags(flags)) {
     return undefined;
   }
   if (flags['signing-method'] === undefined) {
     return '--team-id requires --signing-method.';
+  }
+  const parsed = parseEntitlementsEntries(flags.entitlements ?? []);
+  if (parsed.problem) {
+    return parsed.problem;
   }
   if (hasSigningFlags(flags)) {
     return 'Cloud signing flags cannot be combined with --certificate-p12, --certificate-password, or --provisioning-profile.';

--- a/src/exec-client.ts
+++ b/src/exec-client.ts
@@ -96,6 +96,7 @@ export type XcodeBuildExecRequest = {
     apiKeyId: string;
     apiIssuerId: string;
     apiPrivateKeyBase64: string;
+    entitlements?: Record<string, string>;
   };
   /** Wire name retained for compatibility with the limbuild exec API. */
   testflight?: AppStoreUploadConfig;

--- a/src/resources/xcode-instances-helpers.ts
+++ b/src/resources/xcode-instances-helpers.ts
@@ -195,6 +195,15 @@ export type XcodeCloudSigningConfig = {
   apiKeyId: string;
   apiIssuerId: string;
   apiPrivateKeyBase64: string;
+  /**
+   * Base64-encoded entitlements plists keyed by bundle id, embedded into
+   * the archive so cloud signing preserves capability entitlements
+   * (HealthKit, CloudKit, app groups, ...). The empty key targets the
+   * top-level app. Values must be fully expanded (no $(...) build
+   * settings) and every capability must be enabled on the App ID. Older
+   * limbuild servers silently ignore this field.
+   */
+  entitlements?: Record<string, string>;
 };
 
 export type ReactNativeBuildConfig = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches cloud signing export configuration; bad entitlements or App ID capabilities can fail signing, but changes are additive with upfront CLI validation and no change to credential or ASC key handling.
> 
> **Overview**
> Adds **`--entitlements`** to **`lim xcode build`** when using **`--signing-method`**, so custom capability entitlements (HealthKit, App Groups, etc.) are embedded into the archive before Apple cloud signing and survive export.
> 
> A **bare plist path** targets the main app; **`&lt;bundleId&gt;=&lt;path&gt;`** targets extensions (widgets, watch apps). The CLI validates entries early (one app path max, no duplicate bundle IDs, **`--entitlements` requires `--signing-method`**) and sends **base64 plists** on **`cloudSigning.entitlements`** in the exec request. Older limbuild servers ignore the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a25068279c35314e65d1fee05a67d63cc4d058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->