### PR TITLE
cli: release 0.30.3 for cloud signing entitlements

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lim",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Use remote XCode, Gradle, iOS Simulator, Android Emulator and more to build and test apps from Linux, Windows or macOS.",
   "bin": {
     "lim": "./bin/run.js"
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@limrun/api": "^0.48.3",
+    "@limrun/api": "^0.48.4",
     "@oclif/core": "^4",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.5",

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -578,10 +578,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@limrun/api@^0.48.3":
-  version "0.48.3"
-  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.48.3.tgz#0f5303f8faccc818f1666a1f44cc9127ce1c94f8"
-  integrity sha512-TSmedDxfVq9mffFKPKct+8JvVrdlXrsKq1NmZUCoNXWpqDcetA4VjMKer0IqG0cLuTwzZoOUdykY5JOR4A3v5g==
+"@limrun/api@^0.48.4":
+  version "0.48.4"
+  resolved "https://registry.yarnpkg.com/@limrun/api/-/api-0.48.4.tgz#3f90283ea49d11891546f9e43d75a4ec3bf14a0c"
+  integrity sha512-cSmcbgE/MauQ2raBHg7hdiL3uzJ5NE9JKGvWkIFhGX2GlFgStjxCeXqR5/S09K3qexsSZEeTSyK5PKUv0nzXqQ==
   dependencies:
     "@limrun/xdelta3-wasm" "0.2.0"
     eventsource-client "^1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency and version bump only; no application logic changes in the CLI package.
> 
> **Overview**
> **Release `lim` CLI 0.30.3** by bumping the package version and pinning **`@limrun/api` from `^0.48.3` to `^0.48.4`** (with the matching `yarn.lock` update).
> 
> There are **no CLI source changes** in this diff—the release ships the newer API client so users get **Xcode cloud signing / entitlements** support that landed in `@limrun/api` 0.48.4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2171725bfaebc096d6da55c9bcf1d946215f8ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->