### PR TITLE
cli: read build webhook and signed upload URL from the environment

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -485,6 +485,11 @@ lim xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --
 # Headless one-shot build: return after submission and reap the fresh instance shortly after completion
 lim xcode build ./MyProject --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun
 
+# Same callback, configured through the environment instead of the command line
+LIM_WEBHOOK_URL=https://ci.example.com/hooks/limrun \
+  LIM_WEBHOOK_HEADERS="Authorization=Bearer $HOOK_SECRET" \
+  lim xcode build ./MyProject --detach
+
 # Attach an existing simulator so builds auto-install there
 lim xcode attach-simulator ios_abc123 --id sandbox_def456
 
@@ -720,6 +725,16 @@ lim asset pull my-app-build -o ./build-output
 `lim xcode build [PATH]` automatically performs a one-shot code sync for the given project path before invoking `xcodebuild`. The sync step automatically ignores build artifacts (`build/`, `DerivedData/`, `.build/`), dependency folders (`Pods/`, `Carthage/Build/`, `.swiftpm/`), and user-specific files (`xcuserdata/`, `.dSYM/`).
 
 For headless CI-style builds, pass `--detach --webhook-url <url>`. The command still creates or resolves the instance and syncs the project, but returns as soon as limbuild accepts the build rather than holding an SSE log stream open until completion. `--detach` requires a webhook so the terminal result remains observable. Pass `--inactivity-timeout <duration>` (for example `3s`) to skip any cached Xcode target and create a fresh one-shot instance with that timeout; it cannot be combined with `--id`. Active builds continually report activity, so a short timeout only starts expiring once build work stops. The inactivity controller checks approximately every 15 seconds, so actual teardown can lag the configured timeout by that interval.
+
+The build-capture flags are also readable from the environment (including a local `.env` file), so a wrapper or CI system can attach a callback without editing the command line — and without putting a bearer token or a signed URL into argv, where `ps` and parse-error output can expose it. This applies to both `lim xcode build` and `lim gradle build`:
+
+| Variable                | Flag                  | Notes                                                                                                                                    |
+| ----------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `LIM_WEBHOOK_URL`       | `--webhook-url`       | Satisfies `--detach` on its own.                                                                                                         |
+| `LIM_WEBHOOK_HEADERS`   | `--webhook-header`    | Several headers separated by commas, e.g. `Authorization=Bearer x,X-Trace=abc`. A literal comma inside a value is written `\,`.          |
+| `LIM_SIGNED_UPLOAD_URL` | `--signed-upload-url` | An explicit `--upload` takes precedence and the variable is ignored, so a wrapper's ambient URL never collides with a chosen asset name. |
+
+A flag passed on the command line always wins over its variable, and env-sourced values are validated and sent exactly like flag-sourced ones. For `--webhook-header` that means replacement, not merging: one `--webhook-header` on the command line drops every header `LIM_WEBHOOK_HEADERS` would have set, so repeat the ambient ones alongside yours if you need both.
 
 #### Run project commands
 

--- a/packages/cli/src/commands/gradle/build.ts
+++ b/packages/cli/src/commands/gradle/build.ts
@@ -16,6 +16,7 @@ import {
 } from '../../lib/gradle-signing';
 import { formatDurationMs } from '../../lib/duration';
 import { formatBytes } from '../../lib/bytes';
+import { repeatableFlagFromEnv } from '../../lib/repeatable-flag-env';
 
 export default class GradleBuild extends BaseCommand {
   static summary = 'Build an Android project on a gradle instance';
@@ -33,6 +34,7 @@ export default class GradleBuild extends BaseCommand {
     '<%= config.bin %> gradle build --keystore upload.jks --keystore-password *** --key-alias upload --key-password *** --save-key',
     '<%= config.bin %> gradle build ./my-app --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
     '<%= config.bin %> gradle build ./my-app --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun',
+    'LIM_WEBHOOK_URL=https://ci.example.com/hooks/limrun LIM_WEBHOOK_HEADERS="Authorization=Bearer $HOOK_SECRET" <%= config.bin %> gradle build ./my-app --detach',
     '<%= config.bin %> gradle build --sign --upload-to-playstore --playstore-service-account service-account.json',
   ];
 
@@ -77,7 +79,13 @@ export default class GradleBuild extends BaseCommand {
         "TTL of the uploaded asset as a Go duration (e.g. 24h, 30m). Defaults to 336h (14 days); each build upload pushes the asset's expiry that far out from the upload.",
     }),
     'signed-upload-url': Flags.string({
-      description: 'Presigned URL to upload the resulting APK or AAB to.',
+      description:
+        'Presigned URL to upload the resulting APK or AAB to. Defaults to LIM_SIGNED_UPLOAD_URL, unless --upload already names a destination.',
+      // A `default` rather than `env` so the variable never lands alongside
+      // --upload: it is ambient wrapper configuration, and the two flags
+      // name different destinations, so an env value must not read as the
+      // contradiction that two explicit flags do.
+      default: async ({ flags }) => (flags['upload'] ? undefined : process.env['LIM_SIGNED_UPLOAD_URL']),
     }),
     sign: Flags.boolean({
       description:
@@ -109,11 +117,16 @@ export default class GradleBuild extends BaseCommand {
     'webhook-url': Flags.string({
       description:
         'HTTPS URL that the build daemon POSTs a JSON payload to once the build reaches a terminal state, carrying the result and a console debug link. Must be a public DNS host; IP-literal and private targets are rejected. Delivery is best-effort and never fails the build.',
+      env: 'LIM_WEBHOOK_URL',
     }),
     'webhook-header': Flags.string({
       description:
-        'Header to set verbatim on the webhook request as NAME=VALUE, for example Authorization="Bearer $SECRET". Requires --webhook-url. Repeat for multiple headers (at most 16).',
+        'Header to set verbatim on the webhook request as NAME=VALUE, for example Authorization="Bearer $SECRET". Requires --webhook-url. Repeat for multiple headers (at most 16). Defaults to LIM_WEBHOOK_HEADERS, which holds several headers separated by commas; write a literal comma inside a value as \\,.',
       multiple: true,
+      // A `default` rather than `env`: oclif hands a `multiple` flag its env
+      // value unsplit and unwrapped, which would put a bare string behind a
+      // string[] type. See repeatableFlagFromEnv.
+      default: async () => repeatableFlagFromEnv('LIM_WEBHOOK_HEADERS'),
     }),
     'upload-to-playstore': Flags.boolean({
       description:

--- a/packages/cli/src/commands/xcode/build.ts
+++ b/packages/cli/src/commands/xcode/build.ts
@@ -15,6 +15,7 @@ import { parseEnvEntries } from '../../lib/env-entries';
 import { registerCreatedInstance, type LastIosInstance, type LastXcodeInstance } from '../../lib/config';
 import { webhookConfigFromFlags } from '../../lib/webhook-options';
 import { parseUploadOptions } from '../../lib/upload-options';
+import { repeatableFlagFromEnv } from '../../lib/repeatable-flag-env';
 import {
   cloudSigningFlagsProblem,
   hasCloudSigningFlags,
@@ -77,6 +78,7 @@ export default class XcodeBuild extends BaseCommand {
     `<%= config.bin %> xcode build ./MyProject --build-setting 'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) LIMRUN' --build-setting APP_CONFIG_DEV_LOGIN_SECRET="$DEV_LOGIN_SECRET"`,
     '<%= config.bin %> xcode build ./MyProject --webhook-url https://ci.example.com/hooks/limrun --webhook-header Authorization="Bearer $HOOK_SECRET"',
     '<%= config.bin %> xcode build ./MyProject --detach --inactivity-timeout 3s --webhook-url https://ci.example.com/hooks/limrun',
+    'LIM_WEBHOOK_URL=https://ci.example.com/hooks/limrun LIM_WEBHOOK_HEADERS="Authorization=Bearer $HOOK_SECRET" <%= config.bin %> xcode build ./MyProject --detach',
     '<%= config.bin %> xcode build ./MyProject --basis-cache-dir ./.limsync-cache',
     '<%= config.bin %> xcode build ./MyProject --ignore "\\\\.xcuserdata/"',
     '<%= config.bin %> xcode build ./MyProject --additional-file ~/.netrc=~/.netrc',
@@ -149,7 +151,13 @@ export default class XcodeBuild extends BaseCommand {
         'App metadata to record on the uploaded asset as key=value, repeatable. Keys: displayName, bundleIdentifier, shortVersion, buildVersion, deeplink. limbuild extracts the same metadata from the built bundle and overwrites it; values set here survive only for fields the bundle does not declare (e.g. deeplink).',
     }),
     'signed-upload-url': Flags.string({
-      description: 'Presigned URL to upload the resulting build artifact to.',
+      description:
+        'Presigned URL to upload the resulting build artifact to. Defaults to LIM_SIGNED_UPLOAD_URL, unless --upload already names a destination.',
+      // A `default` rather than `env` so the variable never lands alongside
+      // --upload: it is ambient wrapper configuration, and the two flags
+      // name different destinations, so an env value must not read as the
+      // contradiction that two explicit flags do.
+      default: async ({ flags }) => (flags['upload'] ? undefined : process.env['LIM_SIGNED_UPLOAD_URL']),
     }),
     'build-setting': Flags.string({
       description:
@@ -213,11 +221,16 @@ export default class XcodeBuild extends BaseCommand {
     'webhook-url': Flags.string({
       description:
         'HTTPS URL that limbuild POSTs a JSON payload to once the build reaches a terminal state, carrying the result, a console debug link, and a presigned build-log URL. Must be a public DNS host; IP-literal and private targets are rejected. Delivery is best-effort and never fails the build.',
+      env: 'LIM_WEBHOOK_URL',
     }),
     'webhook-header': Flags.string({
       description:
-        'Header to set verbatim on the webhook request as NAME=VALUE, for example Authorization="Bearer $SECRET". Requires --webhook-url. Repeat for multiple headers (at most 16).',
+        'Header to set verbatim on the webhook request as NAME=VALUE, for example Authorization="Bearer $SECRET". Requires --webhook-url. Repeat for multiple headers (at most 16). Defaults to LIM_WEBHOOK_HEADERS, which holds several headers separated by commas; write a literal comma inside a value as \\,.',
       multiple: true,
+      // A `default` rather than `env`: oclif hands a `multiple` flag its env
+      // value unsplit and unwrapped, which would put a bare string behind a
+      // string[] type. See repeatableFlagFromEnv.
+      default: async () => repeatableFlagFromEnv('LIM_WEBHOOK_HEADERS'),
     }),
     detach: Flags.boolean({
       description:

--- a/packages/cli/src/lib/build-env-flags.test.ts
+++ b/packages/cli/src/lib/build-env-flags.test.ts
@@ -1,0 +1,94 @@
+import { Interfaces, Parser } from '@oclif/core';
+import GradleBuild from '../commands/gradle/build';
+import XcodeBuild from '../commands/xcode/build';
+import { webhookConfigFromFlags, type WebhookFlagValues } from './webhook-options';
+
+// Lives under lib/ rather than beside the commands because test files compile
+// into dist/, where oclif would pick up dist/commands/*.test.js as a command.
+
+type BuildFlagValues = WebhookFlagValues & {
+  detach?: boolean;
+  upload?: string;
+  'signed-upload-url'?: string;
+};
+
+const VARS = ['LIM_WEBHOOK_URL', 'LIM_WEBHOOK_HEADERS', 'LIM_SIGNED_UPLOAD_URL'];
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const name of VARS) {
+    saved[name] = process.env[name];
+    delete process.env[name];
+  }
+});
+
+afterEach(() => {
+  for (const name of VARS) {
+    if (saved[name] === undefined) delete process.env[name];
+    else process.env[name] = saved[name];
+  }
+});
+
+async function parseFlags(flags: Interfaces.FlagInput, argv: string[]): Promise<BuildFlagValues> {
+  const { flags: parsed } = await Parser.parse(argv, { flags, strict: false });
+  return parsed as BuildFlagValues;
+}
+
+describe.each([
+  { name: 'xcode build', flags: XcodeBuild.flags as Interfaces.FlagInput },
+  { name: 'gradle build', flags: GradleBuild.flags as Interfaces.FlagInput },
+])('$name captures build flags from the environment', ({ flags }) => {
+  it('takes the webhook from the environment, and lets an explicit flag replace it', async () => {
+    process.env['LIM_WEBHOOK_HEADERS'] = 'Authorization=Bearer ambient,X-Trace=abc';
+    const headersOnly = await parseFlags(flags, []);
+    expect(() => webhookConfigFromFlags(headersOnly)).toThrow('--webhook-header requires --webhook-url.');
+
+    process.env['LIM_WEBHOOK_URL'] = 'https://ambient.example.com/hooks';
+    expect(webhookConfigFromFlags(await parseFlags(flags, []))).toEqual({
+      url: 'https://ambient.example.com/hooks',
+      headers: { Authorization: 'Bearer ambient', 'X-Trace': 'abc' },
+    });
+
+    // Argv replaces the variable outright rather than merging with it.
+    const typed = await parseFlags(flags, [
+      '--webhook-url',
+      'https://typed.example.com/hooks',
+      '--webhook-header',
+      'Authorization=Bearer typed',
+    ]);
+    expect(webhookConfigFromFlags(typed)).toEqual({
+      url: 'https://typed.example.com/hooks',
+      headers: { Authorization: 'Bearer typed' },
+    });
+  });
+
+  it('satisfies the --detach guard with a webhook URL from the environment', async () => {
+    process.env['LIM_WEBHOOK_URL'] = 'https://ci.example.com/hooks/limrun';
+    const parsed = await parseFlags(flags, ['--detach']);
+    // The guard both commands run is `flags.detach && !flags['webhook-url']`.
+    expect(parsed.detach).toBe(true);
+    expect(parsed['webhook-url']).toBe('https://ci.example.com/hooks/limrun');
+  });
+
+  it('withholds the ambient signed upload URL when --upload names a destination', async () => {
+    process.env['LIM_SIGNED_UPLOAD_URL'] = 'https://storage.example.com/put?sig=ambient';
+    expect((await parseFlags(flags, []))['signed-upload-url']).toBe(
+      'https://storage.example.com/put?sig=ambient',
+    );
+
+    // Never reaches the parsed flags, so the commands' "not both" guard sees
+    // only the destination the caller actually asked for.
+    expect((await parseFlags(flags, ['--upload', 'myapp-build']))['signed-upload-url']).toBeUndefined();
+
+    // Two explicit flags do still contradict each other, and both survive
+    // parsing so the guard can reject them.
+    const typed = await parseFlags(flags, [
+      '--upload',
+      'myapp-build',
+      '--signed-upload-url',
+      'https://storage.example.com/put?sig=typed',
+    ]);
+    expect(typed.upload).toBe('myapp-build');
+    expect(typed['signed-upload-url']).toBe('https://storage.example.com/put?sig=typed');
+  });
+});

--- a/packages/cli/src/lib/gradle-build-options.test.ts
+++ b/packages/cli/src/lib/gradle-build-options.test.ts
@@ -46,6 +46,13 @@ describe('gradleBuildOptionsFromFlags signing validation', () => {
     },
     { name: 'sign with an explicit bundle task', flags: { sign: true, task: [':app:bundleRelease'] } },
     { name: 'BYO keystore with a debug task stays allowed', flags: { ...byo, task: ['assembleDebug'] } },
+    {
+      // The commands rely on this: LIM_SIGNED_UPLOAD_URL is withheld when
+      // --upload is present, so reaching here means both were passed.
+      name: 'upload with an explicit signed upload URL',
+      flags: { upload: 'app.aab', 'signed-upload-url': 'https://storage.example.com/put' },
+      error: /not both/,
+    },
   ];
 
   it.each(cases)('$name', ({ flags, error }) => {

--- a/packages/cli/src/lib/repeatable-flag-env.test.ts
+++ b/packages/cli/src/lib/repeatable-flag-env.test.ts
@@ -1,0 +1,35 @@
+import { repeatableFlagFromEnv } from './repeatable-flag-env';
+
+describe('repeatableFlagFromEnv', () => {
+  const VAR = 'LIM_TEST_REPEATABLE';
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[VAR];
+    delete process.env[VAR];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[VAR];
+    else process.env[VAR] = saved;
+  });
+
+  it('returns nothing when the variable is unset or holds no entries', () => {
+    expect(repeatableFlagFromEnv(VAR)).toBeUndefined();
+    process.env[VAR] = '';
+    expect(repeatableFlagFromEnv(VAR)).toBeUndefined();
+    process.env[VAR] = ',,';
+    expect(repeatableFlagFromEnv(VAR)).toBeUndefined();
+  });
+
+  it('splits on unescaped commas', () => {
+    // One value carrying all three cases: an escaped comma inside a
+    // SigV4-style Authorization, a real separator, and the trailing one a
+    // concatenating wrapper leaves behind.
+    process.env[VAR] = 'Authorization=AWS4-HMAC-SHA256 Credential=x\\, Signature=y,X-Trace=abc,';
+    expect(repeatableFlagFromEnv(VAR)).toEqual([
+      'Authorization=AWS4-HMAC-SHA256 Credential=x, Signature=y',
+      'X-Trace=abc',
+    ]);
+  });
+});

--- a/packages/cli/src/lib/repeatable-flag-env.ts
+++ b/packages/cli/src/lib/repeatable-flag-env.ts
@@ -1,0 +1,30 @@
+/** A comma that is not escaped as `\,`. */
+const ENTRY_SEPARATOR = /(?<!\\),/;
+
+/**
+ * Default for a `multiple: true` flag whose entries can come from an
+ * environment variable, as comma-separated values.
+ *
+ * Use this rather than the flag's `env` property: oclif passes an env-sourced
+ * value to a `multiple` flag unsplit and unwrapped (@oclif/core 4.13), so the
+ * flag's declared string[] would hold a bare string and every consumer would
+ * iterate it by character. A `default` returning the parsed array keeps the
+ * declared type honest, and argv still wins because oclif resolves tokens
+ * before defaults.
+ *
+ * Values legitimately contain commas (an AWS SigV4 Authorization header is
+ * full of them), so a literal one is written `\,`, matching how oclif
+ * unescapes its own delimited flags. Empty segments are dropped, since a
+ * wrapper concatenating the variable routinely leaves a trailing separator.
+ */
+export function repeatableFlagFromEnv(variable: string): string[] | undefined {
+  const raw = process.env[variable];
+  if (!raw) {
+    return undefined;
+  }
+  const entries = raw
+    .split(ENTRY_SEPARATOR)
+    .map((entry) => entry.trim().replace(/\\,/g, ','))
+    .filter((entry) => entry.length > 0);
+  return entries.length > 0 ? entries : undefined;
+}

--- a/packages/cli/src/lib/webhook-options.test.ts
+++ b/packages/cli/src/lib/webhook-options.test.ts
@@ -46,6 +46,16 @@ describe('webhookConfigFromFlags', () => {
     }
   });
 
+  test('names a malformed entry by position instead of echoing the credential', () => {
+    const call = () =>
+      webhookConfigFromFlags({
+        'webhook-url': 'https://ci.example.com/h',
+        'webhook-header': ['X-Trace=abc', 'Bearer sk-live-supersecret'],
+      });
+    expect(call).toThrow('Invalid --webhook-header entry 2: expected NAME=VALUE.');
+    expect(call).not.toThrow(/sk-live-supersecret/);
+  });
+
   test('rejects duplicate header names', () => {
     expect(() =>
       webhookConfigFromFlags({

--- a/packages/cli/src/lib/webhook-options.ts
+++ b/packages/cli/src/lib/webhook-options.ts
@@ -26,10 +26,13 @@ export function webhookConfigFromFlags(flags: WebhookFlagValues): WebhookConfig 
   }
   const headers: Record<string, string> = {};
   const seen = new Set<string>();
-  for (const entry of headerEntries) {
+  for (const [index, entry] of headerEntries.entries()) {
     const separator = entry.indexOf('=');
     if (separator <= 0) {
-      throw new Error(`Invalid --webhook-header ${JSON.stringify(entry)}: expected NAME=VALUE.`);
+      // Reported by position, never echoed: the entry is usually an
+      // Authorization value, and one that came from the environment is
+      // otherwise absent from the terminal.
+      throw new Error(`Invalid --webhook-header entry ${index + 1}: expected NAME=VALUE.`);
     }
     const name = entry.slice(0, separator);
     const key = name.toLowerCase();


### PR DESCRIPTION
## Summary

- `--webhook-url`, `--webhook-header`, and `--signed-upload-url` on `lim xcode build` and
  `lim gradle build` now also read `LIM_WEBHOOK_URL`, `LIM_WEBHOOK_HEADERS`, and
  `LIM_SIGNED_UPLOAD_URL`
- a malformed `--webhook-header` is reported by position instead of echoed

CI wrappers that shim `lim` need to attach a build-finish webhook without editing the user's command
line, and argv is the wrong channel: `--webhook-header` carries a bearer token,
`--signed-upload-url` is a signed capability, and both are readable from `/proc/<pid>/cmdline`.
Explicit flags still win; env values take the same validation and request path. CLI-only.

## Why two mechanisms

`--webhook-url` uses oclif's `env`. `env` breaks on the other two, so they use a `default`:

- **`--webhook-header`** is `multiple`, and oclif hands those their env value unsplit and unwrapped —
  a bare string behind a `string[]`. `delimiter` applies only to argv, and adding it would change
  what a repeated flag containing a comma means today. The default returns a parsed array and keeps
  the quirk in `repeatableFlagFromEnv`.
- **`--signed-upload-url`** contradicts `--upload`, and an ambient variable is not a contradiction.
  Its default withholds the value when `--upload` is present, so the existing "not both" guards work
  untouched — `gradle-build-options.ts` and `upload-options.ts` are unchanged.

## Test plan

- [x] `./scripts/lint`
- [x] `./scripts/test` (700 passed), and `yarn build && yarn test` in `packages/cli` (147 passed)
- [x] stripped the env wiring and confirmed the new tests fail rather than pass vacuously

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only flag parsing and safer validation messages; explicit flags still win and upload/webhook guards are preserved.
> 
> **Overview**
> **`lim xcode build`** and **`lim gradle build`** can now supply webhook and presigned-upload settings via **`LIM_WEBHOOK_URL`**, **`LIM_WEBHOOK_HEADERS`**, and **`LIM_SIGNED_UPLOAD_URL`** (including from `.env`), so CI wrappers can attach callbacks and upload targets without putting bearer tokens or signed URLs on the command line.
> 
> Command-line flags still override env values. **`LIM_WEBHOOK_HEADERS`** is comma-separated with `\,` for literal commas; any **`--webhook-header`** on argv replaces the whole env-derived header list (no merge). **`LIM_SIGNED_UPLOAD_URL`** is ignored when **`--upload`** is set so ambient wrapper config does not trip the existing “not both” validation.
> 
> Adds **`repeatableFlagFromEnv`** for oclif `multiple` flags fed from env. Malformed **`--webhook-header`** errors are reported by **entry index** instead of echoing the value. README and tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b68566d3389c4cd9cff0f979ac841ca68bee8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->