### PR TITLE
ci: drop the retired NPM_TOKEN gate; npm publishing is OIDC

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,6 +30,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
+      # npm OIDC trusted publishing needs npm >= 11.5; the bundled npm can lag.
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -17,5 +17,3 @@ jobs:
       - name: Check release environment
         run: |
           bash ./bin/check-release-environment
-        env:
-          NPM_TOKEN: ${{ secrets.LIMRUN_NPM_TOKEN || secrets.NPM_TOKEN }}

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,9 +2,8 @@
 
 errors=()
 
-if [ -z "${NPM_TOKEN}" ]; then
-  errors+=("The NPM_TOKEN secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
+# npm publishing uses OIDC trusted publishing (see publish-npm.yml); there
+# is no registry secret to verify here.
 
 lenErrors=${#errors[@]}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes around release checks and npm version; no runtime SDK or auth logic in application code.
> 
> **Overview**
> Release CI no longer treats an **`NPM_TOKEN`** secret as required, matching **npm OIDC trusted publishing** used in the publish workflow.
> 
> **`release-doctor`** stops passing **`NPM_TOKEN`** into **`check-release-environment`**, and that script removes the secret-missing failure path in favor of a note that registry auth is handled via OIDC in **`publish-npm.yml`**.
> 
> The **Publish NPM** workflow adds a step to **`npm install -g npm@latest`** so the runner meets **npm ≥ 11.5**, which OIDC trusted publishing needs when the Node setup’s bundled npm is older.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd813f9db3ad3030cd93b5249376064b98f2db2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->