### PR TITLE
examples: fix compilation and staging-portability breakages

### DIFF
--- a/examples/android-video-recording/package.json
+++ b/examples/android-video-recording/package.json
@@ -17,6 +17,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/android-video-recording/yarn.lock
+++ b/examples/android-video-recording/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/appium-ios/index.ts
+++ b/examples/appium-ios/index.ts
@@ -46,8 +46,11 @@ console.log('Device UDID:', lim.deviceInfo.udid);
 
 // targetHttpPortUrlPrefix allows us to append any port to the URL to connect to that port
 // on the simulator and WDA listens on port 8100 by default.
-// The :443 addition is required by the Appium driver.
-const wdaUrl = instance.status.targetHttpPortUrlPrefix.replace('limrun.net', 'limrun.net:443') + '8100';
+// The Appium driver requires an explicit port in the URL and defaults to
+// 4444 when it is missing, so assemble one with the port spelled out.
+// (URL.toString() would drop an explicit :443 as the https default.)
+const wdaBase = new URL(instance.status.targetHttpPortUrlPrefix);
+const wdaUrl = `${wdaBase.protocol}//${wdaBase.hostname}:${wdaBase.port || '443'}${wdaBase.pathname}8100`;
 
 // WDA may crash during the test and launchMode in initialAssets is effective only for
 // the first installation. So, we make sure WDA is running before the test starts.
@@ -85,6 +88,9 @@ const driver = await remote({
     'appium:useNewWDA': false,
     'appium:usePreinstalledWDA': true,
     'appium:skipLogCapture': true,
+    // Safari's first launch on a fresh instance can take a while to expose
+    // its webviews to the remote debugger.
+    'appium:webviewConnectTimeout': 60_000,
     // @ts-expect-error -- limInstance* are our custom capabilities not known to webdriverio
     'appium:limInstanceApiUrl': instance.status.apiUrl,
     'appium:limInstanceToken': instance.status.token,

--- a/examples/asset/package.json
+++ b/examples/asset/package.json
@@ -17,6 +17,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/asset/yarn.lock
+++ b/examples/asset/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/ios-hot-reload/package.json
+++ b/examples/ios-hot-reload/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   },

--- a/examples/ios-hot-reload/yarn.lock
+++ b/examples/ios-hot-reload/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/ios-iap-testing/package.json
+++ b/examples/ios-iap-testing/package.json
@@ -17,6 +17,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/ios-iap-testing/yarn.lock
+++ b/examples/ios-iap-testing/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/ios-video-recording/index.ts
+++ b/examples/ios-video-recording/index.ts
@@ -34,9 +34,17 @@ try {
   await client.launchApp('com.apple.Preferences');
   console.log('Launched Settings');
 
-  // Wait for Settings to render before tapping into General.
-  await sleep(1000);
-  await client.tapElement({ AXLabel: 'General' });
+  // Settings renders asynchronously; retry the tap until the row appears.
+  const tapDeadline = Date.now() + 15_000;
+  for (;;) {
+    try {
+      await client.tapElement({ AXLabel: 'General' });
+      break;
+    } catch (error) {
+      if (Date.now() > tapDeadline) throw error;
+      await sleep(1000);
+    }
+  }
   console.log('Opened General in Settings');
 
   // Open Safari to apple.com from the simulator.
@@ -56,6 +64,7 @@ try {
   console.log('Stopped recording and saved to video.mp4');
 } catch (error) {
   console.error('Error:', error);
+  process.exitCode = 1;
 } finally {
   client.disconnect();
   console.log('\nDisconnected from instance');

--- a/examples/ios-video-recording/index.ts
+++ b/examples/ios-video-recording/index.ts
@@ -36,7 +36,7 @@ try {
 
   // Wait for Settings to render before tapping into General.
   await sleep(1000);
-  await client.tapElement({ label: 'General' });
+  await client.tapElement({ AXLabel: 'General' });
   console.log('Opened General in Settings');
 
   // Open Safari to apple.com from the simulator.

--- a/examples/ios-video-recording/package.json
+++ b/examples/ios-video-recording/package.json
@@ -17,6 +17,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/ios-video-recording/yarn.lock
+++ b/examples/ios-video-recording/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/maestro-ios/package.json
+++ b/examples/maestro-ios/package.json
@@ -13,6 +13,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/maestro-ios/yarn.lock
+++ b/examples/maestro-ios/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/tunnel/index.ts
+++ b/examples/tunnel/index.ts
@@ -46,3 +46,5 @@ process.on('SIGTERM', () => {
 await new Promise((resolve) => setTimeout(resolve, 30_000));
 console.log('Closing the ADB tunnel');
 close();
+await limrun.androidInstances.delete(androidInstance.metadata.id);
+console.log('Deleted instance');

--- a/examples/tunnel/package.json
+++ b/examples/tunnel/package.json
@@ -17,6 +17,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/tunnel/yarn.lock
+++ b/examples/tunnel/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/websocket-android/package.json
+++ b/examples/websocket-android/package.json
@@ -17,6 +17,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/websocket-android/yarn.lock
+++ b/examples/websocket-android/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"

--- a/examples/websocket-ios/index.ts
+++ b/examples/websocket-ios/index.ts
@@ -30,6 +30,24 @@ const client = await Ios.createInstanceClient({
   logLevel: 'debug',
 });
 console.log('Connected to instance');
+
+// Screens render asynchronously (app cold launches, keyboard focus), so
+// retry a tap until its element appears instead of sleeping a fixed time.
+async function tapWhenPresent(
+  selector: Parameters<typeof client.tapElement>[0],
+  deadlineMs = 20_000,
+): Promise<Awaited<ReturnType<typeof client.tapElement>>> {
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    try {
+      return await client.tapElement(selector);
+    } catch (error) {
+      if (Date.now() > deadline) throw error;
+      await sleep(1000);
+    }
+  }
+}
+
 try {
   // ========================================================================
   // Screenshot
@@ -55,18 +73,43 @@ try {
 
   // Element tree at specific point
   console.log('\n--- Testing tapElement ---');
-  const safari = await client.tapElement({ AXUniqueId: 'Safari' });
+  // The instance may be reused from a previous run with an app in the
+  // foreground; go home first so the Safari icon is in the frontmost tree.
+  await client.performActions([
+    { type: 'buttonDown', button: 'home' },
+    { type: 'buttonUp', button: 'home' },
+  ]);
+  await sleep(1000);
+  const safari = await tapWhenPresent({ AXUniqueId: 'Safari' });
   console.log(`Tapped element: ${safari.elementType} - "${safari.elementLabel}"`);
-  await sleep(3 * 1000);
-  const urlBar = await client.tapElement({ type: 'TextField' });
+  // Safari's first launch on a fresh instance can take the better part of a
+  // minute to surface the address bar in the accessibility tree.
+  const urlBar = await tapWhenPresent({ type: 'TextField' }, 90_000);
   console.log(`Tapped element: ${urlBar.elementType} - "${urlBar.elementLabel}"`);
-  await sleep(1 * 1000);
+  // Give the tapped field time to take keyboard focus before typing.
+  await sleep(3 * 1000);
 
   // ========================================================================
   // Type Text
   // ========================================================================
   console.log('\n--- Testing typeText ---');
-  await client.typeText('Hello from TypeScript SDK!');
+  // On a cold Safari launch the field can take a while to gain focus, and a
+  // tap landing mid-animation can miss; re-tap between attempts.
+  const typeDeadline = Date.now() + 60_000;
+  for (;;) {
+    try {
+      await client.typeText('Hello from TypeScript SDK!');
+      break;
+    } catch (error) {
+      if (Date.now() > typeDeadline) throw error;
+      await sleep(2000);
+      try {
+        await client.tapElement({ type: 'TextField' });
+      } catch {
+        // The bar may be mid-transition; the next attempt re-checks focus.
+      }
+    }
+  }
   console.log('Typed text: "Hello from TypeScript SDK!"');
 
   // ========================================================================
@@ -87,7 +130,13 @@ try {
 
   await sleep(3 * 1000);
 
-  await client.tapElement({ type: 'Button', AXLabel: 'Close' });
+  // A Close overlay only sometimes appears after navigation; dismiss it when
+  // present and move on otherwise.
+  try {
+    await tapWhenPresent({ type: 'Button', AXLabel: 'Close' }, 10_000);
+  } catch {
+    console.log('No Close button to dismiss');
+  }
   await sleep(5 * 1000);
 
   // ========================================================================
@@ -235,7 +284,7 @@ function findNodesWithTrait(nodes: Ios.ElementTree, trait: string): Ios.ElementT
   const matches: Ios.ElementTreeNode[] = [];
 
   const visit = (node: Ios.ElementTreeNode): void => {
-    if (node.traits.includes(trait)) {
+    if (node.traits?.includes(trait)) {
       matches.push(node);
     }
 

--- a/examples/websocket-ios/package.json
+++ b/examples/websocket-ios/package.json
@@ -17,6 +17,7 @@
     "@limrun/api": "^0.46.11"
   },
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/examples/websocket-ios/yarn.lock
+++ b/examples/websocket-ios/yarn.lock
@@ -151,6 +151,13 @@
   resolved "https://registry.yarnpkg.com/@limrun/xdelta3-wasm/-/xdelta3-wasm-0.2.0.tgz#f74444ba7eb2be90e86e0c24edf55e9505127354"
   integrity sha512-mEohO7CYj4Gdc0v1Gr/AjlBhfbXQnIz6+2wmMhRfwz8hXZrsIC/yqYQhfoDhu1ysqQwBnU5lDDLPUGdUu+8hPQ==
 
+"@types/node@^25.5.2":
+  version "25.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.5.tgz#0fefc09e6e82e94cde291bacf43522e989eb01a4"
+  integrity sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -253,6 +260,11 @@ typescript@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@7.29.0:
   version "7.29.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to example scripts and devDependencies; no production API or auth logic is modified.
> 
> **Overview**
> Hardens **example scripts** so they compile reliably and behave on staging/reused instances, without changing the SDK itself.
> 
> **TypeScript:** Adds `@types/node` to multiple example `package.json` files (and lockfiles) so Node globals like `process` type-check.
> 
> **Appium iOS:** Replaces the hostname string hack for WebDriverAgent with a **`URL`-based WDA base** that always includes an explicit port (default `443`), avoiding Appium’s wrong default when the port is omitted. Sets **`appium:webviewConnectTimeout`** to 60s for slow Safari webview attach on fresh simulators.
> 
> **iOS automation demos** (`websocket-ios`, `ios-video-recording`): Swaps fixed sleeps for **retry-until-present** taps (and longer deadlines for cold Safari), presses **home** before hunting the Safari icon, retries **`typeText`** with re-taps, treats optional UI (e.g. Close) as non-fatal, uses **`AXLabel`** where needed, and uses optional chaining on **`traits`**. **`ios-video-recording`** sets **`process.exitCode = 1`** on failure.
> 
> **Tunnel example:** Deletes the Android instance after the tunnel closes, matching other examples’ cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0df035f61726b522a5e588c35ac098500898d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->